### PR TITLE
Allow trailing tabs in setext heading underlines

### DIFF
--- a/src/Block/Parser/SetExtHeadingParser.php
+++ b/src/Block/Parser/SetExtHeadingParser.php
@@ -38,7 +38,7 @@ class SetExtHeadingParser extends AbstractBlockParser
             return false;
         }
 
-        $match = RegexHelper::matchAll('/^(?:=+|-+) *$/', $cursor->getLine(), $cursor->getFirstNonSpacePosition());
+        $match = RegexHelper::matchAll('/^(?:=+|-+)[ \t]*$/', $cursor->getLine(), $cursor->getFirstNonSpacePosition());
         if ($match === null) {
             return false;
         }


### PR DESCRIPTION
This fix mirrors jgm/commonmark.js#109