### PR TITLE
Use PHP 5.5 class constant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "colinodell/commonmark-php": "*"
     },
     "require": {
-        "php": ">=5.6.5",
+        "php": "^5.6.5||^7.0",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/src/Extension/CommonMarkCoreExtension.php
+++ b/src/Extension/CommonMarkCoreExtension.php
@@ -14,9 +14,11 @@
 
 namespace League\CommonMark\Extension;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Parser as BlockParser;
 use League\CommonMark\Block\Renderer as BlockRenderer;
 use League\CommonMark\ConfigurableEnvironmentInterface;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Parser as InlineParser;
 use League\CommonMark\Inline\Processor as InlineProcessor;
 use League\CommonMark\Inline\Renderer as InlineRenderer;
@@ -49,25 +51,25 @@ final class CommonMarkCoreExtension implements ExtensionInterface
 
             ->addInlineProcessor(new InlineProcessor\EmphasisProcessor(), 0)
 
-            ->addBlockRenderer('League\CommonMark\Block\Element\BlockQuote',    new BlockRenderer\BlockQuoteRenderer(),    0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\Document',      new BlockRenderer\DocumentRenderer(),      0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\FencedCode',    new BlockRenderer\FencedCodeRenderer(),    0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\Heading',       new BlockRenderer\HeadingRenderer(),       0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\HtmlBlock',     new BlockRenderer\HtmlBlockRenderer(),     0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\IndentedCode',  new BlockRenderer\IndentedCodeRenderer(),  0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\ListBlock',     new BlockRenderer\ListBlockRenderer(),     0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\ListItem',      new BlockRenderer\ListItemRenderer(),      0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\Paragraph',     new BlockRenderer\ParagraphRenderer(),     0)
-            ->addBlockRenderer('League\CommonMark\Block\Element\ThematicBreak', new BlockRenderer\ThematicBreakRenderer(), 0)
+            ->addBlockRenderer(BlockElement\BlockQuote::class,    new BlockRenderer\BlockQuoteRenderer(),    0)
+            ->addBlockRenderer(BlockElement\Document::class,      new BlockRenderer\DocumentRenderer(),      0)
+            ->addBlockRenderer(BlockElement\FencedCode::class,    new BlockRenderer\FencedCodeRenderer(),    0)
+            ->addBlockRenderer(BlockElement\Heading::class,       new BlockRenderer\HeadingRenderer(),       0)
+            ->addBlockRenderer(BlockElement\HtmlBlock::class,     new BlockRenderer\HtmlBlockRenderer(),     0)
+            ->addBlockRenderer(BlockElement\IndentedCode::class,  new BlockRenderer\IndentedCodeRenderer(),  0)
+            ->addBlockRenderer(BlockElement\ListBlock::class,     new BlockRenderer\ListBlockRenderer(),     0)
+            ->addBlockRenderer(BlockElement\ListItem::class,      new BlockRenderer\ListItemRenderer(),      0)
+            ->addBlockRenderer(BlockElement\Paragraph::class,     new BlockRenderer\ParagraphRenderer(),     0)
+            ->addBlockRenderer(BlockElement\ThematicBreak::class, new BlockRenderer\ThematicBreakRenderer(), 0)
 
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Code',       new InlineRenderer\CodeRenderer(),       0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Emphasis',   new InlineRenderer\EmphasisRenderer(),   0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\HtmlInline', new InlineRenderer\HtmlInlineRenderer(), 0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Image',      new InlineRenderer\ImageRenderer(),      0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Link',       new InlineRenderer\LinkRenderer(),       0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Newline',    new InlineRenderer\NewlineRenderer(),    0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Strong',     new InlineRenderer\StrongRenderer(),     0)
-            ->addInlineRenderer('League\CommonMark\Inline\Element\Text',       new InlineRenderer\TextRenderer(),       0)
+            ->addInlineRenderer(InlineElement\Code::class,       new InlineRenderer\CodeRenderer(),       0)
+            ->addInlineRenderer(InlineElement\Emphasis::class,   new InlineRenderer\EmphasisRenderer(),   0)
+            ->addInlineRenderer(InlineElement\HtmlInline::class, new InlineRenderer\HtmlInlineRenderer(), 0)
+            ->addInlineRenderer(InlineElement\Image::class,      new InlineRenderer\ImageRenderer(),      0)
+            ->addInlineRenderer(InlineElement\Link::class,       new InlineRenderer\LinkRenderer(),       0)
+            ->addInlineRenderer(InlineElement\Newline::class,    new InlineRenderer\NewlineRenderer(),    0)
+            ->addInlineRenderer(InlineElement\Strong::class,     new InlineRenderer\StrongRenderer(),     0)
+            ->addInlineRenderer(InlineElement\Text::class,       new InlineRenderer\TextRenderer(),       0)
         ;
     }
 }

