### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.6-dev"
+            "dev-master": "0.7-dev"
         }
     }
 }


### PR DESCRIPTION
I noticed a public method was removed, among other things since 0.6.1.