### PR TITLE
Add smart punctuation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "erusev/parsedown": "~1.0",
         "jgm/CommonMark": "0.20",
+        "jgm/SmartPunct": "0.20",
         "michelf/php-markdown": "~1.4",
         "phpunit/phpunit": "~4.3",
         "phpunit/phpunit-mock-objects": "2.3.0",
@@ -36,6 +37,17 @@
                 "version": "0.20",
                 "dist": {
                     "url": "http://spec.commonmark.org/0.20/spec.txt",
+                    "type": "file"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "jgm/SmartPunct",
+                "version": "0.20",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/jgm/commonmark.js/0.20.0/test/smart_punct.txt",
                     "type": "file"
                 }
             }

--- a/src/Delimiter/DelimiterStack.php
+++ b/src/Delimiter/DelimiterStack.php
@@ -134,27 +134,27 @@ class DelimiterStack
 
         while ($closer !== null) {
             $closerChar = $closer->getChar();
-            if ($closer->canClose() && (in_array($closerChar, $characters))) {
-                // Found emphasis closer. Now look back for first matching opener:
-                $opener = $this->findFirstMatchingOpener($closer, $openersBottom, $stackBottom);
 
-                $oldCloser = $closer;
-
-                if ($opener !== null) {
-                    $closer = $callback($opener, $closer, $this);
-                } else {
-                    $closer = $closer->getNext();
-                    // Set lower bound for future searches for openers:
-                    $openersBottom[$closerChar] = $oldCloser->getPrevious();
-                    if (!$oldCloser->canOpen()) {
-                        // We can remove a closer that can't be an opener,
-                        // once we've seen there's no matching opener:
-                        $this->removeDelimiter($oldCloser);
-                    }
-                }
-            } else {
+            if (!$closer->canClose() || !in_array($closerChar, $characters)) {
                 $closer = $closer->getNext();
+                continue;
             }
+
+            $opener = $this->findFirstMatchingOpener($closer, $openersBottom, $stackBottom);
+            if (!$opener) {
+                $oldCloser = $closer;
+                $closer = $closer->getNext();
+                // Set lower bound for future searches for openers:
+                $openersBottom[$closerChar] = $oldCloser->getPrevious();
+                if (!$oldCloser->canOpen()) {
+                    // We can remove a closer that can't be an opener,
+                    // once we've seen there's no matching opener:
+                    $this->removeDelimiter($oldCloser);
+                }
+                continue;
+            }
+
+            $closer = $callback($opener, $closer, $this);
         }
     }
 

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -441,7 +441,7 @@ class Environment
     {
         $chars = array_keys($this->inlineParsersByCharacter);
 
-        $this->inlineParserCharacterRegex = '/^[^' . preg_quote(implode('', $chars)) . ']+/';
+        $this->inlineParserCharacterRegex = '/^[^' . preg_quote(implode('', $chars)) . ']+/u';
     }
 
     /**

--- a/src/Extension/SmartPunctExtension.php
+++ b/src/Extension/SmartPunctExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ *  - (c) John MacFarlane
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension;
+
+use League\CommonMark\Block\Parser as BlockParser;
+use League\CommonMark\Block\Renderer as BlockRenderer;
+use League\CommonMark\Inline\Parser as InlineParser;
+use League\CommonMark\Inline\Processor as InlineProcessor;
+use League\CommonMark\Inline\Renderer as InlineRenderer;
+
+class SmartPunctExtension extends Extension
+{
+    /**
+     * @return BlockParser\BlockParserInterface[]
+     */
+    public function getBlockParsers()
+    {
+        return [];
+    }
+
+    /**
+     * @return BlockRenderer\BlockRendererInterface[]
+     */
+    public function getBlockRenderers()
+    {
+        return [
+            'League\CommonMark\Block\Element\Document'            => new BlockRenderer\DocumentRenderer(),
+            'League\CommonMark\Block\Element\Paragraph'           => new BlockRenderer\ParagraphRenderer(),
+        ];
+    }
+
+    /**
+     * @return InlineParser\InlineParserInterface[]
+     */
+    public function getInlineParsers()
+    {
+        return [
+            new InlineParser\QuoteParser(),
+            new InlineParser\SmartPunctParser(),
+        ];
+    }
+
+    /**
+     * @return InlineProcessor\InlineProcessorInterface[]
+     */
+    public function getInlineProcessors()
+    {
+        return [
+            new InlineProcessor\QuoteProcessor(),
+        ];
+    }
+
+    /**
+     * @return InlineRenderer\InlineRendererInterface[]
+     */
+    public function getInlineRenderers()
+    {
+        return [
+            'League\CommonMark\Inline\Element\Text' => new InlineRenderer\TextRenderer(),
+        ];
+    }
+
+    /**
+     * Returns the name of the extension
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'smartpunct';
+    }
+}

--- a/src/Inline/Parser/CloseBracketParser.php
+++ b/src/Inline/Parser/CloseBracketParser.php
@@ -17,6 +17,7 @@ namespace League\CommonMark\Inline\Parser;
 use League\CommonMark\ContextInterface;
 use League\CommonMark\Cursor;
 use League\CommonMark\Delimiter\Delimiter;
+use League\CommonMark\Delimiter\DelimiterStack;
 use League\CommonMark\Environment;
 use League\CommonMark\EnvironmentAwareInterface;
 use League\CommonMark\Inline\Element\AbstractWebResource;
@@ -88,8 +89,13 @@ class CloseBracketParser extends AbstractInlineParser implements EnvironmentAwar
             return false;
         }
 
+        $delimiterStack = $inlineContext->getDelimiterStack();
+        $stackBottom = $opener->getPrevious();
         foreach ($this->environment->getInlineProcessors() as $inlineProcessor) {
-            $inlineProcessor->processInlines($labelInlines, $inlineContext->getDelimiterStack(), $opener->getPrevious());
+            $inlineProcessor->processInlines($labelInlines, $delimiterStack, $stackBottom);
+        }
+        if($delimiterStack instanceof DelimiterStack){
+            $delimiterStack->removeAll($stackBottom);
         }
 
         // Remove the part of inlines that become link_text

--- a/src/Inline/Parser/QuoteParser.php
+++ b/src/Inline/Parser/QuoteParser.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ *  - (c) John MacFarlane
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Inline\Parser;
+
+use League\CommonMark\ContextInterface;
+use League\CommonMark\Delimiter\Delimiter;
+use League\CommonMark\InlineParserContext;
+use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Util\RegexHelper;
+
+class QuoteParser extends AbstractInlineParser
+{
+    protected $double = ['"', "“", "”"];
+    protected $single = ["'", "‘", "’"];
+
+    /**
+     * @return string[]
+     */
+    public function getCharacters()
+    {
+        return array_merge($this->double, $this->single);
+    }
+
+    /**
+     * @param ContextInterface $context
+     * @param InlineParserContext $inlineContext
+     *
+     * @return bool
+     */
+    public function parse(ContextInterface $context, InlineParserContext $inlineContext)
+    {
+        $character = $inlineContext->getCursor()->getCharacter();
+        if (in_array($character, $this->double)) {
+            $character = '“';
+        } elseif (in_array($character, $this->single)) {
+            $character = "’";
+        } else {
+            return false;
+        }
+
+        $cursor = $inlineContext->getCursor();
+        $charBefore = $cursor->peek(-1);
+        if ($charBefore === null) {
+            $charBefore = "\n";
+        }
+
+        $cursor->advance();
+
+        $charAfter = $cursor->getCharacter();
+        if ($charAfter === null) {
+            $charAfter = "\n";
+        }
+
+        $afterIsWhitespace = preg_match('/\pZ|\s/u', $charAfter);
+        $afterIsPunctuation = preg_match(RegexHelper::REGEX_PUNCTUATION, $charAfter);
+        $beforeIsWhitespace = preg_match('/\pZ|\s/u', $charBefore);
+        $beforeIsPunctuation = preg_match(RegexHelper::REGEX_PUNCTUATION, $charBefore);
+
+        $leftFlanking = !$afterIsWhitespace &&
+            !($afterIsPunctuation &&
+            !$beforeIsWhitespace &&
+            !$beforeIsPunctuation);
+
+        $rightFlanking = !$beforeIsWhitespace &&
+            !($beforeIsPunctuation &&
+            !$afterIsWhitespace &&
+            !$afterIsPunctuation);
+
+        $canOpen = $leftFlanking;
+        $canClose = $rightFlanking;
+
+        $inlineContext->getInlines()->add(
+            new Text($character, ['delim' => true])
+        );
+
+        // Add entry to stack to this opener
+        $delimiter = new Delimiter($character, 1, $inlineContext->getInlines()->count() - 1, $canOpen, $canClose);
+        $inlineContext->getDelimiterStack()->push($delimiter);
+
+        return true;
+    }
+}

