### PR TITLE
Standardize delimiter processing node types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+ - `DelimiterProcessorInterface::process()` will accept any type of `AbstractStringContainer` now, not just `Text` nodes
+ - The `Delimiter` constructor, `getInlineNode()`, and `setInlineNode()` no longer accept generic `Node` elements - only `AbstractStringContainer`s
+
 ## [1.0.0-beta1] - 2019-05-26
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,12 @@
 
 **Note:** This file has been deprecated.  Future upgrade instructions can be found on our website: <https://commonmark.thephpleague.com/releases>
 
+## UNRELEASED
+
+### Delimiter Processing
+
+We've standardized the new delimiter processing to work with `AbstractStringContainer` nodes.  Previously in 1.0.0-beta1, some parts (incorrectly) accepted any type of `Node`, while others forced you to use `Text` elements instead.
+
 ## 1.0.0-beta1
 
 ### Text Encoding

--- a/src/Delimiter/Delimiter.php
+++ b/src/Delimiter/Delimiter.php
@@ -14,7 +14,7 @@
 
 namespace League\CommonMark\Delimiter;
 
-use League\CommonMark\Node\Node;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 
 class Delimiter
 {
@@ -27,7 +27,7 @@ class Delimiter
     /** @var int */
     protected $origDelims;
 
-    /** @var Node */
+    /** @var AbstractStringContainer */
     protected $inlineNode;
 
     /** @var Delimiter|null */
@@ -49,14 +49,14 @@ class Delimiter
     protected $index;
 
     /**
-     * @param string   $char
-     * @param int      $numDelims
-     * @param Node     $node
-     * @param bool     $canOpen
-     * @param bool     $canClose
-     * @param int|null $index
+     * @param string                  $char
+     * @param int                     $numDelims
+     * @param AbstractStringContainer $node
+     * @param bool                    $canOpen
+     * @param bool                    $canClose
+     * @param int|null                $index
      */
-    public function __construct(string $char, int $numDelims, Node $node, bool $canOpen, bool $canClose, ?int $index = null)
+    public function __construct(string $char, int $numDelims, AbstractStringContainer $node, bool $canOpen, bool $canClose, ?int $index = null)
     {
         $this->char = $char;
         $this->numDelims = $numDelims;
@@ -217,19 +217,19 @@ class Delimiter
     }
 
     /**
-     * @return Node
+     * @return AbstractStringContainer
      */
-    public function getInlineNode(): Node
+    public function getInlineNode(): AbstractStringContainer
     {
         return $this->inlineNode;
     }
 
     /**
-     * @param Node $node
+     * @param AbstractStringContainer $node
      *
      * @return $this
      */
-    public function setInlineNode(Node $node)
+    public function setInlineNode(AbstractStringContainer $node)
     {
         $this->inlineNode = $node;
 

--- a/src/Delimiter/DelimiterStack.php
+++ b/src/Delimiter/DelimiterStack.php
@@ -19,7 +19,6 @@ namespace League\CommonMark\Delimiter;
 
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorCollection;
 use League\CommonMark\Inline\AdjacentTextMerger;
-use League\CommonMark\Inline\Element\Text;
 
 class DelimiterStack
 {
@@ -189,9 +188,7 @@ class DelimiterStack
                 continue;
             }
 
-            /** @var Text $openerNode */
             $openerNode = $opener->getInlineNode();
-            /** @var Text $closerNode */
             $closerNode = $closer->getInlineNode();
 
             // Remove number of used delimiters from stack and inline nodes.

--- a/src/Delimiter/Processor/DelimiterProcessorInterface.php
+++ b/src/Delimiter/Processor/DelimiterProcessorInterface.php
@@ -18,7 +18,7 @@
 namespace League\CommonMark\Delimiter\Processor;
 
 use League\CommonMark\Delimiter\Delimiter;
-use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 
 /**
  * Interface for a delimiter processor
@@ -76,9 +76,9 @@ interface DelimiterProcessorInterface
      * Note that removal of the delimiter from the delimiter nodes and detaching
      * them is done by the caller.
      *
-     * @param Text $opener       The Text node that contained the opening delimiter
-     * @param Text $closer       The text node that contained the closing delimiter
-     * @param int  $delimiterUse The number of delimiters that were used
+     * @param AbstractStringContainer $opener       The node that contained the opening delimiter
+     * @param AbstractStringContainer $closer       The node that contained the closing delimiter
+     * @param int                     $delimiterUse The number of delimiters that were used
      */
-    public function process(Text $opener, Text $closer, int $delimiterUse);
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse);
 }

--- a/src/Delimiter/Processor/EmphasisDelimiterProcessor.php
+++ b/src/Delimiter/Processor/EmphasisDelimiterProcessor.php
@@ -18,9 +18,9 @@
 namespace League\CommonMark\Delimiter\Processor;
 
 use League\CommonMark\Delimiter\Delimiter;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 use League\CommonMark\Inline\Element\Emphasis;
 use League\CommonMark\Inline\Element\Strong;
-use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Util\ConfigurationAwareInterface;
 use League\CommonMark\Util\ConfigurationInterface;
 
@@ -93,7 +93,7 @@ final class EmphasisDelimiterProcessor implements DelimiterProcessorInterface, C
     /**
      * {@inheritdoc}
      */
