### PR TITLE
Bugfix for HTML Element __toString()

### DIFF
--- a/src/HtmlElement.php
+++ b/src/HtmlElement.php
@@ -122,7 +122,7 @@ class HtmlElement
             $result .= ' ' . $key . '="' . $value . '"';
         }
 
-        if ($this->contents) {
+        if (!is_null($this->contents) AND $this->contents != '') {
             $result .= '>' . $this->getContents(true) . '</' . $this->tagName . '>';
         } elseif ($this->selfClosing) {
             $result .= ' />';

--- a/src/HtmlElement.php
+++ b/src/HtmlElement.php
@@ -122,7 +122,7 @@ class HtmlElement
             $result .= ' ' . $key . '="' . $value . '"';
         }
 
-        if (!is_null($this->contents) AND $this->contents != '') {
+        if (!is_null($this->contents) and $this->contents != '') {
             $result .= '>' . $this->getContents(true) . '</' . $this->tagName . '>';
         } elseif ($this->selfClosing) {
             $result .= ' />';


### PR DESCRIPTION
Logic was too broad, any value that could be considered false (like '0') would be treated as an empty tag.