--- a/src/Inline/Parser/SmartPunctParser.php
+++ b/src/Inline/Parser/SmartPunctParser.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ *  - (c) John MacFarlane
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Inline\Parser;
+
+use League\CommonMark\ContextInterface;
+use League\CommonMark\InlineParserContext;
+use League\CommonMark\Inline\Element\Text;
+
+class SmartPunctParser extends AbstractInlineParser
+{
+    /**
+     * @return string[]
+     */
+    public function getCharacters()
+    {
+        return ['-', '.'];
+    }
+
+    /**
+     * @param ContextInterface $context
+     * @param InlineParserContext $inlineContext
+     *
+     * @return bool
+     */
+    public function parse(ContextInterface $context, InlineParserContext $inlineContext)
+    {
+        $cursor = $inlineContext->getCursor();
+        $ch = $cursor->getCharacter();
+
+        // Ellipses
+        if ($ch === '.' && $matched = $cursor->match('/^\\.( ?\\.)\\1/'))
+        {
+            $inlineContext->getInlines()->add(new Text("…"));
+            return true;
+        }
+
+        // Em/En-dashes
+        elseif ($ch === '-' && $matched = $cursor->match('/^(?<!-)(-{2,})/'))
+        {
+            $count = strlen($matched);
+            $en_dash = '–';
+            $en_count = 0;
+            $em_dash = '—';
+            $em_count = 0;
+            if ($count % 3 === 0) {
+                $em_count = $count / 3;
+            } elseif ($count % 2 === 0) {
+                $en_count = $count / 2;
+            } elseif (($count - 2) % 3 === 0) {
+                $em_count = floor(($count - 2) / 3);
+                $en_count = 1;
+            } else {
+                $em_count = floor(($count - 4) / 3);
+                $en_count = 2;
+            }
+            $inlineContext->getInlines()->add(new Text(
+                str_repeat($em_dash, $em_count).
+                str_repeat($en_dash, $en_count)
+            ));
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Inline/Parser/SmartPunctParser.php
+++ b/src/Inline/Parser/SmartPunctParser.php
@@ -50,24 +50,19 @@ class SmartPunctParser extends AbstractInlineParser
         elseif ($ch === '-' && $matched = $cursor->match('/^(?<!-)(-{2,})/'))
         {
             $count = strlen($matched);
-            $en_dash = '–';
-            $en_count = 0;
+
+            $em_count = floor($count / 3);
+            $count -= $em_count * 3;
+
+            $en_count = floor($count / 2);
+            $count -= $en_count * 2;
+
             $em_dash = '—';
-            $em_count = 0;
-            if ($count % 3 === 0) {
-                $em_count = $count / 3;
-            } elseif ($count % 2 === 0) {
-                $en_count = $count / 2;
-            } elseif (($count - 2) % 3 === 0) {
-                $em_count = floor(($count - 2) / 3);
-                $en_count = 1;
-            } else {
-                $em_count = floor(($count - 4) / 3);
-                $en_count = 2;
-            }
+            $en_dash = '–';
             $inlineContext->getInlines()->add(new Text(
                 str_repeat($em_dash, $em_count).
-                str_repeat($en_dash, $en_count)
+                str_repeat($en_dash, $en_count).
+                str_repeat("-", $count)
             ));
             return true;
         }

--- a/src/Inline/Processor/EmphasisProcessor.php
+++ b/src/Inline/Processor/EmphasisProcessor.php
@@ -84,7 +84,5 @@ class EmphasisProcessor implements InlineProcessorInterface
         $delimiterStack->iterateByCharacters(['_', '*'], $callback, $stackBottom);
         // Remove gaps
         $inlines->removeGaps();
-        // Remove all delimiters
-        $delimiterStack->removeAll($stackBottom);
     }
 }

--- a/src/Inline/Processor/QuoteProcessor.php
+++ b/src/Inline/Processor/QuoteProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ *  - (c) John MacFarlane
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Inline\Processor;
+
+use League\CommonMark\Delimiter\Delimiter;
+use League\CommonMark\Delimiter\DelimiterStack;
+use League\CommonMark\Util\ArrayCollection;
+
+class QuoteProcessor implements InlineProcessorInterface
+{
+    public function processInlines(ArrayCollection $inlines, DelimiterStack $delimiterStack, Delimiter $stackBottom = null)
+    {
+        $callback = function (Delimiter $opener, Delimiter $closer, DelimiterStack $stack) use ($inlines) {
+            // Open quote
+            $openerInline = $inlines->get($opener->getPos());
+            $openerInline->setContent(
+                $openerInline->getContent() === '“' ? '“' : '‘'
+            );
+
+            // Close quote
+            $closerInline = $inlines->get($closer->getPos());
+            $closerInline->setContent(
+                $closerInline->getContent() === '“' ? '”' : '’'
+            );
+
+            return $closer->getNext();
+        };
+
+        // Process the emphasis characters
+        $delimiterStack->iterateByCharacters(['“', "’"], $callback, $stackBottom);
+        // Remove gaps
+        $inlines->removeGaps();
+    }
+}

--- a/src/Inline/Processor/QuoteProcessor.php
+++ b/src/Inline/Processor/QuoteProcessor.php
@@ -40,7 +40,5 @@ class QuoteProcessor implements InlineProcessorInterface
 
         // Process the emphasis characters
         $delimiterStack->iterateByCharacters(['“', "’"], $callback, $stackBottom);
-        // Remove gaps
-        $inlines->removeGaps();
     }
 }

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -74,9 +74,14 @@ class InlineParserEngine
      */
     protected function processInlines(InlineParserContext $inlineParserContext)
     {
+        $delimiterStack = $inlineParserContext->getDelimiterStack();
+
         foreach ($this->environment->getInlineProcessors() as $inlineProcessor) {
-            $inlineProcessor->processInlines($inlineParserContext->getInlines(), $inlineParserContext->getDelimiterStack());
+            $inlineProcessor->processInlines($inlineParserContext->getInlines(), $delimiterStack);
         }
+
+        // Remove all delimiters
+        $delimiterStack->removeAll();
     }
 
     /**

--- a/tests/functional/SmartPunctTest.php
+++ b/tests/functional/SmartPunctTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ *  - (c) John MacFarlane
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Functional;
+
+use League\CommonMark\Environment;
+use League\CommonMark\Inline\Parser\SmartPunctParser;
+use League\CommonMark\Inline\Parser\QuoteParser;
+use League\CommonMark\Inline\Processor\QuoteProcessor;
+use League\CommonMark\Inline\Renderer\TextRenderer;
+use League\CommonMark\Converter;
+use League\CommonMark\DocParser;
+use League\CommonMark\HtmlRenderer;
+
+/**
+ * Tests the parser against the CommonMark spec
+ */
+class SmartPunctTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CommonMarkConverter
+     */
+    protected $converter;
+
+    protected function setUp()
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser(new SmartPunctParser());
+        $environment->addInlineParser(new QuoteParser());
+        $environment->addInlineProcessor(new QuoteProcessor());
+        $this->converter = new Converter(
+            new DocParser($environment),
+            new HtmlRenderer($environment)
+        );
+    }
+
+    /**
+     * @param string $markdown Markdown to parse
+     * @param string $html     Expected result
+     * @param string $section  Section of the spec
+     * @param int    $number   Example number
+     *
+     * @dataProvider dataProvider
+     */
+    public function testExample($markdown, $html, $section, $number)
+    {
+        $actualResult = $this->converter->convertToHtml($markdown);
+
+        $failureMessage = sprintf('Unexpected result ("%s" section, example #%d)', $section, $number);
+        $failureMessage .= "\n=== markdown ===============\n" . $markdown;
+        $failureMessage .= "\n=== expected ===============\n" . $html;
+        $failureMessage .= "\n=== got ====================\n" . $actualResult;
+
+        $this->assertEquals($html, $actualResult, $failureMessage);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider()
+    {
+        $filename = __DIR__ . '/../../vendor/jgm/SmartPunct/smart_punct.txt';
+        if (($data = file_get_contents($filename)) === false) {
+            $this->fail(sprintf('Failed to load spec from %s', $filename));
+        }
+
+        $matches = [];
+        // Normalize newlines for platform independence
+        $data = preg_replace('/\r\n?/', "\n", $data);
+        $data = preg_replace('/<!-- END TESTS -->.*$/', '', $data);
+        preg_match_all('/^\.\n([\s\S]*?)^\.\n([\s\S]*?)^\.$|^#{1,6} *(.*)$/m', $data, $matches, PREG_SET_ORDER);
+
+        $examples = [];
+        $currentSection = "";
+        $exampleNumber = 0;
+
+        foreach ($matches as $match) {
+            if (isset($match[3])) {
+                $currentSection = $match[3];
+            } else {
+                $exampleNumber++;
+
+                $markdown = $match[1];
+                $markdown = str_replace('→', "\t", $markdown);
+
+                $examples[] = [
+                    'markdown' => $markdown,
+                    'html' => $match[2],
+                    'section' => $currentSection,
+                    'number' => $exampleNumber
+                ];
+            }
+        }
+
+        return $examples;
+    }
+}

