### PR TITLE
Remove barely-used options resolver component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "ext-mbstring": "*",
-        "symfony/options-resolver": "~2.3"
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "erusev/parsedown": "~1.0",

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -17,8 +17,6 @@ namespace League\CommonMark;
 use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Element\ReferenceDefinition;
 use League\CommonMark\Inline\Element\AbstractBaseInline;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Renders a parsed AST to HTML
@@ -42,21 +40,12 @@ class HtmlRenderer
     {
         $this->environment = $environment;
 
-        $resolver = new OptionsResolver();
-        $this->configureOptions($resolver);
-        $this->options = $resolver->resolve($options);
-    }
-
-    /**
-     * @param OptionsResolverInterface $resolver
-     */
-    protected function configureOptions(OptionsResolverInterface $resolver)
-    {
-        $resolver->setDefaults(array(
+        $defaults = array(
             'blockSeparator' => "\n",
             'innerSeparator' => "\n",
             'softBreak' => "\n"
-        ));
+        );
+        $this->options = array_merge($defaults, $options);
     }
 
     /**


### PR DESCRIPTION
`array_merge` is sufficient for our purposes - no need for an additional library.
