### PR TITLE
Allow swapping built-in renderers without using their fully qualified names

### DIFF
--- a/src/Extension/MiscExtension.php
+++ b/src/Extension/MiscExtension.php
@@ -89,6 +89,23 @@ class MiscExtension implements ExtensionInterface
      */
     public function addBlockRenderer($blockClass, BlockRendererInterface $blockRenderer)
     {
+        $builtInClasses = [
+            'BlockQuote',
+            'Document',
+            'FencedCode',
+            'Header',
+            'HorizontalRule',
+            'HtmlBlock',
+            'IndentedCode',
+            'ListBlock',
+            'ListItem',
+            'Paragraph'
+        ];
+
+        if (in_array($blockClass, $builtInClasses)) {
+            $blockClass = 'League\CommonMark\Block\Element\\' . $blockClass;
+        }
+
         $this->blockRenderers[$blockClass] = $blockRenderer;
     }
 
@@ -154,6 +171,21 @@ class MiscExtension implements ExtensionInterface
      */
     public function addInlineRenderer($inlineClass, InlineRendererInterface $inlineRenderer)
     {
+        $builtInClasses = [
+            'Code',
+            'Emphasis',
+            'Html',
+            'Image',
+            'Link',
+            'Newline',
+            'Strong',
+            'Text'
+        ];
+
+        if (in_array($inlineClass, $builtInClasses)) {
+            $inlineClass = 'League\CommonMark\Inline\Element\\' . $inlineClass;
+        }
+
         $this->inlineRenderers[$inlineClass] = $inlineRenderer;
 
         return $this;

--- a/src/Extension/MiscExtension.php
+++ b/src/Extension/MiscExtension.php
@@ -89,20 +89,7 @@ class MiscExtension implements ExtensionInterface
      */
     public function addBlockRenderer($blockClass, BlockRendererInterface $blockRenderer)
     {
-        $builtInClasses = [
-            'BlockQuote',
-            'Document',
-            'FencedCode',
-            'Header',
-            'HorizontalRule',
-            'HtmlBlock',
-            'IndentedCode',
-            'ListBlock',
-            'ListItem',
-            'Paragraph'
-        ];
-
-        if (in_array($blockClass, $builtInClasses)) {
+        if (class_exists('League\CommonMark\Block\Element\\' . $blockClass)) {
             $blockClass = 'League\CommonMark\Block\Element\\' . $blockClass;
         }
 
@@ -171,18 +158,7 @@ class MiscExtension implements ExtensionInterface
      */
     public function addInlineRenderer($inlineClass, InlineRendererInterface $inlineRenderer)
     {
-        $builtInClasses = [
-            'Code',
-            'Emphasis',
-            'Html',
-            'Image',
-            'Link',
-            'Newline',
-            'Strong',
-            'Text'
-        ];
-
-        if (in_array($inlineClass, $builtInClasses)) {
+        if (class_exists('League\CommonMark\Inline\Element\\' . $inlineClass)) {
             $inlineClass = 'League\CommonMark\Inline\Element\\' . $inlineClass;
         }
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -145,6 +145,67 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($renderer, $environment->getBlockRendererForClass('MyClass'));
     }
 
+    public function testSwapBuiltInBlockRenderer()
+    {
+        $environment = new Environment();
+
+        $mockRenderer = $this->getMock('League\CommonMark\Block\Renderer\BlockRendererInterface');
+
+        $builtInClasses = [
+            'BlockQuote'     => 'League\CommonMark\Block\Element\BlockQuote',
+            'Document'       => 'League\CommonMark\Block\Element\Document',
+            'FencedCode'     => 'League\CommonMark\Block\Element\FencedCode',
+            'Header'         => 'League\CommonMark\Block\Element\Header',
+            'HorizontalRule' => 'League\CommonMark\Block\Element\HorizontalRule',
+            'HtmlBlock'      => 'League\CommonMark\Block\Element\HtmlBlock',
+            'IndentedCode'   => 'League\CommonMark\Block\Element\IndentedCode',
+            'ListBlock'      => 'League\CommonMark\Block\Element\ListBlock',
+            'ListItem'       => 'League\CommonMark\Block\Element\ListItem',
+            'Paragraph'      => 'League\CommonMark\Block\Element\Paragraph',
+        ];
+
+        foreach ($builtInClasses as $name => $fullyQualifiedName){
+            $environment->addBlockRenderer($name, $mockRenderer);
+        }
+
+        foreach ($builtInClasses as $name => $fullyQualifiedName){
+            $this->assertEquals(
+                $mockRenderer,
+                $environment->getBlockRendererForClass($fullyQualifiedName)
+            );
+        }
+    }
+
+    public function testSwapBuiltInInlineRenderer()
+    {
+        $environment = new Environment();
+
+        $mockRenderer = $this->getMock('League\CommonMark\Inline\Renderer\InlineRendererInterface');
+
+        $builtInClasses = [
+            'Code'     => 'League\CommonMark\Inline\Element\Code',
+            'Emphasis' => 'League\CommonMark\Inline\Element\Emphasis',
+            'Html'     => 'League\CommonMark\Inline\Element\Html',
+            'Image'    => 'League\CommonMark\Inline\Element\Image',
+            'Link'     => 'League\CommonMark\Inline\Element\Link',
+            'Newline'  => 'League\CommonMark\Inline\Element\Newline',
+            'Strong'   => 'League\CommonMark\Inline\Element\Strong',
+            'Text'     => 'League\CommonMark\Inline\Element\Text',
+        ];
+
+        foreach ($builtInClasses as $name => $fullyQualifiedName){
+            $environment->addInlineRenderer($name, $mockRenderer);
+        }
+
+        foreach ($builtInClasses as $name => $fullyQualifiedName){
+            $this->assertEquals(
+                $mockRenderer,
+                $environment->getInlineRendererForClass($fullyQualifiedName)
+            );
+        }
+    }
+
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
The documentation implies that the main purpose of Environment::addBlockRenderer() and Environment::addInlineRenderer() are to override the default renderers ("When registering these with the environment, you must tell it which block/inline classes it should handle. This allows you to essentially “swap out” built-in renderers with your own."), and the examples suggest that it can be done like this :

```php
$environment->addBlockRenderer('FencedCode', $myRenderer);
$environment->addBlockRenderer('IndentedCode', $myRenderer);
```
The problem is this doesn't work, as you would actually have to do this in order to replace the built-in block renderers :
```php
$environment->addBlockRenderer('League\CommonMark\Block\Element\FencedCode', $myRenderer);
$environment->addBlockRenderer('League\CommonMark\Block\Element\IndentedCode', $myRenderer);
```

The proposed pull requests adds tests that failed for both block and inline renderers being swapped as in the documentation, as well as a fix that makes it work, without breaking the existing tests which add other renderers.

It may not be the best way to work around that (I'm not even sure we should work around it), but at least the documentation should be consistent with the actual behavior.

Thanks.