--- a/tests/functional/SmartPunctTest.php
+++ b/tests/functional/SmartPunctTest.php
@@ -15,10 +15,7 @@
 namespace League\CommonMark\Tests\Functional;
 
 use League\CommonMark\Environment;
-use League\CommonMark\Inline\Parser\SmartPunctParser;
-use League\CommonMark\Inline\Parser\QuoteParser;
-use League\CommonMark\Inline\Processor\QuoteProcessor;
-use League\CommonMark\Inline\Renderer\TextRenderer;
+use League\CommonMark\Extension\SmartPunctExtension;
 use League\CommonMark\Converter;
 use League\CommonMark\DocParser;
 use League\CommonMark\HtmlRenderer;
@@ -36,9 +33,7 @@ class SmartPunctTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $environment = Environment::createCommonMarkEnvironment();
-        $environment->addInlineParser(new SmartPunctParser());
-        $environment->addInlineParser(new QuoteParser());
-        $environment->addInlineProcessor(new QuoteProcessor());
+        $environment->addExtension(new SmartPunctExtension());
         $this->converter = new Converter(
             new DocParser($environment),
             new HtmlRenderer($environment)


### PR DESCRIPTION
Per jgm/commonmark.js@7bd852b40170f9a32864c6644ac7b5248f880f12

This PR implements the smart punctuation work done in commonmark.js and fixes a few bugs with this package.

- Smart quote, ellipsis, and en/em-dash replacement
- Punctuation tests added from jgm/commonmark.js
- Fix a unicode issue with parsing (see Environment.php)
- Fix bug where only a single Processor could be added (see closeBracketParser.php, EmphasisProcessor.php, and InlineParserEngine.php)