### PR TITLE
Fixed SmilieParser example

### DIFF
--- a/customization/inline-parsing.md
+++ b/customization/inline-parsing.md
@@ -100,7 +100,7 @@ class SmilieParser extends AbstractInlineParser
         // The next character must be a paren; if not, then bail
         // We use peek() to quickly check without affecting the cursor
         $nextChar = $cursor->peek();
-        if ($nextChar !== '(' || $nextChar !== ')') {
+        if ($nextChar !== '(' && $nextChar !== ')') {
             return false;
         }
 


### PR DESCRIPTION
This or should be an and in order for the parser to work correctly.