### PR TITLE
Html safe mode

### DIFF
--- a/bin/commonmark
+++ b/bin/commonmark
@@ -11,6 +11,7 @@ $options_raw = getopt('', array(
     'use-underscore',
     'enable-strong',
     'enable-em',
+    'safe',
 ));
 foreach ($options_raw as $option => $value) {
     switch ($option) {
@@ -18,6 +19,7 @@ foreach ($options_raw as $option => $value) {
         case 'use-underscore':
         case 'enable-strong':
         case 'enable-em':
+        case 'safe':
             if ($value !== true && $value !== false) {
                 fail("Invalid value '$value' for option '$option'");
             }
@@ -37,6 +39,9 @@ foreach ($argv as $i => $arg) {
             case '--help':
                 echo getHelpText();
                 exit(0);
+            case '--safe':
+                $options['safe'] = true;
+                break;
             default:
                 $option = explode('=', $arg, 2)[0];
                 if (!preg_match('/^--[^-]/', $option)
@@ -82,6 +87,8 @@ CommonMark - Markdown done right
 Usage: commonmark [OPTIONS] [FILE]
 
     -h, --help  Shows help and usage information
+
+    --safe      Escapes all raw HTML input and removes unsafe URLs
 
     If no file is given, input will be read from STDIN
 

--- a/src/Block/Renderer/HtmlBlockRenderer.php
+++ b/src/Block/Renderer/HtmlBlockRenderer.php
@@ -17,9 +17,16 @@ namespace League\CommonMark\Block\Renderer;
 use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Element\HtmlBlock;
 use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Util\Configuration;
+use League\CommonMark\Util\ConfigurationAwareInterface;
 
-class HtmlBlockRenderer implements BlockRendererInterface
+class HtmlBlockRenderer implements BlockRendererInterface, ConfigurationAwareInterface
 {
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
     /**
      * @param HtmlBlock                $block
      * @param ElementRendererInterface $htmlRenderer
@@ -33,6 +40,18 @@ class HtmlBlockRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: ' . get_class($block));
         }
 
+        if ($this->config->getConfig('safe') === true) {
+            return '';
+        }
+
         return $block->getStringContent();
+    }
+
+    /**
+     * @param Configuration $configuration
+     */
+    public function setConfiguration(Configuration $configuration)
+    {
+        $this->config = $configuration;
     }
 }

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -443,6 +443,7 @@ class Environment
                 'inner_separator' => "\n",
                 'soft_break'      => "\n",
             ],
+            'safe' => false,
         ]);
 
         return $environment;

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -23,6 +23,7 @@ use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\Inline\Processor\InlineProcessorInterface;
 use League\CommonMark\Inline\Renderer\InlineRendererInterface;
 use League\CommonMark\Util\Configuration;
+use League\CommonMark\Util\ConfigurationAwareInterface;
 
 class Environment
 {
@@ -357,6 +358,10 @@ class Environment
                 $blockParser->setEnvironment($this);
             }
 
+            if ($blockParser instanceof ConfigurationAwareInterface) {
+                $blockParser->setConfiguration($this->config);
+            }
+
             $this->blockParsers[$blockParser->getName()] = $blockParser;
         }
     }
@@ -368,6 +373,10 @@ class Environment
     {
         foreach ($blockRenderers as $class => $blockRenderer) {
             $this->blockRenderersByClass[$class] = $blockRenderer;
+
+            if ($blockRenderer instanceof ConfigurationAwareInterface) {
+                $blockRenderer->setConfiguration($this->config);
+            }
         }
     }
 
