### PR TITLE
Make `AbstractBlock::handleRemainingContents()` no longer abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
  - Modified `AbstractBlock::setLastLineBlank()`
    - Functionality moved to `AbstractBlock::shouldLastLineBeBlank()` and new `DocParser::setAndPropagateLastLineBlank()` method
    - `AbstractBlock::setLastLineBlank()` is now a setter method for `AbstractBlock::$lastLineBlank`
+ - `AbstractBlock::handleRemainingContents()` is no longer abstract
+   - A default implementation is provided
+   - Removed duplicate code from sub-classes which used the default implementation - they'll just use the parent method from now on
 
 ### Fixed
  - Fixed logic error in calculation of offset (see jgm/commonmark.js@94053a8)

--- a/src/Block/Element/AbstractBlock.php
+++ b/src/Block/Element/AbstractBlock.php
@@ -139,7 +139,13 @@ abstract class AbstractBlock extends Node
      * @param ContextInterface $context
      * @param Cursor           $cursor
      */
-    abstract public function handleRemainingContents(ContextInterface $context, Cursor $cursor);
+    public function handleRemainingContents(ContextInterface $context, Cursor $cursor)
+    {
+        // create paragraph container for line
+        $context->addBlock(new Paragraph());
+        $cursor->advanceToFirstNonSpace();
+        $context->getTip()->addLine($cursor->getRemainder());
+    }
 
     /**
      * @param int $startLine

--- a/src/Block/Element/BlockQuote.php
+++ b/src/Block/Element/BlockQuote.php
@@ -14,7 +14,6 @@
 
 namespace League\CommonMark\Block\Element;
 
-use League\CommonMark\ContextInterface;
 use League\CommonMark\Cursor;
 
 class BlockQuote extends AbstractBlock
@@ -64,21 +63,6 @@ class BlockQuote extends AbstractBlock
         }
 
         return false;
-    }
-
-    /**
-     * @param ContextInterface $context
-     * @param Cursor           $cursor
-     */
-    public function handleRemainingContents(ContextInterface $context, Cursor $cursor)
-    {
-        if ($cursor->isBlank()) {
-            return;
-        }
-
-        $context->addBlock(new Paragraph());
-        $cursor->advanceToFirstNonSpace();
-        $context->getTip()->addLine($cursor->getRemainder());
     }
 
     /**

--- a/src/Block/Element/Document.php
+++ b/src/Block/Element/Document.php
@@ -14,7 +14,6 @@
 
 namespace League\CommonMark\Block\Element;
 
-use League\CommonMark\ContextInterface;
 use League\CommonMark\Cursor;
 use League\CommonMark\Reference\ReferenceMap;
 
@@ -77,20 +76,5 @@ class Document extends AbstractBlock
     public function matchesNextLine(Cursor $cursor)
     {
         return true;
-    }
-
-    /**
-     * @param ContextInterface $context
-     * @param Cursor           $cursor
-     */
-    public function handleRemainingContents(ContextInterface $context, Cursor $cursor)
-    {
-        if ($cursor->isBlank()) {
-            return;
-        }
-
-        $context->addBlock(new Paragraph());
-        $cursor->advanceToFirstNonSpace();
-        $context->getTip()->addLine($cursor->getRemainder());
     }
 }

--- a/src/Block/Element/HorizontalRule.php
+++ b/src/Block/Element/HorizontalRule.php
@@ -14,7 +14,6 @@
 
 namespace League\CommonMark\Block\Element;
 
-use League\CommonMark\ContextInterface;
 use League\CommonMark\Cursor;
 
 class HorizontalRule extends AbstractBlock
@@ -54,14 +53,5 @@ class HorizontalRule extends AbstractBlock
     public function matchesNextLine(Cursor $cursor)
     {
         return false;
-    }
-
-    /**
-     * @param ContextInterface $context
-     * @param Cursor           $cursor
-     */
-    public function handleRemainingContents(ContextInterface $context, Cursor $cursor)
-    {
-        // nothing to do; we already added the contents.
     }
 }

--- a/src/Block/Element/ListBlock.php
+++ b/src/Block/Element/ListBlock.php
@@ -131,16 +131,4 @@ class ListBlock extends AbstractBlock
     {
         return $this->tight;
     }
-
-    /**
-     * @param ContextInterface $context
-     * @param Cursor           $cursor
-     */
-    public function handleRemainingContents(ContextInterface $context, Cursor $cursor)
-    {
-        // create paragraph container for line
-        $context->addBlock(new Paragraph());
-        $cursor->advanceToFirstNonSpace();
-        $context->getTip()->addLine($cursor->getRemainder());
-    }
 }

--- a/src/Block/Element/ListItem.php
+++ b/src/Block/Element/ListItem.php
@@ -14,7 +14,6 @@
 
 namespace League\CommonMark\Block\Element;
 
-use League\CommonMark\ContextInterface;
 use League\CommonMark\Cursor;
 
 class ListItem extends AbstractBlock
@@ -74,22 +73,6 @@ class ListItem extends AbstractBlock
         }
 
         return true;
-    }
-
-    /**
-     * @param ContextInterface $context
-     * @param Cursor           $cursor
-     */
-    public function handleRemainingContents(ContextInterface $context, Cursor $cursor)
-    {
-        if ($cursor->isBlank()) {
-            return;
-        }
-
-        // create paragraph container for line
-        $context->addBlock(new Paragraph());
-        $cursor->advanceToFirstNonSpace();
-        $context->getTip()->addLine($cursor->getRemainder());
     }
 
     /**


### PR DESCRIPTION
A default implementation is provided.  This was based on code which was duplicated across several
sub-classes.  This duplicate code is therefore unneeded and was removed.