### PR TITLE
Fix name of method argument

### DIFF
--- a/src/DocParser.php
+++ b/src/DocParser.php
@@ -34,12 +34,12 @@ class DocParser
     private $inlineParserEngine;
 
     /**
-     * @param Environment $parsers
+     * @param Environment $environment
      */
-    public function __construct(Environment $parsers)
+    public function __construct(Environment $environment)
     {
-        $this->environment = $parsers;
-        $this->inlineParserEngine = new InlineParserEngine($parsers);
+        $this->environment = $environment;
+        $this->inlineParserEngine = new InlineParserEngine($environment);
     }
 
     /**


### PR DESCRIPTION
Seems like a typo or refactoring relict.

This should not change any public behavior or breake public APIs.