--- a/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
+++ b/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\BlockQuote;
 use League\CommonMark\Block\Renderer\BlockQuoteRenderer;
 use League\CommonMark\HtmlElement;
@@ -66,7 +67,7 @@ class BlockQuoteRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
+++ b/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
@@ -66,7 +66,7 @@ class BlockQuoteRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/DocumentRendererTest.php
+++ b/tests/unit/Block/Renderer/DocumentRendererTest.php
@@ -59,7 +59,7 @@ class DocumentRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/DocumentRendererTest.php
+++ b/tests/unit/Block/Renderer/DocumentRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\Document;
 use League\CommonMark\Block\Renderer\DocumentRenderer;
 use League\CommonMark\Tests\Unit\FakeEmptyHtmlRenderer;
@@ -59,7 +60,7 @@ class DocumentRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/FencedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/FencedCodeRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\Document;
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Block\Renderer\FencedCodeRenderer;
@@ -94,7 +95,7 @@ class FencedCodeRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/FencedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/FencedCodeRendererTest.php
@@ -94,7 +94,7 @@ class FencedCodeRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/HeadingRendererTest.php
+++ b/tests/unit/Block/Renderer/HeadingRendererTest.php
@@ -69,7 +69,7 @@ class HeadingRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/HeadingRendererTest.php
+++ b/tests/unit/Block/Renderer/HeadingRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\Heading;
 use League\CommonMark\Block\Renderer\HeadingRenderer;
 use League\CommonMark\HtmlElement;
@@ -69,7 +70,7 @@ class HeadingRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
@@ -37,7 +37,7 @@ class HtmlBlockRendererTest extends TestCase
     public function testRender()
     {
         /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
-        $block = $this->getMockBuilder('League\CommonMark\Block\Element\HtmlBlock')
+        $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
         $block->expects($this->any())
@@ -59,7 +59,7 @@ class HtmlBlockRendererTest extends TestCase
         ]));
 
         /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
-        $block = $this->getMockBuilder('League\CommonMark\Block\Element\HtmlBlock')
+        $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
         $block->expects($this->any())
@@ -81,7 +81,7 @@ class HtmlBlockRendererTest extends TestCase
         ]));
 
         /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
-        $block = $this->getMockBuilder('League\CommonMark\Block\Element\HtmlBlock')
+        $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
         $block->expects($this->any())
@@ -103,7 +103,7 @@ class HtmlBlockRendererTest extends TestCase
         ]));
 
         /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
-        $block = $this->getMockBuilder('League\CommonMark\Block\Element\HtmlBlock')
+        $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
         $block->expects($this->any())
@@ -125,7 +125,7 @@ class HtmlBlockRendererTest extends TestCase
         ]));
 
         /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
-        $block = $this->getMockBuilder('League\CommonMark\Block\Element\HtmlBlock')
+        $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
         $block->expects($this->any())
@@ -145,7 +145,7 @@ class HtmlBlockRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\HtmlBlock;
 use League\CommonMark\Block\Renderer\HtmlBlockRenderer;
 use League\CommonMark\Environment;