@@ -379,6 +388,10 @@ class Environment
         foreach ($inlineParsers as $inlineParser) {
             if ($inlineParser instanceof EnvironmentAwareInterface) {
                 $inlineParser->setEnvironment($this);
+            }
+
+            if ($inlineParser instanceof ConfigurationAwareInterface) {
+                $inlineParser->setConfiguration($this->config);
             }
 
             $this->inlineParsers[$inlineParser->getName()] = $inlineParser;
@@ -396,6 +409,10 @@ class Environment
     {
         foreach ($inlineProcessors as $inlineProcessor) {
             $this->inlineProcessors[] = $inlineProcessor;
+
+            if ($inlineProcessor instanceof ConfigurationAwareInterface) {
+                $inlineProcessor->setConfiguration($this->config);
+            }
         }
     }
 
@@ -406,6 +423,10 @@ class Environment
     {
         foreach ($inlineRenderers as $class => $inlineRenderer) {
             $this->inlineRenderersByClass[$class] = $inlineRenderer;
+
+            if ($inlineRenderer instanceof ConfigurationAwareInterface) {
+                $inlineRenderer->setConfiguration($this->config);
+            }
         }
     }
 

--- a/src/Inline/Renderer/LinkRenderer.php
+++ b/src/Inline/Renderer/LinkRenderer.php
@@ -18,9 +18,17 @@ use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
 use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Element\Link;
+use League\CommonMark\Util\Configuration;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\RegexHelper;
 
-class LinkRenderer implements InlineRendererInterface
+class LinkRenderer implements InlineRendererInterface, ConfigurationAwareInterface
 {
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
     /**
      * @param Link                     $inline
      * @param ElementRendererInterface $htmlRenderer
@@ -38,12 +46,22 @@ class LinkRenderer implements InlineRendererInterface
             $attrs[$key] = $htmlRenderer->escape($value, true);
         }
 
-        $attrs['href'] = $htmlRenderer->escape($inline->getUrl(), true);
+        if (!($this->config->getConfig('safe') && RegexHelper::isLinkPotentiallyUnsafe($inline->getUrl()))) {
+            $attrs['href'] = $htmlRenderer->escape($inline->getUrl(), true);
+        }
 
         if (isset($inline->data['title'])) {
             $attrs['title'] = $htmlRenderer->escape($inline->data['title'], true);
         }
 
         return new HtmlElement('a', $attrs, $htmlRenderer->renderInlines($inline->children()));
+    }
+
+    /**
+     * @param Configuration $configuration
+     */
+    public function setConfiguration(Configuration $configuration)
+    {
+        $this->config = $configuration;
     }
 }

--- a/src/Inline/Renderer/RawHtmlRenderer.php
+++ b/src/Inline/Renderer/RawHtmlRenderer.php
@@ -17,9 +17,16 @@ namespace League\CommonMark\Inline\Renderer;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Element\Html;
+use League\CommonMark\Util\Configuration;
+use League\CommonMark\Util\ConfigurationAwareInterface;
 
-class RawHtmlRenderer implements InlineRendererInterface
+class RawHtmlRenderer implements InlineRendererInterface, ConfigurationAwareInterface
 {
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
     /**
      * @param Html                     $inline
      * @param ElementRendererInterface $htmlRenderer
@@ -32,6 +39,18 @@ class RawHtmlRenderer implements InlineRendererInterface
             throw new \InvalidArgumentException('Incompatible inline type: ' . get_class($inline));
         }
 
+        if ($this->config->getConfig('safe') === true) {
+            return '';
+        }
+
         return $inline->getContent();
+    }
+
+    /**
+     * @param Configuration $configuration
+     */
+    public function setConfiguration(Configuration $configuration)
+    {
+        $this->config = $configuration;
     }
 }

--- a/src/Util/ConfigurationAwareInterface.php
+++ b/src/Util/ConfigurationAwareInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace League\CommonMark\Util;
+
+/**
+ * Implement this class to inject the configuration where needed
+ */
+interface ConfigurationAwareInterface
+{
+    /**
+     * @param Configuration $configuration
+     */
+    public function setConfiguration(Configuration $configuration);
+}

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -54,6 +54,8 @@ class RegexHelper
     const REGEX_ESCAPABLE = '[!"#$%&\'()*+,.\/:;<=>?@[\\\\\]^_`{|}~-]';
     const REGEX_ENTITY = '&(?:#x[a-f0-9]{1,8}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});';
     const REGEX_PUNCTUATION = '/^[\x{2000}-\x{206F}\x{2E00}-\x{2E7F}\\\\\'!"#\$%&\(\)\*\+,\-\.\\/:;<=>\?@\[\]\^_`\{\|\}~]/u';
+    const REGEX_UNSAFE_PROTOCOL = '/^javascript:|vbscript:|file:|data:/i';
+    const REGEX_SAFE_DATA_PROTOCOL = '/^data:image\/(?:png|gif|jpeg|webp)/i';
 
     protected $regex = [];
 
@@ -295,5 +297,15 @@ class RegexHelper
             case HtmlBlock::TYPE_5_CDATA:
                 return '/\]\]>/';
         }
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
+    public static function isLinkPotentiallyUnsafe($url)
+    {
+        return preg_match(self::REGEX_UNSAFE_PROTOCOL, $url) !== 0 && preg_match(self::REGEX_SAFE_DATA_PROTOCOL, $url) === 0;
     }
 }

