### PR TITLE
Use locally-installed PHPUnit instead of phar; avoid coverage in HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ sudo: false
 
 install: travis_retry composer install --no-interaction --prefer-source
 
-script: phpunit --coverage-text --coverage-clover=coverage.clover
+script:
+  - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then vendor/bin/phpunit; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover; fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
Avoiding the use of Travis' pre-built phar allows us to work around this
HHVM issue: https://github.com/facebook/hhvm/issues/5215