@@ -145,7 +146,7 @@ class HtmlBlockRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
@@ -67,7 +67,7 @@ class IndentedCodeRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\Document;
 use League\CommonMark\Block\Element\IndentedCode;
 use League\CommonMark\Block\Renderer\IndentedCodeRenderer;
@@ -67,7 +68,7 @@ class IndentedCodeRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ListBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/ListBlockRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\ListBlock;
 use League\CommonMark\Block\Element\ListData;
 use League\CommonMark\Block\Renderer\ListBlockRenderer;
@@ -82,7 +83,7 @@ class ListBlockRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ListBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/ListBlockRendererTest.php
@@ -82,7 +82,7 @@ class ListBlockRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ListItemRendererTest.php
+++ b/tests/unit/Block/Renderer/ListItemRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\ListData;
 use League\CommonMark\Block\Element\ListItem;
 use League\CommonMark\Block\Renderer\ListItemRenderer;
@@ -51,7 +52,7 @@ class ListItemRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ListItemRendererTest.php
+++ b/tests/unit/Block/Renderer/ListItemRendererTest.php
@@ -51,7 +51,7 @@ class ListItemRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ParagraphRendererTest.php
+++ b/tests/unit/Block/Renderer/ParagraphRendererTest.php
@@ -51,7 +51,7 @@ class ParagraphRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ParagraphRendererTest.php
+++ b/tests/unit/Block/Renderer/ParagraphRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\Paragraph;
 use League\CommonMark\Block\Renderer\ParagraphRenderer;
 use League\CommonMark\HtmlElement;
@@ -51,7 +52,7 @@ class ParagraphRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
+++ b/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
@@ -48,7 +48,7 @@ class ThematicBreakRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Block\Element\AbstractBlock');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
+++ b/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Block\Renderer;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Block\Element\ThematicBreak;
 use League\CommonMark\Block\Renderer\ThematicBreakRenderer;
 use League\CommonMark\HtmlElement;
@@ -48,7 +49,7 @@ class ThematicBreakRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/CommonMarkConverterTest.php
+++ b/tests/unit/CommonMarkConverterTest.php
@@ -3,10 +3,12 @@
 namespace League\CommonMark\Tests\Unit;
 
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Converter;
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
 use League\CommonMark\EnvironmentInterface;
+use League\CommonMark\Extension\CommonMarkCoreExtension;
 use PHPUnit\Framework\TestCase;
 
 class CommonMarkConverterTest extends TestCase
@@ -19,7 +21,7 @@ class CommonMarkConverterTest extends TestCase
         $environment = $this->getEnvironmentFromConverter($converter);
 
         $this->assertCount(1, $environment->getExtensions());
