### PR TITLE
Add optional `Environment` parameter to `CommonMarkConverter` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased][unreleased]
 
+### Added
+ - Added optional `Environment` parameter to `CommonMarkConverter` constructor
+
 ### Changed
  - Renamed "header" things to "heading" for spec consistency
    - `Header` => `Heading`

--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -22,11 +22,15 @@ class CommonMarkConverter extends Converter
     /**
      * Create a new commonmark converter instance.
      *
-     * @param array $config
+     * @param array            $config
+     * @param Environment|null $environment
      */
-    public function __construct(array $config = [])
+    public function __construct(array $config = [], Environment $environment = null)
     {
-        $environment = Environment::createCommonMarkEnvironment();
+        if ($environment === null) {
+            $environment = Environment::createCommonMarkEnvironment();
+        }
+
         $environment->mergeConfig($config);
         parent::__construct(new DocParser($environment), new HtmlRenderer($environment));
     }

--- a/tests/unit/CommonMarkConverterTest.php
+++ b/tests/unit/CommonMarkConverterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace League\CommonMark\Tests\Unit;
+
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Converter;
+use League\CommonMark\DocParser;
+use League\CommonMark\Environment;
+
+class CommonMarkConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmptyConstructor()
+    {
+        $converter = new CommonMarkConverter();
+        $expectedEnvironment = Environment::createCommonMarkEnvironment();
+
+        $environment = $this->getEnvironmentFromConverter($converter);
+
+        $this->assertCount(1, $environment->getExtensions());
+        $this->assertInstanceOf('League\CommonMark\Extension\CommonMarkCoreExtension', $environment->getExtensions()[0]);
+        $this->assertEquals($expectedEnvironment->getConfig(), $environment->getConfig());
+    }
+
+    public function testConfigOnlyConstructor()
+    {
+        $config = ['foo' => 'bar'];
+        $converter = new CommonMarkConverter($config);
+
+        $environment = $this->getEnvironmentFromConverter($converter);
+
+        $this->assertCount(1, $environment->getExtensions());
+        $this->assertInstanceOf('League\CommonMark\Extension\CommonMarkCoreExtension', $environment->getExtensions()[0]);
+        $this->assertArrayHasKey('foo', $environment->getConfig());
+    }
+
+    public function testEnvironmentAndConfigConstructor()
+    {
+        $config = ['foo' => 'bar'];
+        $mockEnvironment = $this->getMock('League\CommonMark\Environment');
+        $mockEnvironment->expects($this->once())
+            ->method('mergeConfig')
+            ->with($config);
+
+        $converter = new CommonMarkConverter($config, $mockEnvironment);
+
+        $environment = $this->getEnvironmentFromConverter($converter);
+
+        $this->assertSame($mockEnvironment, $environment);
+    }
+
+    /**
+     * @param Converter $converter
+     *
+     * @return \League\CommonMark\Environment
+     */
+    private function getEnvironmentFromConverter(Converter $converter)
+    {
+        /** @var DocParser $docParser */
+        $docParser = $this->readAttribute($converter, 'docParser');
+
+        return $docParser->getEnvironment();
+    }
+}


### PR DESCRIPTION
This change allows developers to convert Markdown using a custom environment without needing to manually instantiate the doc parser and renderer.