### PR TITLE
Remove unnecessary check for hrule in parseListMarker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Removed
  - Removed PHP 5.3 workaround (see commit 5747822)
  - Removed unused AbstractWebResource::setUrl() method
+ - Removed unnecessary check for hrule when parsing lists (#85)
 
 ## [0.7.2] - 2015-03-08
 ### Changed

--- a/src/Block/Parser/ListParser.php
+++ b/src/Block/Parser/ListParser.php
@@ -36,10 +36,6 @@ class ListParser extends AbstractBlockParser
 
         $rest = $tmpCursor->getRemainder();
 
-        if (preg_match(RegexHelper::getInstance()->getHRuleRegex(), $rest)) {
-            return false;
-        }
-
         $data = new ListData();
 
         if ($matches = RegexHelper::matchAll('/^[*+-]( +|$)/', $rest)) {


### PR DESCRIPTION
By the time parseListMarker is called, the hrule block start was already
tried. In case it matches, no further block starts are tried. So the
later check is not necessary and can be removed.

Mirrors jgm/commonmark.js#19