-        $this->assertInstanceOf(\League\CommonMark\Extension\CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
+        $this->assertInstanceOf(CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
         $this->assertEquals($expectedEnvironment->getConfig(), $environment->getConfig());
     }
 
@@ -31,14 +33,14 @@ class CommonMarkConverterTest extends TestCase
         $environment = $this->getEnvironmentFromConverter($converter);
 
         $this->assertCount(1, $environment->getExtensions());
-        $this->assertInstanceOf(\League\CommonMark\Extension\CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
+        $this->assertInstanceOf(CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
         $this->assertArrayHasKey('foo', $environment->getConfig());
     }
 
     public function testEnvironmentAndConfigConstructor()
     {
         $config = ['foo' => 'bar'];
-        $mockEnvironment = $this->createMock(\League\CommonMark\ConfigurableEnvironmentInterface::class);
+        $mockEnvironment = $this->createMock(ConfigurableEnvironmentInterface::class);
         $mockEnvironment->expects($this->once())
             ->method('mergeConfig')
             ->with($config);

--- a/tests/unit/CommonMarkConverterTest.php
+++ b/tests/unit/CommonMarkConverterTest.php
@@ -19,7 +19,7 @@ class CommonMarkConverterTest extends TestCase
         $environment = $this->getEnvironmentFromConverter($converter);
 
         $this->assertCount(1, $environment->getExtensions());
-        $this->assertInstanceOf('League\CommonMark\Extension\CommonMarkCoreExtension', $environment->getExtensions()[0]);
+        $this->assertInstanceOf(\League\CommonMark\Extension\CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
         $this->assertEquals($expectedEnvironment->getConfig(), $environment->getConfig());
     }
 
@@ -31,14 +31,14 @@ class CommonMarkConverterTest extends TestCase
         $environment = $this->getEnvironmentFromConverter($converter);
 
         $this->assertCount(1, $environment->getExtensions());
-        $this->assertInstanceOf('League\CommonMark\Extension\CommonMarkCoreExtension', $environment->getExtensions()[0]);
+        $this->assertInstanceOf(\League\CommonMark\Extension\CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
         $this->assertArrayHasKey('foo', $environment->getConfig());
     }
 
     public function testEnvironmentAndConfigConstructor()
     {
         $config = ['foo' => 'bar'];
-        $mockEnvironment = $this->createMock('League\CommonMark\ConfigurableEnvironmentInterface');
+        $mockEnvironment = $this->createMock(\League\CommonMark\ConfigurableEnvironmentInterface::class);
         $mockEnvironment->expects($this->once())
             ->method('mergeConfig')
             ->with($config);

--- a/tests/unit/ConverterTest.php
+++ b/tests/unit/ConverterTest.php
@@ -14,7 +14,7 @@ class ConverterTest extends TestCase
         $expectedHtml = '<strong>Strong</strong>';
 
         /** @var Converter|PHPUnit_Framework_MockObject_MockObject $converter */
-        $converter = $this->getMockBuilder(\League\CommonMark\Converter::class)
+        $converter = $this->getMockBuilder(Converter::class)
             ->disableOriginalConstructor()
             ->setMethods(['convertToHtml'])
             ->getMock();

--- a/tests/unit/ConverterTest.php
+++ b/tests/unit/ConverterTest.php
@@ -14,7 +14,7 @@ class ConverterTest extends TestCase
         $expectedHtml = '<strong>Strong</strong>';
 
         /** @var Converter|PHPUnit_Framework_MockObject_MockObject $converter */
-        $converter = $this->getMockBuilder('League\CommonMark\Converter')
+        $converter = $this->getMockBuilder(\League\CommonMark\Converter::class)
             ->disableOriginalConstructor()
             ->setMethods(['convertToHtml'])
             ->getMock();

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit;
 
+use League\CommonMark\Block\Parser as BlockParser;
 use League\CommonMark\Block\Parser\BlockParserInterface;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\DocumentProcessorInterface;
@@ -140,7 +141,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->createMock(\League\CommonMark\Block\Parser\BlockParserInterface::class);
+        $parser = $this->createMock(BlockParser\BlockParserInterface::class);
         $environment->addBlockParser($parser);
 
         $this->assertContains($parser, $environment->getBlockParsers());
@@ -156,7 +157,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getBlockParsers();
 
-        $parser = $this->createMock(\League\CommonMark\Block\Parser\BlockParserInterface::class);
+        $parser = $this->createMock(BlockParser\BlockParserInterface::class);
         $environment->addBlockParser($parser);
     }
 
@@ -164,7 +165,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $renderer = $this->createMock(\League\CommonMark\Block\Renderer\BlockRendererInterface::class);
+        $renderer = $this->createMock(BlockRendererInterface::class);
         $environment->addBlockRenderer('MyClass', $renderer);
 
         $this->assertContains($renderer, $environment->getBlockRenderersForClass('MyClass'));
@@ -180,7 +181,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getBlockRenderersForClass('MyClass');
 
-        $renderer = $this->createMock(\League\CommonMark\Block\Renderer\BlockRendererInterface::class);
+        $renderer = $this->createMock(BlockRendererInterface::class);
         $environment->addBlockRenderer('MyClass', $renderer);
     }
 
@@ -188,7 +189,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->createMock(\League\CommonMark\Inline\Parser\InlineParserInterface::class);
+        $parser = $this->createMock(InlineParserInterface::class);
         $parser->expects($this->any())
             ->method('getCharacters')
             ->will($this->returnValue(['/']));
@@ -209,7 +210,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineParsersForCharacter('');
 
-        $parser = $this->createMock(\League\CommonMark\Inline\Parser\InlineParserInterface::class);
+        $parser = $this->createMock(InlineParserInterface::class);
         $environment->addInlineParser($parser);
     }
 
@@ -217,7 +218,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->createMock(\League\CommonMark\Inline\Parser\InlineParserInterface::class);
+        $parser = $this->createMock(InlineParserInterface::class);
         $parser->expects($this->any())
             ->method('getName')
             ->will($this->returnValue('test'));
@@ -241,7 +242,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $processor = $this->createMock(\League\CommonMark\Inline\Processor\InlineProcessorInterface::class);
+        $processor = $this->createMock(InlineProcessorInterface::class);
         $environment->addInlineProcessor($processor);
 
         $this->assertContains($processor, $environment->getInlineProcessors());
@@ -257,7 +258,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineProcessors();
 
-        $processor = $this->createMock(\League\CommonMark\Inline\Processor\InlineProcessorInterface::class);
+        $processor = $this->createMock(InlineProcessorInterface::class);
         $environment->addInlineProcessor($processor);
     }
 
