### PR TITLE
Convert URLs that support https but are http presently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We accept contributions via Pull Requests on [GitHub](https://github.com/thephpl
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://pear.php.net/package/PHP_CodeSniffer).
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {
             "name": "Colin O'Dell",
             "email": "colinodell@gmail.com",
-            "homepage": "http://www.colinodell.com",
+            "homepage": "https://www.colinodell.com",
             "role": "Lead Developer"
         }
     ],

--- a/src/Block/Element/AbstractBlock.php
+++ b/src/Block/Element/AbstractBlock.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/BlockQuote.php
+++ b/src/Block/Element/BlockQuote.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/Document.php
+++ b/src/Block/Element/Document.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/FencedCode.php
+++ b/src/Block/Element/FencedCode.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/Heading.php
+++ b/src/Block/Element/Heading.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/HtmlBlock.php
+++ b/src/Block/Element/HtmlBlock.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/IndentedCode.php
+++ b/src/Block/Element/IndentedCode.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/ListBlock.php
+++ b/src/Block/Element/ListBlock.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/ListData.php
+++ b/src/Block/Element/ListData.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/ListItem.php
+++ b/src/Block/Element/ListItem.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/Paragraph.php
+++ b/src/Block/Element/Paragraph.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Element/ThematicBreak.php
+++ b/src/Block/Element/ThematicBreak.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/ATXHeadingParser.php
+++ b/src/Block/Parser/ATXHeadingParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/BlockParserInterface.php
+++ b/src/Block/Parser/BlockParserInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/BlockQuoteParser.php
+++ b/src/Block/Parser/BlockQuoteParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/FencedCodeParser.php
+++ b/src/Block/Parser/FencedCodeParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/HtmlBlockParser.php
+++ b/src/Block/Parser/HtmlBlockParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/IndentedCodeParser.php
+++ b/src/Block/Parser/IndentedCodeParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/LazyParagraphParser.php
+++ b/src/Block/Parser/LazyParagraphParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/ListParser.php
+++ b/src/Block/Parser/ListParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/SetExtHeadingParser.php
+++ b/src/Block/Parser/SetExtHeadingParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Parser/ThematicBreakParser.php
+++ b/src/Block/Parser/ThematicBreakParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/BlockQuoteRenderer.php
+++ b/src/Block/Renderer/BlockQuoteRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/BlockRendererInterface.php
+++ b/src/Block/Renderer/BlockRendererInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/DocumentRenderer.php
+++ b/src/Block/Renderer/DocumentRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/FencedCodeRenderer.php
+++ b/src/Block/Renderer/FencedCodeRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/HeadingRenderer.php
+++ b/src/Block/Renderer/HeadingRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/HtmlBlockRenderer.php
+++ b/src/Block/Renderer/HtmlBlockRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/IndentedCodeRenderer.php
+++ b/src/Block/Renderer/IndentedCodeRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/ListBlockRenderer.php
+++ b/src/Block/Renderer/ListBlockRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/ListItemRenderer.php
+++ b/src/Block/Renderer/ListItemRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/ParagraphRenderer.php
+++ b/src/Block/Renderer/ParagraphRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Block/Renderer/ThematicBreakRenderer.php
+++ b/src/Block/Renderer/ThematicBreakRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Context.php
+++ b/src/Context.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/ContextInterface.php
+++ b/src/ContextInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Delimiter/Delimiter.php
+++ b/src/Delimiter/Delimiter.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Delimiter/DelimiterStack.php
+++ b/src/Delimiter/DelimiterStack.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/DocParser.php
+++ b/src/DocParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/DocumentProcessorInterface.php
+++ b/src/DocumentProcessorInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/ElementRendererInterface.php
+++ b/src/ElementRendererInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Extension/CommonMarkCoreExtension.php
+++ b/src/Extension/CommonMarkCoreExtension.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Extension/MiscExtension.php
+++ b/src/Extension/MiscExtension.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/AbstractInline.php
+++ b/src/Inline/Element/AbstractInline.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/AbstractInlineContainer.php
+++ b/src/Inline/Element/AbstractInlineContainer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/AbstractStringContainer.php
+++ b/src/Inline/Element/AbstractStringContainer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/AbstractWebResource.php
+++ b/src/Inline/Element/AbstractWebResource.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Code.php
+++ b/src/Inline/Element/Code.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Emphasis.php
+++ b/src/Inline/Element/Emphasis.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/HtmlInline.php
+++ b/src/Inline/Element/HtmlInline.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Image.php
+++ b/src/Inline/Element/Image.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Link.php
+++ b/src/Inline/Element/Link.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Newline.php
+++ b/src/Inline/Element/Newline.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Strong.php
+++ b/src/Inline/Element/Strong.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Element/Text.php
+++ b/src/Inline/Element/Text.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/AutolinkParser.php
+++ b/src/Inline/Parser/AutolinkParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/BacktickParser.php
+++ b/src/Inline/Parser/BacktickParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/BangParser.php
+++ b/src/Inline/Parser/BangParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/CloseBracketParser.php
+++ b/src/Inline/Parser/CloseBracketParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/EmphasisParser.php
+++ b/src/Inline/Parser/EmphasisParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/EntityParser.php
+++ b/src/Inline/Parser/EntityParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/EscapableParser.php
+++ b/src/Inline/Parser/EscapableParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/HtmlInlineParser.php
+++ b/src/Inline/Parser/HtmlInlineParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/NewlineParser.php
+++ b/src/Inline/Parser/NewlineParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Parser/OpenBracketParser.php
+++ b/src/Inline/Parser/OpenBracketParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Processor/EmphasisProcessor.php
+++ b/src/Inline/Processor/EmphasisProcessor.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Processor/InlineProcessorInterface.php
+++ b/src/Inline/Processor/InlineProcessorInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/CodeRenderer.php
+++ b/src/Inline/Renderer/CodeRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/EmphasisRenderer.php
+++ b/src/Inline/Renderer/EmphasisRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/HtmlInlineRenderer.php
+++ b/src/Inline/Renderer/HtmlInlineRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/ImageRenderer.php
+++ b/src/Inline/Renderer/ImageRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/InlineRendererInterface.php
+++ b/src/Inline/Renderer/InlineRendererInterface.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/LinkRenderer.php
+++ b/src/Inline/Renderer/LinkRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/NewlineRenderer.php
+++ b/src/Inline/Renderer/NewlineRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/StrongRenderer.php
+++ b/src/Inline/Renderer/StrongRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Inline/Renderer/TextRenderer.php
+++ b/src/Inline/Renderer/TextRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/InlineParserContext.php
+++ b/src/InlineParserContext.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Reference/Reference.php
+++ b/src/Reference/Reference.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Reference/ReferenceMap.php
+++ b/src/Reference/ReferenceMap.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/ReferenceParser.php
+++ b/src/ReferenceParser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/UnmatchedBlockCloser.php
+++ b/src/UnmatchedBlockCloser.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Util/Html5Entities.php
+++ b/src/Util/Html5Entities.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Util/LinkParserHelper.php
+++ b/src/Util/LinkParserHelper.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Util/UrlEncoder.php
+++ b/src/Util/UrlEncoder.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/functional/SpecTest.php
+++ b/tests/functional/SpecTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
+++ b/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/DocumentRendererTest.php
+++ b/tests/unit/Block/Renderer/DocumentRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/FencedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/FencedCodeRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/HeadingRendererTest.php
+++ b/tests/unit/Block/Renderer/HeadingRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/ListBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/ListBlockRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/ListItemRendererTest.php
+++ b/tests/unit/Block/Renderer/ListItemRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/ParagraphRendererTest.php
+++ b/tests/unit/Block/Renderer/ParagraphRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
+++ b/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Extension/ExtensionTest.php
+++ b/tests/unit/Extension/ExtensionTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Extension/MiscExtensionTest.php
+++ b/tests/unit/Extension/MiscExtensionTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/FakeEmptyHtmlRenderer.php
+++ b/tests/unit/FakeEmptyHtmlRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/FakeHtmlRenderer.php
+++ b/tests/unit/FakeHtmlRenderer.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/HtmlElementTest.php
+++ b/tests/unit/HtmlElementTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Parser/BacktickParserTest.php
+++ b/tests/unit/Inline/Parser/BacktickParserTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/CodeRendererTest.php
+++ b/tests/unit/Inline/Renderer/CodeRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/EmphasisRendererTest.php
+++ b/tests/unit/Inline/Renderer/EmphasisRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/ImageRendererTest.php
+++ b/tests/unit/Inline/Renderer/ImageRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/LinkRendererTest.php
+++ b/tests/unit/Inline/Renderer/LinkRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/NewlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/NewlineRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/StrongRendererTest.php
+++ b/tests/unit/Inline/Renderer/StrongRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE

--- a/tests/unit/Inline/Renderer/TextRendererTest.php
+++ b/tests/unit/Inline/Renderer/TextRendererTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Colin O'Dell <colinodell@gmail.com>
  *
- * Original code based on the CommonMark JS reference parser (http://bitly.com/commonmark-js)
+ * Original code based on the CommonMark JS reference parser (https://bitly.com/commonmark-js)
  *  - (c) John MacFarlane
  *
  * For the full copyright and license information, please view the LICENSE


### PR DESCRIPTION
Excludes tests to avoid reducing coverage.

This is a little bit pedantic, but I forgot to exclude my vendor directory from a grep for insecure http URLs and saw these. Figured I'd sent a pull request to convert the ones that support it.