### PR TITLE
Fix empty inline character regex (#224)

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -351,7 +351,7 @@ class Environment
             $this->initializeExtension($extension);
         }
 
-        // Lastly, let's build a regex which matches all inline characters
+        // Lastly, let's build a regex which matches non-inline characters
         // This will enable a huge performance boost with inline parsing
         $this->buildInlineParserCharacterRegex();
     }
@@ -485,7 +485,9 @@ class Environment
     }
 
     /**
-     * Regex which matches any character that an inline parser might be interested in
+     * Regex which matches any character which doesn't indicate an inline element
+     *
+     * This allows us to parse multiple non-special characters at once
      *
      * @return string
      */
@@ -498,7 +500,13 @@ class Environment
     {
         $chars = array_keys($this->inlineParsersByCharacter);
 
-        $this->inlineParserCharacterRegex = '/^[^' . preg_quote(implode('', $chars)) . ']+/u';
+        if (empty($chars)) {
+            // If no special inline characters exist then parse the whole line
+            $this->inlineParserCharacterRegex = '/^.+$/u';
+        } else {
+            // Match any character which inline parsers are not interested in
+            $this->inlineParserCharacterRegex = '/^[^' . preg_quote(implode('', $chars)) . ']+/u';
+        }
     }
 
     /**

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -436,4 +436,19 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('League\CommonMark\Extension\ExtensionInterface', $environment->getExtensions()[1]);
         $this->assertInstanceOf('League\CommonMark\Extension\MiscExtension', $environment->getExtensions()[2]);
     }
+
+    public function testGetInlineParserCharacterRegexForEmptyEnvironment()
+    {
+        $environment = new Environment();
+
+        // This triggers the initialization which builds the regex
+        $environment->createInlineParserEngine();
+
+        $regex = $environment->getInlineParserCharacterRegex();
+
+        $test = '*This* should match **everything** including chars like `[`.';
+        $matches = [];
+        preg_match($regex, $test, $matches);
+        $this->assertSame($test, $matches[0]);
+    }
 }


### PR DESCRIPTION
If an Environment creates without any inline parsers, the
`getInlineParserCharacterRegex()` method will return an invalid
regular expression. This fix ensures that a valid regex is returned
in this particular edge case.