### PR TITLE
Allow for multiple reference parsers

### DIFF
--- a/src/Block/Element/Document.php
+++ b/src/Block/Element/Document.php
@@ -23,7 +23,7 @@ class Document extends AbstractBlock
     /***
      * @var ReferenceMap
      */
-    private $referenceMap;
+    protected $referenceMap;
 
     public function __construct()
     {

--- a/src/Block/Element/FencedCode.php
+++ b/src/Block/Element/FencedCode.php
@@ -23,22 +23,22 @@ class FencedCode extends AbstractBlock
     /**
      * @var string
      */
-    private $info;
+    protected $info;
 
     /**
      * @var int
      */
-    private $length;
+    protected $length;
 
     /**
      * @var string
      */
-    private $char;
+    protected $char;
 
     /**
      * @var int
      */
-    private $offset;
+    protected $offset;
 
     /**
      * @param int $length

--- a/src/Block/Element/ListBlock.php
+++ b/src/Block/Element/ListBlock.php
@@ -25,12 +25,12 @@ class ListBlock extends AbstractBlock
     /**
      * @var bool
      */
-    private $tight = false;
+    protected $tight = false;
 
     /**
      * @var ListData
      */
-    private $data;
+    protected $data;
 
     public function __construct(ListData $listData)
     {

--- a/src/Block/Element/ListItem.php
+++ b/src/Block/Element/ListItem.php
@@ -22,7 +22,7 @@ class ListItem extends AbstractBlock
     /**
      * @var ListData
      */
-    private $data;
+    protected $data;
 
     public function __construct(ListData $listData)
     {

--- a/src/Block/Element/Paragraph.php
+++ b/src/Block/Element/Paragraph.php
@@ -90,7 +90,7 @@ class Paragraph extends AbstractInlineContainer
      *
      * @return bool
      */
-    private function parseReferences(ContextInterface $context, Cursor $cursor)
+    protected function parseReferences(ContextInterface $context, Cursor $cursor)
     {
         $referenceFound = false;
         while ($cursor->getCharacter() === '[' && $context->getReferenceParser()->parse($cursor)) {

--- a/src/Block/Element/Paragraph.php
+++ b/src/Block/Element/Paragraph.php
@@ -69,8 +69,8 @@ class Paragraph extends AbstractInlineContainer
         $this->finalStringContents = preg_replace('/^  */m', '', implode("\n", $this->getStrings()));
 
         // Short-circuit
-        if ($this->finalStringContents === '' || $this->finalStringContents[0] !== '[') {
-            return;
+        if ($this->finalStringContents === '') {
+            return false;
         }
 
         $cursor = new Cursor($this->finalStringContents);
@@ -93,9 +93,23 @@ class Paragraph extends AbstractInlineContainer
     protected function parseReferences(ContextInterface $context, Cursor $cursor)
     {
         $referenceFound = false;
-        while ($cursor->getCharacter() === '[' && $context->getReferenceParser()->parse($cursor)) {
-            $this->finalStringContents = $cursor->getRemainder();
-            $referenceFound = true;
+        $parsers = array();
+        $prefixes = array();
+        
+        foreach ($context->getReferenceParsers() as $referenceParser) {
+            $prefix = $referenceParser->getPrefix();
+            $parsers[$prefix] = $referenceParser;
+            $prefixes[] = preg_quote($prefix, '/');
+        }
+
+        while ($prefix = $cursor->match('/^(' .implode('|', $prefixes). ')/')) {
+            $cursor->advanceBy(strlen($prefix) * -1);
+            if ($parsers[$prefix]->parse($cursor)) {
+                $this->finalStringContents = $cursor->getRemainder();
+                $referenceFound = true;
+            } else {
+                break;
+            }
         }
 
         return $referenceFound;

--- a/src/Block/Element/ReferenceDefinition.php
+++ b/src/Block/Element/ReferenceDefinition.php
@@ -23,7 +23,7 @@ class ReferenceDefinition extends AbstractBlock
     /**
      * @var Reference
      */
-    private $reference;
+    protected $reference;
 
     public function __construct(Reference $reference)
     {

--- a/src/Block/Parser/ListParser.php
+++ b/src/Block/Parser/ListParser.php
@@ -84,7 +84,7 @@ class ListParser extends AbstractBlockParser
      *
      * @return int
      */
-    private function calculateListMarkerPadding($marker, $spacesAfterMarker, $rest)
+    protected function calculateListMarkerPadding($marker, $spacesAfterMarker, $rest)
     {
         $markerLength = strlen($marker);
 

--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -58,4 +58,20 @@ class CommonMarkConverter
 
         return $this->htmlRenderer->renderBlock($documentAST);
     }
+
+    /**
+     * @return DocParser
+     */
+    public function getDocParser()
+    {
+        return $this->docParser;
+    }
+
+    /**
+     * @return HtmlRenderer
+     */
+    public function getHtmlRenderer()
+    {
+        return $this->htmlRenderer;
+    }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -57,7 +57,7 @@ class Context implements ContextInterface
      */
     protected $blocksParsed = false;
 
-    protected $referenceParser;
+    protected $referenceParsers;
 
     /**
      * @var callable|null
@@ -72,7 +72,7 @@ class Context implements ContextInterface
 
         $this->environment = $environment;
 
-        $this->referenceParser = new ReferenceParser($document->getReferenceMap());
+        $this->setReferenceParsers($this->environment->getReferenceParsers());
     }
 
     /**
@@ -241,8 +241,16 @@ class Context implements ContextInterface
     /**
      * @return ReferenceParser
      */
-    public function getReferenceParser()
+    public function getReferenceParsers()
     {
-        return $this->referenceParser;
+        return $this->referenceParsers;
+    }
+    
+    public function setReferenceParsers(array $parsers)
+    {
+        foreach ($parsers as &$parser) {
+            $parser->setReferenceMap($this->getDocument()->getReferenceMap());
+        }
+        $this->referenceParsers = $parsers;
     }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -62,7 +62,7 @@ class Context implements ContextInterface
     /**
      * @var callable|null
      */
-    private $unmatchedBlockCloser;
+    protected $unmatchedBlockCloser;
 
     public function __construct(Document $document, Environment $environment)
     {

--- a/src/ContextInterface.php
+++ b/src/ContextInterface.php
@@ -97,7 +97,7 @@ interface ContextInterface
     public function setBlocksParsed($bool);
 
     /**
-     * @return ReferenceParser
+     * @return ReferenceParserInterface[]
      */
-    public function getReferenceParser();
+    public function getReferenceParsers();
 }

--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -18,12 +18,12 @@ class Cursor
     /**
      * @var string
      */
-    private $line;
+    protected $line;
 
     /**
      * @var int
      */
-    private $length;
+    protected $length;
 
     /**
      * @var int
@@ -31,17 +31,17 @@ class Cursor
      * It's possible for this to be 1 char past the end, meaning we've parsed all chars and have
      * reached the end.  In this state, any character-returning method MUST return null.
      */
-    private $currentPosition = 0;
+    protected $currentPosition = 0;
 
     /**
      * @var int
      */
-    private $previousPosition = 0;
+    protected $previousPosition = 0;
 
     /**
      * @var int|null
      */
-    private $firstNonSpaceCache;
+    protected $firstNonSpaceCache;
 
     /**
      * @param string $line

--- a/src/CursorState.php
+++ b/src/CursorState.php
@@ -16,27 +16,27 @@ class CursorState
     /**
      * @var string
      */
-    private $line;
+    protected $line;
 
     /**
      * @var int
      */
-    private $length;
+    protected $length;
 
     /**
      * @var int
      */
-    private $currentPosition;
+    protected $currentPosition;
 
     /**
      * @var int
      */
-    private $previousPosition;
+    protected $previousPosition;
 
     /**
      * @var int|null
      */
-    private $firstNonSpaceCache;
+    protected $firstNonSpaceCache;
 
     /**
      * @param string $line

--- a/src/DocParser.php
+++ b/src/DocParser.php
@@ -31,7 +31,7 @@ class DocParser
     /**
      * @var InlineParserEngine
      */
-    private $inlineParserEngine;
+    protected $inlineParserEngine;
 
     /**
      * @param Environment $parsers
@@ -55,7 +55,7 @@ class DocParser
      *
      * @return string[]
      */
-    private function preProcessInput($input)
+    protected function preProcessInput($input)
     {
         // Remove any /n which appears at the very end of the string
         if (substr($input, -1) == "\n") {
@@ -89,7 +89,7 @@ class DocParser
         return $context->getDocument();
     }
 
-    private function incorporateLine(ContextInterface $context)
+    protected function incorporateLine(ContextInterface $context)
     {
         $cursor = new Cursor($context->getLine());
         $oldTip = $context->getTip();
@@ -158,7 +158,7 @@ class DocParser
         }
     }
 
-    private function processInlines(ContextInterface $context, AbstractBlock $block)
+    protected function processInlines(ContextInterface $context, AbstractBlock $block)
     {
         if ($block instanceof AbstractInlineContainer) {
             $cursor = new Cursor(trim($block->getStringContent()));
@@ -179,7 +179,7 @@ class DocParser
      * @param ContextInterface $context
      * @param AbstractBlock $block
      */
-    private function breakOutOfLists(ContextInterface $context, AbstractBlock $block)
+    protected function breakOutOfLists(ContextInterface $context, AbstractBlock $block)
     {
         $b = $block;
         $lastList = null;

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -25,6 +25,11 @@ use League\CommonMark\Inline\Renderer\InlineRendererInterface;
 class Environment
 {
     /**
+     * @var ExtensionInterface[]
+     */
+    protected $extensions;
+    
+    /**
      * @var BlockParserInterface[]
      */
     protected $blockParsers = array();
@@ -218,6 +223,8 @@ class Environment
      */
     public function addExtension(ExtensionInterface $extension)
     {
+        $this->extensions[] = $extension;
+        
         // Block parsers
         foreach ($extension->getBlockParsers() as $blockParser) {
             $this->addBlockParser($blockParser);
@@ -242,6 +249,14 @@ class Environment
         foreach ($extension->getInlineRenderers() as $class => $inlineRenderer) {
             $this->addInlineRenderer($class, $inlineRenderer);
         }
+    }
+
+    /**
+     * @return ExtensionInterface[]
+     */
+    public function getExtensions()
+    {
+        return $this->extensions;
     }
 
     /**

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -60,6 +60,11 @@ class Environment
     protected $inlineRenderersByClass = array();
 
     /**
+     * @var ReferenceParserInterface[]
+     */
+    protected $referenceParsers = array();
+
+    /**
      * @param BlockParserInterface $parser
      *
      * @return $this
@@ -209,6 +214,14 @@ class Environment
         return $this->inlineRenderersByClass[$inlineClass];
     }
 
+    /**
+     * @return ReferenceParserInterface[]
+     */
+    public function getReferenceParsers()
+    {
+        return $this->referenceParsers;
+    }
+
     public function createInlineParserEngine()
     {
         return new InlineParserEngine($this);
@@ -249,6 +262,8 @@ class Environment
         foreach ($extension->getInlineRenderers() as $class => $inlineRenderer) {
             $this->addInlineRenderer($class, $inlineRenderer);
         }
+
+        $this->referenceParsers = $extension->getReferenceParsers();
     }
 
     /**

--- a/src/Extension/CommonMarkCoreExtension.php
+++ b/src/Extension/CommonMarkCoreExtension.php
@@ -19,6 +19,7 @@ use League\CommonMark\Block\Renderer as BlockRenderer;
 use League\CommonMark\Inline\Parser as InlineParser;
 use League\CommonMark\Inline\Processor as InlineProcessor;
 use League\CommonMark\Inline\Renderer as InlineRenderer;
+use League\CommonMark\ReferenceParser;
 
 class CommonMarkCoreExtension extends Extension
 {
@@ -104,6 +105,13 @@ class CommonMarkCoreExtension extends Extension
             'League\CommonMark\Inline\Element\Newline'  => new InlineRenderer\NewlineRenderer(),
             'League\CommonMark\Inline\Element\Strong'   => new InlineRenderer\StrongRenderer(),
             'League\CommonMark\Inline\Element\Text'     => new InlineRenderer\TextRenderer(),
+        );
+    }
+    
+    public function getReferenceParsers()
+    {
+        return array(
+            new ReferenceParser()
         );
     }
 

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -61,4 +61,12 @@ abstract class Extension implements ExtensionInterface
     {
         return array();
     }
+
+    /**
+     * @return ReferenceParserInterface[]
+     */
+    public function getReferenceParsers()
+    {
+        return array();
+    }
 }

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -62,6 +62,13 @@ interface ExtensionInterface
     public function getInlineRenderers();
 
     /**
+     * Returns a list of reference parsers to add to the existing list
+     * 
+     * @return ReferenceParserInterface[]
+     */
+    public function getReferenceParsers();
+
+    /**
      * Returns the name of the extension
      *
      * @return string

--- a/src/HtmlElement.php
+++ b/src/HtmlElement.php
@@ -7,22 +7,22 @@ class HtmlElement
     /**
      * @var string
      */
-    private $tagName;
+    protected $tagName;
 
     /**
      * @var string[]
      */
-    private $attributes = array();
+    protected $attributes = array();
 
     /**
      * @var HtmlElement|HtmlElement[]|string
      */
-    private $contents;
+    protected $contents;
 
     /**
      * @var bool
      */
-    private $selfClosing = false;
+    protected $selfClosing = false;
 
     /**
      * @param string $tagName

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -142,4 +142,12 @@ class HtmlRenderer
 
         return implode($this->options['blockSeparator'], $result);
     }
+
+    /**
+     * @return Environment
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
 }

--- a/src/Inline/Element/InlineCollection.php
+++ b/src/Inline/Element/InlineCollection.php
@@ -21,7 +21,7 @@ class InlineCollection extends AbstractInline
     /**
      * @var ArrayCollection|AbstractInline[]
      */
-    private $inlines;
+    protected $inlines;
 
     public function __construct($inlines)
     {

--- a/src/Inline/Element/Newline.php
+++ b/src/Inline/Element/Newline.php
@@ -19,7 +19,7 @@ class Newline extends AbstractInline
     const HARDBREAK = 0;
     const SOFTBREAK = 1;
 
-    private $type;
+    protected $type;
 
     /**
      * @param int $breakType

--- a/src/Inline/Parser/CloseBracketParser.php
+++ b/src/Inline/Parser/CloseBracketParser.php
@@ -34,7 +34,7 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
     /**
      * @var Environment
      */
-    private $environment;
+    protected $environment;
 
     /**
      * @return string[]
@@ -120,7 +120,7 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
      * @param int $start
      * @param int $end
      */
-    private function nullify(ArrayCollection $collection, $start, $end)
+    protected function nullify(ArrayCollection $collection, $start, $end)
     {
         for ($i = $start; $i < $end; $i++) {
             $collection->set($i, null);
@@ -135,7 +135,7 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
      *
      * @return array|bool
      */
-    private function tryParseLink(Cursor $cursor, ReferenceMap $referenceMap, Delimiter $opener, $startPos)
+    protected function tryParseLink(Cursor $cursor, ReferenceMap $referenceMap, Delimiter $opener, $startPos)
     {
         // Check to see if we have a link/image
         // Inline link?
@@ -155,7 +155,7 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
      *
      * @return array|bool
      */
-    private function tryParseInlineLinkAndTitle(Cursor $cursor)
+    protected function tryParseInlineLinkAndTitle(Cursor $cursor)
     {
         $cursor->advance();
         $cursor->advanceToFirstNonSpace();
@@ -188,7 +188,7 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
      *
      * @return Reference|null
      */
-    private function tryParseReference(Cursor $cursor, ReferenceMap $referenceMap, Delimiter $opener, $startPos)
+    protected function tryParseReference(Cursor $cursor, ReferenceMap $referenceMap, Delimiter $opener, $startPos)
     {
         $savePos = $cursor->saveState();
         $cursor->advanceToFirstNonSpace();
@@ -217,7 +217,7 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
      *
      * @return AbstractWebResource
      */
-    private function createInline($url, InlineCollection $labelInlines, $title, $isImage)
+    protected function createInline($url, InlineCollection $labelInlines, $title, $isImage)
     {
         if ($isImage) {
             return new Image($url, $labelInlines, $title);

--- a/src/InlineParserContext.php
+++ b/src/InlineParserContext.php
@@ -19,9 +19,9 @@ use League\CommonMark\Util\ArrayCollection;
 
 class InlineParserContext
 {
-    private $cursor;
-    private $inlines;
-    private $delimiterStack;
+    protected $cursor;
+    protected $inlines;
+    protected $delimiterStack;
 
     public function __construct(Cursor $cursor)
     {

--- a/src/ReferenceParser.php
+++ b/src/ReferenceParser.php
@@ -18,14 +18,17 @@ use League\CommonMark\Reference\Reference;
 use League\CommonMark\Reference\ReferenceMap;
 use League\CommonMark\Util\LinkParserHelper;
 
-class ReferenceParser
+class ReferenceParser implements ReferenceParserInterface
 {
     /**
      * @var ReferenceMap
      */
     protected $referenceMap;
 
-    public function __construct(ReferenceMap $referenceMap)
+    /**
+     * @param ReferenceMap $referenceMap
+     */
+    public function setReferenceMap(ReferenceMap $referenceMap)
     {
         $this->referenceMap = $referenceMap;
     }
@@ -96,5 +99,10 @@ class ReferenceParser
         }
 
         return true;
+    }
+
+    public function getPrefix()
+    {
+        return '[';
     }
 }

--- a/src/ReferenceParser.php
+++ b/src/ReferenceParser.php
@@ -23,7 +23,7 @@ class ReferenceParser
     /**
      * @var ReferenceMap
      */
-    private $referenceMap;
+    protected $referenceMap;
 
     public function __construct(ReferenceMap $referenceMap)
     {

--- a/src/ReferenceParserInterface.php
+++ b/src/ReferenceParserInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmarkjs)
+ *  - (c) John MacFarlane
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark;
+
+use League\CommonMark\Reference\Reference;
+use League\CommonMark\Reference\ReferenceMap;
+use League\CommonMark\Util\LinkParserHelper;
+
+interface ReferenceParserInterface
+{
+    public function setReferenceMap(ReferenceMap $referenceMap);
+
+    /**
+     * Attempt to parse a link reference, modifying the refmap.
+     *
+     * @param Cursor $cursor
+     *
+     * @return bool
+     */
+    public function parse(Cursor $cursor);
+
+    /**
+     * @return string
+     */
+    public function getPrefix();
+}

--- a/src/Util/ArrayCollection.php
+++ b/src/Util/ArrayCollection.php
@@ -21,7 +21,7 @@ class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAccess
     /**
      * @var array
      */
-    private $elements;
+    protected $elements;
 
     /**
      * Constructor

--- a/src/Util/UnicodeCaseFolder.php
+++ b/src/Util/UnicodeCaseFolder.php
@@ -24,7 +24,7 @@ class UnicodeCaseFolder
      *
      * Manually generated from http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
      */
-    private static $map = array(
+    protected static $map = array(
         0x0041 => 0x0061, // LATIN CAPITAL LETTER A
         0x0042 => 0x0062, // LATIN CAPITAL LETTER B
         0x0043 => 0x0063, // LATIN CAPITAL LETTER C


### PR DESCRIPTION
This extends PR #46 but should be possible to separate

- Makes it possible to register ReferenceParser's (plural) from the extension
- Does NOT currently append ReferenceParsers, this is different to Parsers/Renderers/InlineProcessors
- I think this behavior should be changed for those, as you can use OO principles to extend syntaxes, allowing for any ordering gymnastics to take place. Also, the functions are `set*` not `add*` (except in the case of `addExtension`)