### PR TITLE
Remove unnecessary trim from ListItemRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
  - Changed tab/indentation handling to meet the new spec behavior
  - Modified spec tests to show spaces and tabs in test results
  - Replaced `HtmlRendererInterface` with `ElementRendererInterface` (#141)
+ - Removed the unnecessary `trim()` and string cast from `ListItemRenderer`
 
 ### Fixed
  - Fixed link reference definition edge case (#120)

--- a/src/Block/Renderer/ListItemRenderer.php
+++ b/src/Block/Renderer/ListItemRenderer.php
@@ -49,6 +49,6 @@ class ListItemRenderer implements BlockRendererInterface
 
         $li = new HtmlElement('li', $attrs, $contents);
 
-        return trim($li);
+        return $li;
     }
 }

--- a/tests/unit/Block/Renderer/ListItemRendererTest.php
+++ b/tests/unit/Block/Renderer/ListItemRendererTest.php
@@ -17,6 +17,7 @@ namespace League\CommonMark\Tests\Unit\Block\Renderer;
 use League\CommonMark\Block\Element\ListData;
 use League\CommonMark\Block\Element\ListItem;
 use League\CommonMark\Block\Renderer\ListItemRenderer;
+use League\CommonMark\HtmlElement;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
 
 class ListItemRendererTest extends \PHPUnit_Framework_TestCase
@@ -39,8 +40,9 @@ class ListItemRendererTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('<li id="::escape::id">::blocks::</li>', $result);
+        $this->assertTrue($result instanceof HtmlElement);
+        $this->assertEquals('li', $result->getTagName());
+        $this->assertEquals('<li id="::escape::id">::blocks::</li>', $result->__toString());
     }
 
     /**


### PR DESCRIPTION
This ensures our renderer returns an HtmlElement instead of a string, which is easier to work with