### PR TITLE
Update travis-ci to thephpleague's skeleton style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 composer.phar
 /vendor/
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,20 @@ php:
 matrix:
   allow_failures:
     - php: 7.0
+  include:
+    - php: 5.4
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-source
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then vendor/bin/phpunit; fi
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover; fi
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "michelf/php-markdown": "~1.4",
         "mikehaertl/php-shellcommand": "~1.1.0",
         "phpunit/phpunit": "~4.3",
-        "symfony/finder": "~2.3"
+        "symfony/finder": "~2.3",
+        "scrutinizer/ocular": "^1.1"
     },
     "repositories": [
         {


### PR DESCRIPTION
This removes the need to download ocular.phar (using wget) within travis.  Also adds the ability to check the composer version constraints with (--prefer-lowest).

But all in all, follows the skeleton projects design. (https://github.com/thephpleague/skeleton)