### PR TITLE
Require PHP 7 tests to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ php:
   - hhvm
 
 matrix:
-  allow_failures:
-    - php: 7.0
   include:
     - php: 5.4
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'


### PR DESCRIPTION
While we've always tested against PHP 7, this change will guarantee that all changes **must** be fully-supported.

This PR will be merged once Travis is using a stable build of PHP 7.