### PR TITLE
readme: add github enableNewlines example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ $environment = Environment::createCommonMarkEnvironment();
 // For example:  $environment->addInlineParser(new TwitterHandleParser());
 
 // Define your configuration:
-$config = ['html_input' => 'escape'];
-
-// To configure GitHub style newlines to create line breaks:
-$config = ['renderer' => ['soft_break' => "<br />\n"]];
+$config = [
+  'html_input' => 'escape',
+  'renderer' => [
+    // To configure GitHub style newlines to create line breaks:
+    'soft_break' => "<br />\n",
+  ],
+];
 
 // Create the converter
 $converter = new CommonMarkConverter($config, $environment);

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ $environment = Environment::createCommonMarkEnvironment();
 // Define your configuration:
 $config = ['html_input' => 'escape'];
 
+// To configure GitHub style newlines to create line breaks:
+$config = ['renderer' => ['soft_break' => "<br />\n"]];
+
 // Create the converter
 $converter = new CommonMarkConverter($config, $environment);
 


### PR DESCRIPTION
This is important feature to document, especially when migrating from other implementations.

in [cebe/markdown](https://github.com/cebe/markdown) this is documented as:

> For GithubMarkdown:
> 
> `$parser->enableNewlines = true` to convert all newlines to `<br/>`-tags. By default only newlines with two preceding spaces are converted to `<br/>`-tags.