### PR TITLE
Don't add remaining contents to closed containers (fixes #57)

### DIFF
--- a/src/DocParser.php
+++ b/src/DocParser.php
@@ -154,7 +154,14 @@ class DocParser
             $context->getContainer()->setLastLineBlank($cursor, $context->getLineNumber());
 
             // Handle any remaining cursor contents
-            $context->getContainer()->handleRemainingContents($context, $cursor);
+            if ($context->getContainer()->isOpen()) {
+                $context->getContainer()->handleRemainingContents($context, $cursor);
+            } elseif (!$cursor->isBlank()) {
+                // Create paragraph container for line
+                $context->addBlock(new Paragraph());
+                $cursor->advanceToFirstNonSpace();
+                $context->getTip()->addLine($cursor->getRemainder());
+            }
         }
     }
 


### PR DESCRIPTION
The submitted test case failed because the parser tried to add an empty line to the already-closed IndentedCode block. In the JS reference parser, closing this block type results in it becoming a CodeBlock type, which we don't use, and therefore the addLine() logic doesn't run.  We can mirror that behavior by ensuring nothing ever calls addLine() on a closed block.