@@ -265,7 +266,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $renderer = $this->createMock(\League\CommonMark\Inline\Renderer\InlineRendererInterface::class);
+        $renderer = $this->createMock(InlineRendererInterface::class);
         $environment->addInlineRenderer('MyClass', $renderer);
 
         $this->assertContains($renderer, $environment->getInlineRenderersForClass('MyClass'));
@@ -281,7 +282,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineRenderersForClass('MyClass');
 
-        $renderer = $this->createMock(\League\CommonMark\Inline\Renderer\InlineRendererInterface::class);
+        $renderer = $this->createMock(InlineRendererInterface::class);
         $environment->addInlineRenderer('MyClass', $renderer);
     }
 
@@ -307,7 +308,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $extension = $this->createMock(\League\CommonMark\Extension\ExtensionInterface::class);
+        $extension = $this->createMock(ExtensionInterface::class);
         $environment->addExtension($extension);
 
         $this->assertContains($extension, $environment->getExtensions());
@@ -323,7 +324,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineRenderersForClass('MyClass');
 
-        $extension = $this->createMock(\League\CommonMark\Extension\ExtensionInterface::class);
+        $extension = $this->createMock(ExtensionInterface::class);
         $environment->addExtension($extension);
     }
 
@@ -331,7 +332,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $processor = $this->createMock(\League\CommonMark\DocumentProcessorInterface::class);
+        $processor = $this->createMock(DocumentProcessorInterface::class);
         $environment->addDocumentProcessor($processor);
 
         $this->assertContains($processor, $environment->getDocumentProcessors());
@@ -347,7 +348,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getDocumentProcessors();
 
-        $processor = $this->createMock(\League\CommonMark\DocumentProcessorInterface::class);
+        $processor = $this->createMock(DocumentProcessorInterface::class);
         $environment->addDocumentProcessor($processor);
     }
 

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -140,7 +140,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->createMock('League\CommonMark\Block\Parser\BlockParserInterface');
+        $parser = $this->createMock(\League\CommonMark\Block\Parser\BlockParserInterface::class);
         $environment->addBlockParser($parser);
 
         $this->assertContains($parser, $environment->getBlockParsers());
@@ -156,7 +156,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getBlockParsers();
 
-        $parser = $this->createMock('League\CommonMark\Block\Parser\BlockParserInterface');
+        $parser = $this->createMock(\League\CommonMark\Block\Parser\BlockParserInterface::class);
         $environment->addBlockParser($parser);
     }
 
