### PR TITLE
Fix max_nesting_level example value type on docs/security page

### DIFF
--- a/docs/0.18/security.md
+++ b/docs/0.18/security.md
@@ -60,7 +60,7 @@ use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
 
-$converter = new CommonMarkConverter(['max_nesting_level' => '5']);
+$converter = new CommonMarkConverter(['max_nesting_level' => 5]);
 echo $converter->convertToHtml($markdown);
 
 // <blockquote>

--- a/docs/0.19/security.md
+++ b/docs/0.19/security.md
@@ -61,7 +61,7 @@ use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
 
-$converter = new CommonMarkConverter(['max_nesting_level' => '5']);
+$converter = new CommonMarkConverter(['max_nesting_level' => 5]);
 echo $converter->convertToHtml($markdown);
 
 // <blockquote>

--- a/docs/1.0/security.md
+++ b/docs/1.0/security.md
@@ -62,7 +62,7 @@ use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
 
-$converter = new CommonMarkConverter(['max_nesting_level' => '5']);
+$converter = new CommonMarkConverter(['max_nesting_level' => 5]);
 echo $converter->convertToHtml($markdown);
 
 // <blockquote>


### PR DESCRIPTION
max_nesting_level is either INF (default, float), or an integer, it
doesn't make sense to use a string in the documentation.


------------------

Hello,

Spotted this tiny error in the documentation ;)

Cheers,
~Nico