### PR TITLE
Added reference to parent block for inline elements before processing

### DIFF
--- a/src/DocParser.php
+++ b/src/DocParser.php
@@ -137,7 +137,7 @@ class DocParser
     {
         if ($block instanceof AbstractInlineContainer) {
             $cursor = new Cursor(trim($block->getStringContent()));
-            $block->setInlines($this->inlineParserEngine->parse($context, $cursor));
+            $block->setInlines($this->inlineParserEngine->parse($context, $cursor, $block));
         }
 
         foreach ($block->getChildren() as $child) {


### PR DESCRIPTION
I want to solve a hack with ``debug_backtrace`` in https://github.com/webuni/commonmark-attributes-extension/blob/master/src/AttributesInlineProcessor.php#L39