### PR TITLE
Test against PHP 7.0 (nightly) but allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+
+matrix:
+  allow_failures:
+    - php: 7.0
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## [Unreleased][unreleased]
 ### Added
  - All references can now be obtained from the `ReferenceMap` via `listReferences()` (#73)
+ - Test against PHP 7.0 (nightly) but allow failures
 
 ### Changed
  - ListData::$start now defaults to null instead of 0 (#74)


### PR DESCRIPTION
We'll remove `allow_failures` once Travis includes the `mbstring` extension and PHP 7.0 enters a relatively-stable state (the tests work reliably well)