-    public function process(Text $opener, Text $closer, int $delimiterUse)
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
     {
         if ($delimiterUse === 1) {
             $emphasis = new Emphasis();

--- a/src/Delimiter/Processor/StaggeredDelimiterProcessor.php
+++ b/src/Delimiter/Processor/StaggeredDelimiterProcessor.php
@@ -15,7 +15,7 @@
 namespace League\CommonMark\Delimiter\Processor;
 
 use League\CommonMark\Delimiter\Delimiter;
-use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 
 /**
  * An implementation of DelimiterProcessorInterface that dispatches all calls to two or more other DelimiterProcessors
@@ -92,7 +92,7 @@ final class StaggeredDelimiterProcessor implements DelimiterProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function process(Text $opener, Text $closer, int $delimiterUse)
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
     {
         return $this->findProcessor($delimiterUse)->process($opener, $closer, $delimiterUse);
     }

--- a/tests/functional/Delimiter/FakeDelimiterProcessor.php
+++ b/tests/functional/Delimiter/FakeDelimiterProcessor.php
@@ -16,7 +16,7 @@ namespace League\CommonMark\Tests\Functional\Delimiter;
 
 use League\CommonMark\Delimiter\Delimiter;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
-use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 
 final class FakeDelimiterProcessor implements DelimiterProcessorInterface
 {
@@ -65,7 +65,7 @@ final class FakeDelimiterProcessor implements DelimiterProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function process(Text $opener, Text $closer, int $delimiterUse)
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
     {
     }
 }

--- a/tests/functional/Delimiter/TestDelimiterProcessor.php
+++ b/tests/functional/Delimiter/TestDelimiterProcessor.php
@@ -16,6 +16,7 @@ namespace League\CommonMark\Tests\Functional\Delimiter;
 
 use League\CommonMark\Delimiter\Delimiter;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 use League\CommonMark\Inline\Element\Text;
 
 final class TestDelimiterProcessor implements DelimiterProcessorInterface
@@ -64,7 +65,7 @@ final class TestDelimiterProcessor implements DelimiterProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function process(Text $opener, Text $closer, int $delimiterUse)
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
     {
         $opener->insertAfter(new Text('(' . $this->length . ')'));
         $closer->insertBefore(new Text('(/' . $this->length . ')'));

--- a/tests/functional/Delimiter/UppercaseDelimiterProcessor.php
+++ b/tests/functional/Delimiter/UppercaseDelimiterProcessor.php
@@ -16,7 +16,7 @@ namespace League\CommonMark\Tests\Functional\Delimiter;
 
 use League\CommonMark\Delimiter\Delimiter;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
-use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 
 final class UppercaseDelimiterProcessor implements DelimiterProcessorInterface
 {
@@ -55,7 +55,7 @@ final class UppercaseDelimiterProcessor implements DelimiterProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function process(Text $opener, Text $closer, int $delimiterUse)
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
     {
         $upperCase = new UppercaseText();
         $tmp = $opener->next();

--- a/tests/unit/Delimiter/DelimiterTest.php
+++ b/tests/unit/Delimiter/DelimiterTest.php
@@ -12,14 +12,14 @@
 namespace League\CommonMark\Tests\Unit\Delimiter;
 
 use League\CommonMark\Delimiter\Delimiter;
-use League\CommonMark\Node\Node;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 use PHPUnit\Framework\TestCase;
 
 class DelimiterTest extends TestCase
 {
     public function testConstructorAndGetters()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
 
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
         $this->assertSame('*', $delimiter->getChar());
@@ -42,7 +42,7 @@ class DelimiterTest extends TestCase
 
     public function testSetCanClose()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setCanClose(true);
@@ -51,7 +51,7 @@ class DelimiterTest extends TestCase
 
     public function testSetCanOpen()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setCanOpen(false);
@@ -60,7 +60,7 @@ class DelimiterTest extends TestCase
 
     public function testSetActive()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setActive(true);
@@ -72,7 +72,7 @@ class DelimiterTest extends TestCase
 
     public function testSetChar()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setChar('_');
@@ -81,7 +81,7 @@ class DelimiterTest extends TestCase
 
     public function testSetIndex()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setIndex(7);
@@ -93,7 +93,7 @@ class DelimiterTest extends TestCase
 
     public function testSetNext()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setNext($delimiter);
@@ -105,7 +105,7 @@ class DelimiterTest extends TestCase
 
     public function testSetNumDelims()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setNumDelims(3);
@@ -115,10 +115,10 @@ class DelimiterTest extends TestCase
 
     public function testSetInlineNode()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
-        $node2 = $this->createMock(Node::class);
+        $node2 = $this->createMock(AbstractStringContainer::class);
 
         $delimiter->setInlineNode($node2);
         $this->assertSame($node2, $delimiter->getInlineNode());
@@ -126,7 +126,7 @@ class DelimiterTest extends TestCase
 
     public function testSetPrevious()
     {
-        $node = $this->createMock(Node::class);
+        $node = $this->createMock(AbstractStringContainer::class);
         $delimiter = new Delimiter('*', 2, $node, true, false, null);
 
         $delimiter->setPrevious($delimiter);


### PR DESCRIPTION
This fixes a couple of type issues found in 1.0.0-beta1