@@ -164,7 +164,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $renderer = $this->createMock('League\CommonMark\Block\Renderer\BlockRendererInterface');
+        $renderer = $this->createMock(\League\CommonMark\Block\Renderer\BlockRendererInterface::class);
         $environment->addBlockRenderer('MyClass', $renderer);
 
         $this->assertContains($renderer, $environment->getBlockRenderersForClass('MyClass'));
@@ -180,7 +180,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getBlockRenderersForClass('MyClass');
 
-        $renderer = $this->createMock('League\CommonMark\Block\Renderer\BlockRendererInterface');
+        $renderer = $this->createMock(\League\CommonMark\Block\Renderer\BlockRendererInterface::class);
         $environment->addBlockRenderer('MyClass', $renderer);
     }
 
@@ -188,7 +188,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->createMock('League\CommonMark\Inline\Parser\InlineParserInterface');
+        $parser = $this->createMock(\League\CommonMark\Inline\Parser\InlineParserInterface::class);
         $parser->expects($this->any())
             ->method('getCharacters')
             ->will($this->returnValue(['/']));
@@ -209,7 +209,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineParsersForCharacter('');
 
-        $parser = $this->createMock('League\CommonMark\Inline\Parser\InlineParserInterface');
+        $parser = $this->createMock(\League\CommonMark\Inline\Parser\InlineParserInterface::class);
         $environment->addInlineParser($parser);
     }
 
@@ -217,7 +217,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->createMock('League\CommonMark\Inline\Parser\InlineParserInterface');
+        $parser = $this->createMock(\League\CommonMark\Inline\Parser\InlineParserInterface::class);
         $parser->expects($this->any())
             ->method('getName')
             ->will($this->returnValue('test'));
@@ -241,7 +241,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $processor = $this->createMock('League\CommonMark\Inline\Processor\InlineProcessorInterface');
+        $processor = $this->createMock(\League\CommonMark\Inline\Processor\InlineProcessorInterface::class);
         $environment->addInlineProcessor($processor);
 
         $this->assertContains($processor, $environment->getInlineProcessors());
@@ -257,7 +257,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineProcessors();
 
-        $processor = $this->createMock('League\CommonMark\Inline\Processor\InlineProcessorInterface');
+        $processor = $this->createMock(\League\CommonMark\Inline\Processor\InlineProcessorInterface::class);
         $environment->addInlineProcessor($processor);
     }
 
@@ -265,7 +265,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $renderer = $this->createMock('League\CommonMark\Inline\Renderer\InlineRendererInterface');
+        $renderer = $this->createMock(\League\CommonMark\Inline\Renderer\InlineRendererInterface::class);
         $environment->addInlineRenderer('MyClass', $renderer);
 
         $this->assertContains($renderer, $environment->getInlineRenderersForClass('MyClass'));
@@ -281,7 +281,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineRenderersForClass('MyClass');
 
-        $renderer = $this->createMock('League\CommonMark\Inline\Renderer\InlineRendererInterface');
+        $renderer = $this->createMock(\League\CommonMark\Inline\Renderer\InlineRendererInterface::class);
         $environment->addInlineRenderer('MyClass', $renderer);
     }
 
@@ -307,7 +307,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $extension = $this->createMock('League\CommonMark\Extension\ExtensionInterface');
+        $extension = $this->createMock(\League\CommonMark\Extension\ExtensionInterface::class);
         $environment->addExtension($extension);
 
         $this->assertContains($extension, $environment->getExtensions());
@@ -323,7 +323,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getInlineRenderersForClass('MyClass');
 
-        $extension = $this->createMock('League\CommonMark\Extension\ExtensionInterface');
+        $extension = $this->createMock(\League\CommonMark\Extension\ExtensionInterface::class);
         $environment->addExtension($extension);
     }
 
@@ -331,7 +331,7 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $processor = $this->createMock('League\CommonMark\DocumentProcessorInterface');
+        $processor = $this->createMock(\League\CommonMark\DocumentProcessorInterface::class);
         $environment->addDocumentProcessor($processor);
 
         $this->assertContains($processor, $environment->getDocumentProcessors());
