### PR TITLE
readme: remove markua

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ You can find several examples of useful extensions and customizations in the [le
 
 Custom parsers/renderers can be bundled into extensions which extend CommonMark.  Here are some that you may find interesting:
 
- - [Markua](https://github.com/dshafik/markua) - Markdown parser for PHP which intends to support the full Markua spec.
  - [CommonMark Table Extension](https://github.com/webuni/commonmark-table-extension) - Adds the ability to create tables in CommonMark documents.
  - [CommonMark Attributes Extension](https://github.com/webuni/commonmark-attributes-extension) - Adds a syntax to define attributes on the various HTML elements.
  - [Alt Three Emoji](https://github.com/AltThree/Emoji) An emoji parser for CommonMark.


### PR DESCRIPTION
it was added via wiki convert, probably was not verified what it is:
- d35cd97fc82dc1b02e71ff5056f82db52b4f5704

currently looking at their project, seems useless project which has done only `s/commonmark/markua/g` replacement, not even bothering to remove incorrect information and correcting links.

seems waste of people time sending them there.