### PR TITLE
Fix broken parsing of emphasized text ending with a '0' character (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased][unreleased]
+### Fixed
+ - Fixed broken parsing of emphasized text ending with a '0' character (#81)
 
 ## [0.7.1] - 2015-03-01
 ### Added

--- a/src/Inline/Parser/EmphasisParser.php
+++ b/src/Inline/Parser/EmphasisParser.php
@@ -46,7 +46,10 @@ class EmphasisParser extends AbstractInlineParser
         $numDelims = 0;
 
         $cursor = $inlineContext->getCursor();
-        $charBefore = $cursor->peek(-1) ?: "\n";
+        $charBefore = $cursor->peek(-1);
+        if ($charBefore === null) {
+            $charBefore = "\n";
+        }
 
         while ($cursor->peek($numDelims) === $character) {
             ++$numDelims;
@@ -54,7 +57,10 @@ class EmphasisParser extends AbstractInlineParser
 
         $cursor->advanceBy($numDelims);
 
-        $charAfter = $cursor->getCharacter() ?: "\n";
+        $charAfter = $cursor->getCharacter();
+        if ($charAfter === null) {
+            $charAfter = "\n";
+        }
 
         $leftFlanking = $numDelims > 0 && !preg_match('/\pZ|\s/u', $charAfter) &&
             !(preg_match(RegexHelper::REGEX_PUNCTUATION, $charAfter) &&


### PR DESCRIPTION
The issue was caused by non-strict tests, where a "0" string was considered falsy.