### PR TITLE
Improve Cursor performance when dealing with very long lines.

### DIFF
--- a/src/CursorState.php
+++ b/src/CursorState.php
@@ -63,7 +63,7 @@ class CursorState
      * @param int      $column
      * @param bool     $partiallyConsumedTab
      */
-    public function __construct($line, $length, $currentPosition, $previousPosition, $nextNonSpaceCache, $indent, $column, $partiallyConsumedTab)
+    public function __construct($line, $length, $currentPosition, $previousPosition, $nextNonSpaceCache, $indent, $column, $partiallyConsumedTab, $encoding)
     {
         $this->line = $line;
         $this->length = $length;
@@ -73,6 +73,7 @@ class CursorState
         $this->indent = $indent;
         $this->column = $column;
         $this->partiallyConsumedTab = $partiallyConsumedTab;
+        $this->encoding = $encoding;
     }
 
     /**
@@ -149,5 +150,13 @@ class CursorState
     public function getPartiallyConsumedTab()
     {
         return $this->partiallyConsumedTab;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
     }
 }


### PR DESCRIPTION
Came across this easy-win when parsing text that had an incredibly long JSON string embedded in it.

CommonMark assumes UTF8 encoding in strings and so makes use of the multi-byte `mb_` functions for string interrogation. When using character offsets, `mb_*` functions handling variable-width encodings (like UTF8) typically have to scan the string every time from the beginning which can have `O(n)` time complexity even if you're pulling out just 1 character. As such, all of the `getCharacter()` random access calls that CommonMark makes can cause the parser have `O(n^2)` running time. As CommonMark currently parses line-by-line, this becomes noticable on text with super loooonnngg lines.

For fixed-width encodings like ASCII, the `mb_*` functions can use `O(1)` pointer arithmetic. ASCII is basically the 1-byte codepoints of UTF8 so if we know the UTF8 string only contains ASCII codepoints, then we know that all characters are 1 byte long, and `mb_` can treat the string as if it was ASCII. To allow this, `mb_detect_encoding()` determines whether the characters are ASCII or UTF8 at the point where a `Cursor` is instantiated and this encoding is persisted and used for any subsequent calls to `mb_`.

Note: in the off-chance the string is neither ASCII or UTF8, we fall back to LATIN1 (ISO-8859-1) for which `mb_` effectively treats each byte in the string as 1 character. It's a safe, best-effort fallback.

For performance testing, I ran `benchmark.php` with a new `.md` file that I generated containing a single 64kb line of "Lorem dolor ipsum...", and the parse time went down from 6.6ms to 5.3ms.

I couldn't see how you wanted to automate performance testing but let me know if you'd like me to include this new file as part of the benchmark test going forward.