### PR TITLE
Set inline parents before processing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
  - Added HTML block types
  - Added indentation caching to the cursor
  - Added automated code style checks (#133)
+ - Inline parents are also set prior to processing (#147 & #162)
 
 ### Changed
  - Bumped spec target version to 0.21

--- a/src/DocParser.php
+++ b/src/DocParser.php
@@ -136,6 +136,7 @@ class DocParser
     {
         if ($block instanceof AbstractInlineContainer) {
             $cursor = new Cursor(trim($block->getStringContent()));
+            $context->setContainer($block);
             $block->setInlines($this->inlineParserEngine->parse($context, $cursor));
         }
 

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark;
 
+use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Util\ArrayCollection;
 
@@ -38,6 +39,14 @@ class InlineParserEngine
         while (($character = $cursor->getCharacter()) !== null) {
             if (!$this->parseCharacter($character, $context, $inlineParserContext)) {
                 $this->addPlainText($character, $inlineParserContext);
+            }
+        }
+
+        // Set the parent before processing occurs, as the processors may want to know
+        // which block element the inlines reside inside of.
+        foreach ($inlineParserContext->getInlines() as $inline) {
+            if ($inline instanceof AbstractInline) {
+                $inline->setParent($context->getContainer());
             }
         }
 


### PR DESCRIPTION
It's possible that inlines may be added/modified, so we'll still need to set the parents
afterwards (this functionality already exists).

This is an alternate implementation to #147.