### PR TITLE
Enable calling convertToHtml as a function

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -60,4 +60,18 @@ class Converter
 
         return $this->htmlRenderer->renderBlock($documentAST);
     }
+
+    /**
+     * Converts CommonMark to HTML.
+     *
+     * @see Converter::convertToHtml
+     *
+     * @param $commonMark
+     *
+     * @return string
+     */
+    public function __invoke($commonMark)
+    {
+        return $this->convertToHtml($commonMark);
+    }
 }

--- a/tests/unit/ConverterTest.php
+++ b/tests/unit/ConverterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace League\CommonMark\Tests\Unit;
+
+use League\CommonMark\Converter;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class ConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInvokeReturnsSameOutputAsConvertToHtml()
+    {
+        $inputMarkdown = '**Strong**';
+        $expectedHtml = '<strong>Strong</strong>';
+
+        /** @var Converter|PHPUnit_Framework_MockObject_MockObject $converter */
+        $converter = $this->getMockBuilder('League\CommonMark\Converter')
+            ->disableOriginalConstructor()
+            ->setMethods(['convertToHtml'])
+            ->getMock();
+        $converter->method('convertToHtml')->with($inputMarkdown)->willReturn($expectedHtml);
+
+        $this->assertSame($expectedHtml, $converter($inputMarkdown));
+    }
+}


### PR DESCRIPTION
Adding Converter::__invoke as an alias to Converter::convertToHtml
to enable calling Converter object as functions

resolves #233