### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
  - Removed the unused ArrayCollection::splice() method
  - Removed impossible-to-reach code in Cursor::advanceToFirstNonSpace
  - Removed unnecessary test from the InlineParserEngine
+ - Removed unnecessary/unused RegexHelper::getMainRegex() method
 
 ## [0.6.1] - 2015-01-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
  - More unit tests to increase code coverage
 
 ### Changed
+ - Enabled the InlineParserEngine to parse several non-special characters at once (performance boost)
  - Moved closeUnmatchedBlocks into its own class
  - Image and link elements now extend AbstractInlineContainer; label data is stored via $inlineContents instead
  - Renamed AbstractInlineContainer::$inlineContents and its getter/setter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Changed
  - Enabled the InlineParserEngine to parse several non-special characters at once (performance boost)
+ - NewlineParser no longer attempts to parse spaces; look-behind is used instead (major performance boost)
  - Moved closeUnmatchedBlocks into its own class
  - Image and link elements now extend AbstractInlineContainer; label data is stored via $inlineContents instead
  - Renamed AbstractInlineContainer::$inlineContents and its getter/setter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
  - Removed the InlineCollection class
  - Removed the unused ArrayCollection::splice() method
  - Removed impossible-to-reach code in Cursor::advanceToFirstNonSpace
+ - Removed unnecessary test from the InlineParserEngine
 
 ## [0.6.1] - 2015-01-25
 ### Changed

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -75,6 +75,11 @@ class Environment
      */
     protected $config;
 
+    /**
+     * @var string
+     */
+    protected $inlineParserCharacterRegex;
+
     public function __construct(array $config = array())
     {
         $this->miscExtension = new MiscExtension();
@@ -378,6 +383,10 @@ class Environment
 
         // Also initialize those one-off classes
         $this->initializeExtension($this->miscExtension);
+
+        // Lastly, let's build a regex which matches all inline characters
+        // This will enable a huge performance boost with inline parsing
+        $this->buildInlineParserCharacterRegex();
     }
 
     /**
@@ -470,5 +479,22 @@ class Environment
         ));
 
         return $environment;
+    }
+
+    /**
+     * Regex which matches any character that an inline parser might be interested in
+     *
+     * @return string
+     */
+    public function getInlineParserCharacterRegex()
+    {
+        return $this->inlineParserCharacterRegex;
+    }
+
+    private function buildInlineParserCharacterRegex()
+    {
+        $chars = array_keys($this->inlineParsersByCharacter);
+
+        $this->inlineParserCharacterRegex = '/^[^' . preg_quote(implode('', $chars)) . ']+/';
     }
 }

--- a/src/Inline/Parser/NewlineParser.php
+++ b/src/Inline/Parser/NewlineParser.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Inline\Parser;
 
 use League\CommonMark\ContextInterface;
+use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\InlineParserContext;
 use League\CommonMark\Inline\Element\Newline;
 
@@ -25,7 +26,7 @@ class NewlineParser extends AbstractInlineParser
      */
     public function getCharacters()
     {
-        return array("\n", ' ');
+        return array("\n");
     }
 
     /**
@@ -36,18 +37,25 @@ class NewlineParser extends AbstractInlineParser
      */
     public function parse(ContextInterface $context, InlineParserContext $inlineContext)
     {
-        if ($m = $inlineContext->getCursor()->match('/^ *\n/')) {
-            if (strlen($m) > 2) {
-                $inlineContext->getInlines()->add(new Newline(Newline::HARDBREAK));
+        $inlineContext->getCursor()->advance();
 
-                return true;
-            } elseif (strlen($m) > 0) {
-                $inlineContext->getInlines()->add(new Newline(Newline::SOFTBREAK));
-
-                return true;
+        // Check previous inline for trailing spaces
+        $spaces = 0;
+        $lastInline = $inlineContext->getInlines()->last();
+        if ($lastInline && $lastInline instanceof Text) {
+            $trimmed = rtrim($lastInline->getContent(), ' ');
+            $spaces = strlen($lastInline->getContent()) - strlen($trimmed);
+            if ($spaces) {
+                $lastInline->setContent($trimmed);
             }
         }
 
-        return false;
+        if ($spaces >= 2 ) {
+            $inlineContext->getInlines()->add(new Newline(Newline::HARDBREAK));
+        } else {
+            $inlineContext->getInlines()->add(new Newline(Newline::SOFTBREAK));
+        }
+
+        return true;
     }
 }

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -29,23 +29,20 @@ class InlineParserEngine
     {
         $inlineParserContext = new InlineParserContext($cursor);
         while (($character = $cursor->getCharacter()) !== null) {
-            $res = null;
             if ($matchingParsers = $this->environment->getInlineParsersForCharacter($character)) {
                 foreach ($matchingParsers as $parser) {
-                    if ($res = $parser->parse($context, $inlineParserContext)) {
-                        break;
+                    if ($parser->parse($context, $inlineParserContext)) {
+                        continue 2;
                     }
                 }
             }
 
-            if (!$res) {
-                $cursor->advance();
-                $lastInline = $inlineParserContext->getInlines()->last();
-                if ($lastInline instanceof Text && !isset($lastInline->data['delim'])) {
-                    $lastInline->append($character);
-                } else {
-                    $inlineParserContext->getInlines()->add(new Text($character));
-                }
+            $cursor->advance();
+            $lastInline = $inlineParserContext->getInlines()->last();
+            if ($lastInline instanceof Text && !isset($lastInline->data['delim'])) {
+                $lastInline->append($character);
+            } else {
+                $inlineParserContext->getInlines()->add(new Text($character));
             }
         }
 

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -41,7 +41,7 @@ class InlineParserEngine
             // Attempt to match multiple non-special characters at once
             $text = $cursor->match($this->environment->getInlineParserCharacterRegex());
             // This might fail if we're currently at a special character which wasn't parsed; if so, just add that character
-            if (!$text) {
+            if ($text === null) {
                 $cursor->advance();
                 $text = $character;
             }

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -37,12 +37,20 @@ class InlineParserEngine
                 }
             }
 
-            $cursor->advance();
+            // We reach here if none of the parsers can handle the input
+            // Attempt to match multiple non-special characters at once
+            $text = $cursor->match($this->environment->getInlineParserCharacterRegex());
+            // This might fail if we're currently at a special character which wasn't parsed; if so, just add that character
+            if (!$text) {
+                $cursor->advance();
+                $text = $character;
+            }
+
             $lastInline = $inlineParserContext->getInlines()->last();
             if ($lastInline instanceof Text && !isset($lastInline->data['delim'])) {
-                $lastInline->append($character);
+                $lastInline->append($text);
             } else {
-                $inlineParserContext->getInlines()->add(new Text($character));
+                $inlineParserContext->getInlines()->add(new Text($text));
             }
         }
 

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -182,17 +182,6 @@ class RegexHelper
     }
 
     /**
-     * Matches a character with a special meaning in markdown,
-     * or a string of non-special characters.
-     *
-     * @return string
-     */
-    public function getMainRegex()
-    {
-        return '/^(?:[_*`\n]+|[\[\]\\\\!<&*_]|(?: *[^\n `\[\]\\\\!<&*_]+)+|[ \n]+)/m';
-    }
-
-    /**
      * Attempt to match a regex in string s at offset offset
      * @param string $regex
      * @param string $string


### PR DESCRIPTION
We now parse long spans of non-special characters at once, vs the old approach which parsed each character individually.  This results in a whopping **50% performance boost** according to our internal benchmark (310ms to 156ms on my machine).