@@ -347,7 +347,7 @@ class EnvironmentTest extends TestCase
         // This triggers the initialization
         $environment->getDocumentProcessors();
 
-        $processor = $this->createMock('League\CommonMark\DocumentProcessorInterface');
+        $processor = $this->createMock(\League\CommonMark\DocumentProcessorInterface::class);
         $environment->addDocumentProcessor($processor);
     }
 

--- a/tests/unit/Inline/Element/AbstractWebResourceTest.php
+++ b/tests/unit/Inline/Element/AbstractWebResourceTest.php
@@ -15,7 +15,7 @@ class AbstractWebResourceTest extends TestCase
         $url = 'https://www.example.com/foo';
 
         /** @var AbstractWebResource $element */
-        $element = $this->getMockBuilder('League\\CommonMark\\Inline\\Element\\AbstractWebResource')
+        $element = $this->getMockBuilder(\League\CommonMark\Inline\Element\AbstractWebResource::class)
             ->setConstructorArgs([$url])
             ->getMockForAbstractClass();
 
@@ -31,7 +31,7 @@ class AbstractWebResourceTest extends TestCase
         $url2 = 'https://www.example.com/bar';
 
         /** @var AbstractWebResource $element */
-        $element = $this->getMockBuilder('League\\CommonMark\\Inline\\Element\\AbstractWebResource')
+        $element = $this->getMockBuilder(\League\CommonMark\Inline\Element\AbstractWebResource::class)
             ->setConstructorArgs([$url1])
             ->getMockForAbstractClass();
 

--- a/tests/unit/Inline/Element/AbstractWebResourceTest.php
+++ b/tests/unit/Inline/Element/AbstractWebResourceTest.php
@@ -15,7 +15,7 @@ class AbstractWebResourceTest extends TestCase
         $url = 'https://www.example.com/foo';
 
         /** @var AbstractWebResource $element */
-        $element = $this->getMockBuilder(\League\CommonMark\Inline\Element\AbstractWebResource::class)
+        $element = $this->getMockBuilder(AbstractWebResource::class)
             ->setConstructorArgs([$url])
             ->getMockForAbstractClass();
 
@@ -31,7 +31,7 @@ class AbstractWebResourceTest extends TestCase
         $url2 = 'https://www.example.com/bar';
 
         /** @var AbstractWebResource $element */
-        $element = $this->getMockBuilder(\League\CommonMark\Inline\Element\AbstractWebResource::class)
+        $element = $this->getMockBuilder(AbstractWebResource::class)
             ->setConstructorArgs([$url1])
             ->getMockForAbstractClass();
 

--- a/tests/unit/Inline/Parser/BacktickParserTest.php
+++ b/tests/unit/Inline/Parser/BacktickParserTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Inline\Parser;
 
+use League\CommonMark\Block\Element as BlockElement;
 use League\CommonMark\Inline\Element\Code;
 use League\CommonMark\Inline\Parser\BacktickParser;
 use League\CommonMark\InlineParserContext;
