### PR TITLE
Performance optmisations

### DIFF
--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -24,7 +24,7 @@ class CommonMarkConverter extends Converter
      *
      * This might be a typical `x.y.z` version, or `x.y-dev`.
      */
-    const VERSION = '1.1-dev';
+    public const VERSION = '1.1-dev';
 
     /** @var EnvironmentInterface */
     protected $environment;

--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 /*
  * This file is part of the league/commonmark package.
@@ -222,7 +224,7 @@ class Cursor
     /**
      * Move the cursor forwards
      *
-     * @param int $characters Number of characters to advance by
+     * @param int  $characters       Number of characters to advance by
      * @param bool $advanceByColumns Whether to advance by columns instead of spaces
      */
     public function advanceBy(int $characters, bool $advanceByColumns = false)

--- a/src/Inline/Parser/CloseBracketParser.php
+++ b/src/Inline/Parser/CloseBracketParser.php
@@ -116,10 +116,10 @@ final class CloseBracketParser implements InlineParserInterface, EnvironmentAwar
     }
 
     /**
-     * @param Cursor $cursor
+     * @param Cursor                $cursor
      * @param ReferenceMapInterface $referenceMap
-     * @param DelimiterInterface $opener
-     * @param int $startPos
+     * @param DelimiterInterface    $opener
+     * @param int                   $startPos
      *
      * @return array|bool
      */
@@ -183,10 +183,10 @@ final class CloseBracketParser implements InlineParserInterface, EnvironmentAwar
     }
 
     /**
-     * @param Cursor $cursor
+     * @param Cursor                $cursor
      * @param ReferenceMapInterface $referenceMap
-     * @param DelimiterInterface $opener
-     * @param int $startPos
+     * @param DelimiterInterface    $opener
+     * @param int                   $startPos
      *
      * @return ReferenceInterface|null
      */
@@ -228,7 +228,7 @@ final class CloseBracketParser implements InlineParserInterface, EnvironmentAwar
     /**
      * @param string $url
      * @param string $title
-     * @param bool $isImage
+     * @param bool   $isImage
      *
      * @return AbstractWebResource
      */

--- a/src/InlineParserEngine.php
+++ b/src/InlineParserEngine.php
@@ -22,6 +22,7 @@ use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Reference\ReferenceMapInterface;
 use League\CommonMark\Util\RegexHelper;
