### PR TITLE
Add Sculpin Bundle to list of Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Documentation can be found at [commonmark.thephpleague.com][docs].
 
 - [CakePHP 3](https://github.com/gourmet/commonmark)
 - [Laravel 4 & 5](https://github.com/GrahamCampbell/Laravel-Markdown)
+- [Sculpin](https://github.com/bcremer/sculpin-commonmark-bundle)
 - [Twig](https://github.com/webuni/commonmark-twig-renderer)
 
 ## Community Extensions


### PR DESCRIPTION
Disclaimer: I am the author of [sculpin-commonmark-bundle](https://github.com/bcremer/sculpin-commonmark-bundle).

This Sculpin Bundle provides a league/commonmark integration to [Sculpin](https://sculpin.io/).
It provides access to the low level components of league/commonmark via the sculpin DI-container.

