### PR TITLE
Adding listReferences to ReferenceMap

### DIFF
--- a/src/Reference/ReferenceMap.php
+++ b/src/Reference/ReferenceMap.php
@@ -64,4 +64,14 @@ class ReferenceMap
             return null;
         }
     }
+
+    /**
+     * Lists all registered references.
+     *
+     * @return Reference[]
+     */
+    public function listReferences()
+    {
+        return array_values($this->references);
+    }
 }


### PR DESCRIPTION
I would really like to have some simple way of accessing the References in the ReferenceMap without knowing the keys. I have a project where I want to display the references separately and of course there are ways to do it, but I think a
```php
$document = $parser->parse($markdown);
$references = $document->getReferenceMap()->listReferences();
```
would come in handy.

This pull request is just some proposal of the idea. I wasn't sure about naming and stuff, but it is just way too easy to implement ;)