--- a/tests/functional/BinTest.php
+++ b/tests/functional/BinTest.php
@@ -86,6 +86,35 @@ class BinTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests converting Markdown without the --safe flag
+     */
+    public function testUnsafe()
+    {
+        $cmd = new Command($this->getPathToCommonmark());
+        $cmd->addArg($this->getPathToData('safe/input.md'));
+        $cmd->execute();
+
+        $this->assertEquals(0, $cmd->getExitCode());
+        $expectedContents = trim(file_get_contents($this->getPathToData('safe/unsafe_output.html')));
+        $this->assertEquals($expectedContents, trim($cmd->getOutput()));
+    }
+
+    /**
+     * Tests converting Markdown with the --safe flag
+     */
+    public function testSafe()
+    {
+        $cmd = new Command($this->getPathToCommonmark());
+        $cmd->addArg($this->getPathToData('safe/input.md'));
+        $cmd->addArg('--safe');
+        $cmd->execute();
+
+        $this->assertEquals(0, $cmd->getExitCode());
+        $expectedContents = trim(file_get_contents($this->getPathToData('safe/safe_output.html')));
+        $this->assertEquals($expectedContents, trim($cmd->getOutput()));
+    }
+
+    /**
      * Returns the full path the commonmark "binary"
      *
      * @return string

--- a/tests/functional/SafeTest.php
+++ b/tests/functional/SafeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace League\CommonMark\Tests\Functional;
+
+use League\CommonMark\CommonMarkConverter;
+
+class SafeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultConfig()
+    {
+        $input = file_get_contents(__DIR__ . '/data/safe/input.md');
+        $expectedOutput = trim(file_get_contents(__DIR__ . '/data/safe/unsafe_output.html'));
+
+        $converter = new CommonMarkConverter();
+        $actualOutput = trim($converter->convertToHtml($input));
+
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testSafeConfig()
+    {
+        $input = file_get_contents(__DIR__ . '/data/safe/input.md');
+        $expectedOutput = trim(file_get_contents(__DIR__ . '/data/safe/safe_output.html'));
+
+        $converter = new CommonMarkConverter(['safe' => true]);
+        $actualOutput = trim($converter->convertToHtml($input));
+
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+}

--- a/tests/functional/data/safe/input.md
+++ b/tests/functional/data/safe/input.md
@@ -1,0 +1,13 @@
+[Click me](javascript:alert('XSS'))
+
+<javascript:alert("XSS")>
+
+<div onclick="alert('XSS')">click me</div>
+
+<script>alert("XSS")</script>
+
+<script>
+    alert("XSS");
+</script>
+
+![Inline image](data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)

--- a/tests/functional/data/safe/safe_output.html
+++ b/tests/functional/data/safe/safe_output.html
@@ -1,0 +1,6 @@
+<p><a>Click me</a></p>
+<p><a>javascript:alert(&quot;XSS&quot;)</a></p>
+
+
+
+<p><img src="data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7" alt="Inline image" /></p>

--- a/tests/functional/data/safe/unsafe_output.html
+++ b/tests/functional/data/safe/unsafe_output.html
@@ -1,0 +1,8 @@
+<p><a href="javascript:alert('XSS')">Click me</a></p>
+<p><a href="javascript:alert(%22XSS%22)">javascript:alert(&quot;XSS&quot;)</a></p>
+<div onclick="alert('XSS')">click me</div>
+<script>alert("XSS")</script>
+<script>
+    alert("XSS");
+</script>
+<p><img src="data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7" alt="Inline image" /></p>

--- a/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
@@ -17,6 +17,7 @@ namespace League\CommonMark\Tests\Unit\Block\Renderer;
 use League\CommonMark\Block\Element\HtmlBlock;
 use League\CommonMark\Block\Renderer\HtmlBlockRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
+use League\CommonMark\Util\Configuration;
 
 class HtmlBlockRendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,6 +29,7 @@ class HtmlBlockRendererTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->renderer = new HtmlBlockRenderer();
+        $this->renderer->setConfiguration(new Configuration());
     }
 
     public function testRender()

--- a/tests/unit/Inline/Renderer/ImageRendererTest.php
+++ b/tests/unit/Inline/Renderer/ImageRendererTest.php
@@ -18,6 +18,7 @@ use League\CommonMark\HtmlElement;
 use League\CommonMark\Inline\Element\Image;
 use League\CommonMark\Inline\Renderer\ImageRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
+use League\CommonMark\Util\Configuration;
 
 class ImageRendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,6 +30,7 @@ class ImageRendererTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->renderer = new ImageRenderer();
+        $this->renderer->setConfiguration(new Configuration());
     }
 
     public function testRenderWithTitle()

--- a/tests/unit/Inline/Renderer/LinkRendererTest.php
+++ b/tests/unit/Inline/Renderer/LinkRendererTest.php
@@ -18,6 +18,7 @@ use League\CommonMark\HtmlElement;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Renderer\LinkRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
+use League\CommonMark\Util\Configuration;
 
 class LinkRendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,6 +30,7 @@ class LinkRendererTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->renderer = new LinkRenderer();
+        $this->renderer->setConfiguration(new Configuration());
     }
 
     public function testRenderWithTitle()

--- a/tests/unit/Inline/Renderer/RawHtmlRendererTest.php
+++ b/tests/unit/Inline/Renderer/RawHtmlRendererTest.php
@@ -17,6 +17,7 @@ namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 use League\CommonMark\Inline\Element\Html;
 use League\CommonMark\Inline\Renderer\RawHtmlRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
+use League\CommonMark\Util\Configuration;
 
 class RawHtmlRendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,6 +29,7 @@ class RawHtmlRendererTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->renderer = new RawHtmlRenderer();
+        $this->renderer->setConfiguration(new Configuration());
     }
 
     public function testRender()


### PR DESCRIPTION
This introduces a new `safe` option for both the library and the CLI command.  Enabling it will prevent raw HTML from being rendered, as well as removing unsafe URLs in links and images.

This change mirrors https://github.com/jgm/commonmark.js/commit/57a1ae3ce97f4794f89658cd90b4e4f8d2c9d5a9

Addresses #200 