+use function preg_match;
 
 /**
  * @internal
@@ -160,10 +161,10 @@ final class InlineParserEngine
      */
     private static function determineCanOpenOrClose(string $charBefore, string $charAfter, string $character, DelimiterProcessorInterface $delimiterProcessor)
     {
-        $afterIsWhitespace = \preg_match(RegexHelper::REGEX_UNICODE_WHITESPACE_CHAR, $charAfter);
-        $afterIsPunctuation = \preg_match(RegexHelper::REGEX_PUNCTUATION, $charAfter);
-        $beforeIsWhitespace = \preg_match(RegexHelper::REGEX_UNICODE_WHITESPACE_CHAR, $charBefore);
-        $beforeIsPunctuation = \preg_match(RegexHelper::REGEX_PUNCTUATION, $charBefore);
+        $afterIsWhitespace = preg_match(RegexHelper::REGEX_UNICODE_WHITESPACE_CHAR, $charAfter);
+        $afterIsPunctuation = preg_match(RegexHelper::REGEX_PUNCTUATION, $charAfter);
+        $beforeIsWhitespace = preg_match(RegexHelper::REGEX_UNICODE_WHITESPACE_CHAR, $charBefore);
+        $beforeIsPunctuation = preg_match(RegexHelper::REGEX_PUNCTUATION, $charBefore);
 
         $leftFlanking = !$afterIsWhitespace && (!$afterIsPunctuation || $beforeIsWhitespace || $beforeIsPunctuation);
         $rightFlanking = !$beforeIsWhitespace && (!$beforeIsPunctuation || $afterIsWhitespace || $afterIsPunctuation);

--- a/src/Reference/ReferenceParser.php
+++ b/src/Reference/ReferenceParser.php
@@ -16,6 +16,7 @@ namespace League\CommonMark\Reference;
 
 use League\CommonMark\Cursor;
 use League\CommonMark\Util\LinkParserHelper;
+use function preg_match;
 
 final class ReferenceParser
 {
@@ -54,7 +55,7 @@ final class ReferenceParser
         // We need to trim the opening and closing brackets from the previously-matched text
         $label = \substr($cursor->getPreviousText(), 1, -1);
 
-        if (\preg_match('/[^\s]/', $label) === 0) {
+        if (preg_match('/[^\s]/', $label) === 0) {
             $cursor->restoreState($initialState);
 
             return false;

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -14,9 +14,9 @@
 
 namespace League\CommonMark\Util;
 
+use function count;
 use InvalidArgumentException;
 use League\CommonMark\Block\Element\HtmlBlock;
-use function count;
 use function mb_strcut;
 use function mb_strlen;
 use function mb_substr;

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -14,7 +14,18 @@
 
 namespace League\CommonMark\Util;
 
+use InvalidArgumentException;
 use League\CommonMark\Block\Element\HtmlBlock;
+use function count;
+use function mb_strcut;
+use function mb_strlen;
+use function mb_substr;
+use function preg_match;
+use function preg_match_all;
+use function preg_replace;
+use function preg_replace_callback;
+use function reset;
+use function substr;
 
 /**
  * Provides regular expressions and utilities for parsing Markdown
@@ -22,49 +33,49 @@ use League\CommonMark\Block\Element\HtmlBlock;
 final class RegexHelper
 {
     // Partial regular expressions (wrap with `/` on each side before use)
-    const PARTIAL_ENTITY = '&(?:#x[a-f0-9]{1,6}|#[0-9]{1,7}|[a-z][a-z0-9]{1,31});';
-    const PARTIAL_ESCAPABLE = '[!"#$%&\'()*+,.\/:;<=>?@[\\\\\]^_`{|}~-]';
-    const PARTIAL_ESCAPED_CHAR = '\\\\' . self::PARTIAL_ESCAPABLE;
-    const PARTIAL_IN_DOUBLE_QUOTES = '"(' . self::PARTIAL_ESCAPED_CHAR . '|[^"\x00])*"';
-    const PARTIAL_IN_SINGLE_QUOTES = '\'(' . self::PARTIAL_ESCAPED_CHAR . '|[^\'\x00])*\'';
-    const PARTIAL_IN_PARENS = '\\((' . self::PARTIAL_ESCAPED_CHAR . '|[^)\x00])*\\)';
-    const PARTIAL_REG_CHAR = '[^\\\\()\x00-\x20]';
-    const PARTIAL_IN_PARENS_NOSP = '\((' . self::PARTIAL_REG_CHAR . '|' . self::PARTIAL_ESCAPED_CHAR . '|\\\\)*\)';
-    const PARTIAL_TAGNAME = '[A-Za-z][A-Za-z0-9-]*';
-    const PARTIAL_BLOCKTAGNAME = '(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|title|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)';
-    const PARTIAL_ATTRIBUTENAME = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
-    const PARTIAL_UNQUOTEDVALUE = '[^"\'=<>`\x00-\x20]+';
-    const PARTIAL_SINGLEQUOTEDVALUE = '\'[^\']*\'';
-    const PARTIAL_DOUBLEQUOTEDVALUE = '"[^"]*"';
-    const PARTIAL_ATTRIBUTEVALUE = '(?:' . self::PARTIAL_UNQUOTEDVALUE . '|' . self::PARTIAL_SINGLEQUOTEDVALUE . '|' . self::PARTIAL_DOUBLEQUOTEDVALUE . ')';
-    const PARTIAL_ATTRIBUTEVALUESPEC = '(?:' . '\s*=' . '\s*' . self::PARTIAL_ATTRIBUTEVALUE . ')';
-    const PARTIAL_ATTRIBUTE = '(?:' . '\s+' . self::PARTIAL_ATTRIBUTENAME . self::PARTIAL_ATTRIBUTEVALUESPEC . '?)';
-    const PARTIAL_OPENTAG = '<' . self::PARTIAL_TAGNAME . self::PARTIAL_ATTRIBUTE . '*' . '\s*\/?>';
-    const PARTIAL_CLOSETAG = '<\/' . self::PARTIAL_TAGNAME . '\s*[>]';
-    const PARTIAL_OPENBLOCKTAG = '<' . self::PARTIAL_BLOCKTAGNAME . self::PARTIAL_ATTRIBUTE . '*' . '\s*\/?>';
-    const PARTIAL_CLOSEBLOCKTAG = '<\/' . self::PARTIAL_BLOCKTAGNAME . '\s*[>]';
-    const PARTIAL_HTMLCOMMENT = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->';
-    const PARTIAL_PROCESSINGINSTRUCTION = '[<][?].*?[?][>]';
-    const PARTIAL_DECLARATION = '<![A-Z]+' . '\s+[^>]*>';
-    const PARTIAL_CDATA = '<!\[CDATA\[[\s\S]*?]\]>';
-    const PARTIAL_HTMLTAG = '(?:' . self::PARTIAL_OPENTAG . '|' . self::PARTIAL_CLOSETAG . '|' . self::PARTIAL_HTMLCOMMENT . '|' .
+    public const PARTIAL_ENTITY = '&(?:#x[a-f0-9]{1,6}|#[0-9]{1,7}|[a-z][a-z0-9]{1,31});';
+    public const PARTIAL_ESCAPABLE = '[!"#$%&\'()*+,.\/:;<=>?@[\\\\\]^_`{|}~-]';
+    public const PARTIAL_ESCAPED_CHAR = '\\\\' . self::PARTIAL_ESCAPABLE;
+    public const PARTIAL_IN_DOUBLE_QUOTES = '"(' . self::PARTIAL_ESCAPED_CHAR . '|[^"\x00])*"';
+    public const PARTIAL_IN_SINGLE_QUOTES = '\'(' . self::PARTIAL_ESCAPED_CHAR . '|[^\'\x00])*\'';
+    public const PARTIAL_IN_PARENS = '\\((' . self::PARTIAL_ESCAPED_CHAR . '|[^)\x00])*\\)';
+    public const PARTIAL_REG_CHAR = '[^\\\\()\x00-\x20]';
+    public const PARTIAL_IN_PARENS_NOSP = '\((' . self::PARTIAL_REG_CHAR . '|' . self::PARTIAL_ESCAPED_CHAR . '|\\\\)*\)';
+    public const PARTIAL_TAGNAME = '[A-Za-z][A-Za-z0-9-]*';
+    public const PARTIAL_BLOCKTAGNAME = '(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|title|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)';
+    public const PARTIAL_ATTRIBUTENAME = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
+    public const PARTIAL_UNQUOTEDVALUE = '[^"\'=<>`\x00-\x20]+';
+    public const PARTIAL_SINGLEQUOTEDVALUE = '\'[^\']*\'';
+    public const PARTIAL_DOUBLEQUOTEDVALUE = '"[^"]*"';
+    public const PARTIAL_ATTRIBUTEVALUE = '(?:' . self::PARTIAL_UNQUOTEDVALUE . '|' . self::PARTIAL_SINGLEQUOTEDVALUE . '|' . self::PARTIAL_DOUBLEQUOTEDVALUE . ')';
+    public const PARTIAL_ATTRIBUTEVALUESPEC = '(?:' . '\s*=' . '\s*' . self::PARTIAL_ATTRIBUTEVALUE . ')';
+    public const PARTIAL_ATTRIBUTE = '(?:' . '\s+' . self::PARTIAL_ATTRIBUTENAME . self::PARTIAL_ATTRIBUTEVALUESPEC . '?)';
+    public const PARTIAL_OPENTAG = '<' . self::PARTIAL_TAGNAME . self::PARTIAL_ATTRIBUTE . '*' . '\s*\/?>';
+    public const PARTIAL_CLOSETAG = '<\/' . self::PARTIAL_TAGNAME . '\s*[>]';
+    public const PARTIAL_OPENBLOCKTAG = '<' . self::PARTIAL_BLOCKTAGNAME . self::PARTIAL_ATTRIBUTE . '*' . '\s*\/?>';
+    public const PARTIAL_CLOSEBLOCKTAG = '<\/' . self::PARTIAL_BLOCKTAGNAME . '\s*[>]';
+    public const PARTIAL_HTMLCOMMENT = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->';
+    public const PARTIAL_PROCESSINGINSTRUCTION = '[<][?].*?[?][>]';
+    public const PARTIAL_DECLARATION = '<![A-Z]+' . '\s+[^>]*>';
+    public const PARTIAL_CDATA = '<!\[CDATA\[[\s\S]*?]\]>';
+    public const PARTIAL_HTMLTAG = '(?:' . self::PARTIAL_OPENTAG . '|' . self::PARTIAL_CLOSETAG . '|' . self::PARTIAL_HTMLCOMMENT . '|' .
         self::PARTIAL_PROCESSINGINSTRUCTION . '|' . self::PARTIAL_DECLARATION . '|' . self::PARTIAL_CDATA . ')';
-    const PARTIAL_HTMLBLOCKOPEN = '<(?:' . self::PARTIAL_BLOCKTAGNAME . '(?:[\s\/>]|$)' . '|' .
+    public const PARTIAL_HTMLBLOCKOPEN = '<(?:' . self::PARTIAL_BLOCKTAGNAME . '(?:[\s\/>]|$)' . '|' .
         '\/' . self::PARTIAL_BLOCKTAGNAME . '(?:[\s>]|$)' . '|' . '[?!])';
-    const PARTIAL_LINK_TITLE = '^(?:"(' . self::PARTIAL_ESCAPED_CHAR . '|[^"\x00])*"' .
+    public const PARTIAL_LINK_TITLE = '^(?:"(' . self::PARTIAL_ESCAPED_CHAR . '|[^"\x00])*"' .
         '|' . '\'(' . self::PARTIAL_ESCAPED_CHAR . '|[^\'\x00])*\'' .
         '|' . '\((' . self::PARTIAL_ESCAPED_CHAR . '|[^()\x00])*\))';
 
-    const REGEX_PUNCTUATION = '/^[\x{2000}-\x{206F}\x{2E00}-\x{2E7F}\p{Pc}\p{Pd}\p{Pe}\p{Pf}\p{Pi}\p{Po}\p{Ps}\\\\\'!"#\$%&\(\)\*\+,\-\.\\/:;<=>\?@\[\]\^_`\{\|\}~]/u';
-    const REGEX_UNSAFE_PROTOCOL = '/^javascript:|vbscript:|file:|data:/i';
-    const REGEX_SAFE_DATA_PROTOCOL = '/^data:image\/(?:png|gif|jpeg|webp)/i';
-    const REGEX_NON_SPACE = '/[^ \t\f\v\r\n]/';
+    public const REGEX_PUNCTUATION = '/^[\x{2000}-\x{206F}\x{2E00}-\x{2E7F}\p{Pc}\p{Pd}\p{Pe}\p{Pf}\p{Pi}\p{Po}\p{Ps}\\\\\'!"#\$%&\(\)\*\+,\-\.\\/:;<=>\?@\[\]\^_`\{\|\}~]/u';
+    public const REGEX_UNSAFE_PROTOCOL = '/^javascript:|vbscript:|file:|data:/i';
+    public const REGEX_SAFE_DATA_PROTOCOL = '/^data:image\/(?:png|gif|jpeg|webp)/i';
+    public const REGEX_NON_SPACE = '/[^ \t\f\v\r\n]/';
 
-    const REGEX_WHITESPACE_CHAR = '/^[ \t\n\x0b\x0c\x0d]/';
-    const REGEX_WHITESPACE = '/[ \t\n\x0b\x0c\x0d]+/';
-    const REGEX_UNICODE_WHITESPACE_CHAR = '/^\pZ|\s/u';
-    const REGEX_THEMATIC_BREAK = '/^(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})[ \t]*$/';
-    const REGEX_LINK_DESTINATION_BRACES = '/^(?:<(?:[^<>\\n\\\\\\x00]|\\\\.)*>)/';
+    public const REGEX_WHITESPACE_CHAR = '/^[ \t\n\x0b\x0c\x0d]/';
+    public const REGEX_WHITESPACE = '/[ \t\n\x0b\x0c\x0d]+/';
+    public const REGEX_UNICODE_WHITESPACE_CHAR = '/^\pZ|\s/u';
+    public const REGEX_THEMATIC_BREAK = '/^(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})[ \t]*$/';
+    public const REGEX_LINK_DESTINATION_BRACES = '/^(?:<(?:[^<>\\n\\\\\\x00]|\\\\.)*>)/';
 
     /**
      * @param string $character
@@ -73,7 +84,7 @@ final class RegexHelper
      */
     public static function isEscapable(string $character): bool
     {
-        return \preg_match('/' . self::PARTIAL_ESCAPABLE . '/', $character) === 1;
+        return preg_match('/' . self::PARTIAL_ESCAPABLE . '/', $character) === 1;
     }
 
     /**
@@ -88,13 +99,13 @@ final class RegexHelper
     public static function matchAt(string $regex, string $string, int $offset = 0): ?int
     {
         $matches = [];
-        $string = \mb_substr($string, $offset, null, 'utf-8');
-        if (!\preg_match($regex, $string, $matches, PREG_OFFSET_CAPTURE)) {
+        $string = mb_substr($string, $offset);
+        if (!preg_match($regex, $string, $matches, PREG_OFFSET_CAPTURE)) {
             return null;
         }
 
         // PREG_OFFSET_CAPTURE always returns the byte offset, not the char offset, which is annoying
-        $charPos = \mb_strlen(\mb_strcut($string, 0, $matches[0][1], 'utf-8'), 'utf-8');
+        $charPos = mb_strlen(mb_strcut($string, 0, $matches[0][1], 'utf-8'), 'utf-8');
 
         return $offset + $charPos;
     }
@@ -111,19 +122,19 @@ final class RegexHelper
     public static function matchAll(string $pattern, string $subject, int $offset = 0): ?array
     {
         if ($offset !== 0) {
-            $subject = \substr($subject, $offset);
+            $subject = substr($subject, $offset);
         }
 
-        \preg_match_all($pattern, $subject, $matches, PREG_PATTERN_ORDER);
+        preg_match_all($pattern, $subject, $matches, PREG_PATTERN_ORDER);
 
-        $fullMatches = \reset($matches);
+        $fullMatches = reset($matches);
         if (empty($fullMatches)) {
             return null;
         }
 
-        if (\count($fullMatches) === 1) {
+        if (count($fullMatches) === 1) {
             foreach ($matches as &$match) {
-                $match = \reset($match);
+                $match = reset($match);
             }
         }
 
@@ -141,8 +152,8 @@ final class RegexHelper
     {
         $allEscapedChar = '/\\\\(' . self::PARTIAL_ESCAPABLE . ')/';
 
-        $escaped = \preg_replace($allEscapedChar, '$1', $string);
-        $replaced = \preg_replace_callback('/' . self::PARTIAL_ENTITY . '/i', function ($e) {
+        $escaped = preg_replace($allEscapedChar, '$1', $string);
+        $replaced = preg_replace_callback('/' . self::PARTIAL_ENTITY . '/i', function ($e) {
             return Html5EntityDecoder::decode($e[0]);
         }, $escaped);
 
@@ -175,7 +186,7 @@ final class RegexHelper
                 return '/^(?:' . self::PARTIAL_OPENTAG . '|' . self::PARTIAL_CLOSETAG . ')\\s*$/i';
         }
 
-        throw new \InvalidArgumentException('Invalid HTML block type');
+        throw new InvalidArgumentException('Invalid HTML block type');
     }
 
     /**
@@ -200,7 +211,7 @@ final class RegexHelper
                 return '/\]\]>/';
         }
 
-        throw new \InvalidArgumentException('Invalid HTML block type');
+        throw new InvalidArgumentException('Invalid HTML block type');
     }
 
     /**
@@ -210,6 +221,6 @@ final class RegexHelper
      */
     public static function isLinkPotentiallyUnsafe(string $url): bool
     {
-        return \preg_match(self::REGEX_UNSAFE_PROTOCOL, $url) !== 0 && \preg_match(self::REGEX_SAFE_DATA_PROTOCOL, $url) === 0;
+        return preg_match(self::REGEX_UNSAFE_PROTOCOL, $url) !== 0 && preg_match(self::REGEX_SAFE_DATA_PROTOCOL, $url) === 0;
     }
 }

--- a/tests/benchmark/benchmark.php
+++ b/tests/benchmark/benchmark.php
@@ -203,7 +203,7 @@ if ($config['exec'] === 'exec') {
 
 $run = function (array $config, string $parser) use ($exec) : array {
     if ($config['flags']['isolate']) {
-        $bin = realpath($config['exec']);
+        $bin = str_replace(' ', '\ ', realpath($config['exec']));
         $argv =
             '--exec exec ' .
             "--parser \"{$parser}\" " .


### PR DESCRIPTION
- Updated to call multibyte methods only when necessary
- Replaced some `preg_match` calls searching for tabs with `strpos` searching for `chr(9)`
- Fixed the benchmark error "failed to close process"
- Fixed some possible bugs where it would ignore the encoding of the Cursor and just assume "UTF-8"
- Small PHP optimisations in general

This PR opens some doors as it shows some examples of performance improvements (which I'm sorry I'm not covering more as my time is limited).

With this PR I was able to be around 3~7ms faster.

Before:
```
Running Benchmarks (Isolated), 7 Implementations, 20 Iterations:
	CommonMark                     ....................
	PHP Markdown                   ....................
	PHP Markdown Extra             ....................
	Parsedown                      ....................
	cebe/markdown                  ....................
	cebe/markdown gfm              ....................
	cebe/markdown extra            ....................

Benchmark Results, CPU:
	1) Parsedown                    2.41 ms              
	2) cebe/markdown                2.92 ms      -0.51 ms
	3) cebe/markdown gfm            3.78 ms      -1.37 ms
	4) PHP Markdown                 4.23 ms      -1.82 ms
	5) cebe/markdown extra          4.70 ms      -2.29 ms
	6) PHP Markdown Extra           6.56 ms      -4.15 ms
	7) CommonMark                  31.14 ms     -28.73 ms

Benchmark Results, Peak Memory:
	1) PHP Markdown                 2413 kB              
	2) Parsedown                    2556 kB       -143 kB
	3) PHP Markdown Extra           2573 kB       -160 kB
	4) cebe/markdown                2645 kB       -232 kB
	5) cebe/markdown extra          2780 kB       -367 kB
	6) cebe/markdown gfm            3134 kB       -721 kB
	7) CommonMark                   6545 kB      -4132 kB
```

With my changes:
```
Running Benchmarks (Isolated), 7 Implementations, 20 Iterations:
	CommonMark                     ....................
	PHP Markdown                   ....................
	PHP Markdown Extra             ....................
	Parsedown                      ....................
	cebe/markdown                  ....................
	cebe/markdown gfm              ....................
	cebe/markdown extra            ....................

Benchmark Results, CPU:
	1) Parsedown                    2.45 ms              
	2) cebe/markdown                2.82 ms      -0.37 ms
	3) cebe/markdown extra          3.06 ms      -0.61 ms
	4) cebe/markdown gfm            3.86 ms      -1.41 ms
	5) PHP Markdown                 4.26 ms      -1.81 ms
	6) PHP Markdown Extra           6.47 ms      -4.02 ms
	7) CommonMark                  26.89 ms     -24.44 ms

Benchmark Results, Peak Memory:
	1) PHP Markdown                 2413 kB              
	2) Parsedown                    2556 kB       -143 kB
	3) PHP Markdown Extra           2573 kB       -160 kB
	4) cebe/markdown                2645 kB       -232 kB
	5) cebe/markdown extra          2780 kB       -367 kB
	6) cebe/markdown gfm            3134 kB       -721 kB
	7) CommonMark                   6526 kB      -4113 kB
```

This doesn't solve entirely but helps a lot #385 (at least the benchmark script problem with `-memory` flag).

Some further read that helps it:
https://mike42.me/blog/2018-06-how-i-made-my-php-code-run-100-times-faster
http://maettig.com/code/php/php-performance-benchmarks.php