@@ -30,7 +31,7 @@ class BacktickParserTest extends TestCase
      */
     public function testParse($string, $expectedContents)
     {
-        $nodeStub = $this->createMock(\League\CommonMark\Block\Element\AbstractBlock::class);
+        $nodeStub = $this->createMock(BlockElement\AbstractBlock::class);
         $nodeStub->expects($this->any())->method('getStringContent')->willReturn($string);
         $nodeStub
             ->expects($this->once())

--- a/tests/unit/Inline/Parser/BacktickParserTest.php
+++ b/tests/unit/Inline/Parser/BacktickParserTest.php
@@ -30,7 +30,7 @@ class BacktickParserTest extends TestCase
      */
     public function testParse($string, $expectedContents)
     {
-        $nodeStub = $this->createMock('League\CommonMark\Block\Element\AbstractBlock');
+        $nodeStub = $this->createMock(\League\CommonMark\Block\Element\AbstractBlock::class);
         $nodeStub->expects($this->any())->method('getStringContent')->willReturn($string);
         $nodeStub
             ->expects($this->once())

--- a/tests/unit/Inline/Renderer/CodeRendererTest.php
+++ b/tests/unit/Inline/Renderer/CodeRendererTest.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Code;
 use League\CommonMark\Inline\Renderer\CodeRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -51,7 +52,7 @@ class CodeRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/CodeRendererTest.php
+++ b/tests/unit/Inline/Renderer/CodeRendererTest.php
@@ -51,7 +51,7 @@ class CodeRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/EmphasisRendererTest.php
+++ b/tests/unit/Inline/Renderer/EmphasisRendererTest.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Emphasis;
 use League\CommonMark\Inline\Renderer\EmphasisRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -51,7 +52,7 @@ class EmphasisRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/EmphasisRendererTest.php
+++ b/tests/unit/Inline/Renderer/EmphasisRendererTest.php
@@ -51,7 +51,7 @@ class EmphasisRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
 use League\CommonMark\Environment;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\HtmlInline;
 use League\CommonMark\Inline\Renderer\HtmlInlineRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -110,7 +111,7 @@ class HtmlInlineRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
@@ -110,7 +110,7 @@ class HtmlInlineRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/ImageRendererTest.php
+++ b/tests/unit/Inline/Renderer/ImageRendererTest.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Image;
 use League\CommonMark\Inline\Renderer\ImageRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -116,7 +117,7 @@ class ImageRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/ImageRendererTest.php
+++ b/tests/unit/Inline/Renderer/ImageRendererTest.php
@@ -116,7 +116,7 @@ class ImageRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/LinkRendererTest.php
+++ b/tests/unit/Inline/Renderer/LinkRendererTest.php
@@ -114,7 +114,7 @@ class LinkRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/LinkRendererTest.php
+++ b/tests/unit/Inline/Renderer/LinkRendererTest.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Renderer\LinkRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -114,7 +115,7 @@ class LinkRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/NewlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/NewlineRendererTest.php
@@ -59,7 +59,7 @@ class NewlineRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/NewlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/NewlineRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Newline;
 use League\CommonMark\Inline\Renderer\NewlineRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -59,7 +60,7 @@ class NewlineRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/StrongRendererTest.php
+++ b/tests/unit/Inline/Renderer/StrongRendererTest.php
@@ -15,6 +15,7 @@
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Strong;
 use League\CommonMark\Inline\Renderer\StrongRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -51,7 +52,7 @@ class StrongRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/StrongRendererTest.php
+++ b/tests/unit/Inline/Renderer/StrongRendererTest.php
@@ -51,7 +51,7 @@ class StrongRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/TextRendererTest.php
+++ b/tests/unit/Inline/Renderer/TextRendererTest.php
@@ -47,7 +47,7 @@ class TextRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass('League\CommonMark\Inline\Element\AbstractInline');
+        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);

--- a/tests/unit/Inline/Renderer/TextRendererTest.php
+++ b/tests/unit/Inline/Renderer/TextRendererTest.php
@@ -14,6 +14,7 @@
 
 namespace League\CommonMark\Tests\Unit\Inline\Renderer;
 
+use League\CommonMark\Inline\Element as InlineElement;
 use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Inline\Renderer\TextRenderer;
 use League\CommonMark\Tests\Unit\FakeHtmlRenderer;
@@ -47,7 +48,7 @@ class TextRendererTest extends TestCase
      */
     public function testRenderWithInvalidType()
     {
-        $inline = $this->getMockForAbstractClass(\League\CommonMark\Inline\Element\AbstractInline::class);
+        $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
         $this->renderer->render($inline, $fakeRenderer);


### PR DESCRIPTION
This project minimum php requirement is 5.6, so it's time to use `::class` constant.

cc @colinodell