### PR TITLE
Fix wording for invalid inline exception

### DIFF
--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -74,7 +74,7 @@ class HtmlRenderer implements HtmlRendererInterface
     {
         $renderer = $this->environment->getInlineRendererForClass(get_class($inline));
         if (!$renderer) {
-            throw new \RuntimeException('Unable to find corresponding renderer for block type ' . get_class($inline));
+            throw new \RuntimeException('Unable to find corresponding renderer for inline type ' . get_class($inline));
         }
 
         return $renderer->render($inline, $this);


### PR DESCRIPTION
This has thrown me off a few times. Looks like a copy/paste issue. (Same exact error message can be found later in the file for invalid blocks.)