### PR TITLE
Fix replacement of multiple apostrophes in the same paragraph

### DIFF
--- a/src/Inline/Parser/QuoteParser.php
+++ b/src/Inline/Parser/QuoteParser.php
@@ -78,7 +78,7 @@ class QuoteParser extends AbstractInlineParser
             !$afterIsWhitespace &&
             !$afterIsPunctuation);
 
-        $canOpen = $leftFlanking;
+        $canOpen = $leftFlanking && ($character !== '’' || !$rightFlanking);
         $canClose = $rightFlanking;
 
         $inlineContext->getInlines()->add(


### PR DESCRIPTION
Per jgm/commonmark.js#61, which isn't yet merged, but don't see why it wouldn't be.

This could probably be merged right away, if you wanted, since it doesn't break any existing tests. The test it helps to pass is in jgm/commonmark.js#61.