### PR TITLE
Fixed phpdoc

### DIFF
--- a/src/Block/Element/AbstractBlock.php
+++ b/src/Block/Element/AbstractBlock.php
@@ -24,9 +24,9 @@ use League\CommonMark\Util\ArrayCollection;
 abstract class AbstractBlock
 {
     /**
-     * @var array
+     * Used for storage of arbitrary data.
      *
-     * Used for storage of arbitrary data
+     * @var array
      */
     public $data = array();
 


### PR DESCRIPTION
The "short description" MUST be the first non-empty line in the phpdoc.