### PR TITLE
Fix URL normalization

### DIFF
--- a/src/Util/UrlEncoder.php
+++ b/src/Util/UrlEncoder.php
@@ -40,17 +40,17 @@ final class UrlEncoder
     ];
 
     protected static $dontDecode = [
-        ';',
-        '/',
-        '?',
-        ':',
-        '@',
-        '&',
-        '=',
-        '+',
-        '$',
-        ',',
-        '#',
+        '%3B' => ';',
+        '%2F' => '/',
+        '%3F' => '?',
+        '%3A' => ':',
+        '%40' => '@',
+        '%26' => '&',
+        '%3D' => '=',
+        '%2B' => '+',
+        '%24' => '$',
+        '%2C' => ',',
+        '%23' => '#',
     ];
 
     /**
@@ -75,14 +75,28 @@ final class UrlEncoder
     private static function decode(string $uri): string
     {
         /** @var string $ret */
-        $ret = \preg_replace_callback('/%([0-9a-f]{2})/iu', function ($matches) {
-            $char = \chr(\hexdec($matches[1]));
+        $ret = \preg_replace_callback('/((%[0-9a-f]{2})+)/iu', function ($matches) {
+            $bytes = \hex2bin(\str_replace('%', '', $matches[1]));
 
-            if (\in_array($char, self::$dontDecode, true)) {
+            // Invalid UTF-8 sequences should be kept as-is
+            if ($bytes === false || !\mb_check_encoding($bytes, 'UTF-8')) {
                 return \strtoupper($matches[0]);
             }
 
-            return $char;
+            // Otherwise, split the sequence into characters and decode them (unless that character shouldn't be decoded)
+            /** @var string[] $characters */
+            $characters = \preg_split('//u', $bytes, -1, \PREG_SPLIT_NO_EMPTY);
+
+            $ret = '';
+            foreach ($characters as $char) {
+                if (($encoding = \array_search($char, self::$dontDecode, true)) !== false) {
+                    $ret .= $encoding;
+                } else {
+                    $ret .= $char;
+                }
+            }
+
+            return $ret;
         }, $uri);
 
         return $ret;

--- a/src/Util/UrlEncoder.php
+++ b/src/Util/UrlEncoder.php
@@ -75,7 +75,7 @@ final class UrlEncoder
     private static function decode(string $uri): string
     {
         /** @var string $ret */
-        $ret = \preg_replace_callback('/((%[0-9a-f]{2})+)/iu', function ($matches) {
+        $ret = \preg_replace_callback('/((?:%[0-9a-f]{2})+)/iu', function ($matches) {
             $bytes = \hex2bin(\str_replace('%', '', $matches[1]));
 
             // Invalid UTF-8 sequences should be kept as-is

--- a/tests/unit/Util/UrlEncoderTest.php
+++ b/tests/unit/Util/UrlEncoderTest.php
@@ -93,6 +93,7 @@ class UrlEncoderTest extends TestCase
             ['http://example.com/a%62%63%2fd%3Fe', 'http://example.com/abc%2Fd%3Fe'],
             ['http://ko.wikipedia.org/wiki/위키백과:대문', 'http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8'],
             ['http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8', 'http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8'],
+            ['http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8', 'http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8'],
             ['http://www.inpec.gov.co/portal/page/portal/Inpec/Institucion/Estad%EDsticas/Estadisticas/Informes%20y%20Boletines%20Estad%EDsticos/1%20INFORME%20ENERO%202017.pdf', 'http://www.inpec.gov.co/portal/page/portal/Inpec/Institucion/Estad%EDsticas/Estadisticas/Informes%20y%20Boletines%20Estad%EDsticos/1%20INFORME%20ENERO%202017.pdf'],
         ];
     }

--- a/tests/unit/Util/UrlEncoderTest.php
+++ b/tests/unit/Util/UrlEncoderTest.php
@@ -82,6 +82,7 @@ class UrlEncoderTest extends TestCase
             ['%40', '%40'],
             ['%5F', '_'],
             ['%7E', '~'],
+            ['%ED', '%ED'],
             ['java%0ascript:alert("XSS")', 'java%0Ascript:alert(%22XSS%22)'],
             ['java%0Ascript:alert("XSS")', 'java%0Ascript:alert(%22XSS%22)'],
             ["java\nscript:alert('XSS')", "java%0Ascript:alert('XSS')"],
@@ -92,6 +93,7 @@ class UrlEncoderTest extends TestCase
             ['http://example.com/a%62%63%2fd%3Fe', 'http://example.com/abc%2Fd%3Fe'],
             ['http://ko.wikipedia.org/wiki/위키백과:대문', 'http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8'],
             ['http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8', 'http://ko.wikipedia.org/wiki/%EC%9C%84%ED%82%A4%EB%B0%B1%EA%B3%BC:%EB%8C%80%EB%AC%B8'],
+            ['http://www.inpec.gov.co/portal/page/portal/Inpec/Institucion/Estad%EDsticas/Estadisticas/Informes%20y%20Boletines%20Estad%EDsticos/1%20INFORME%20ENERO%202017.pdf', 'http://www.inpec.gov.co/portal/page/portal/Inpec/Institucion/Estad%EDsticas/Estadisticas/Informes%20y%20Boletines%20Estad%EDsticos/1%20INFORME%20ENERO%202017.pdf'],
         ];
     }
 }


### PR DESCRIPTION
Fixes #395

Our previous approach was very naive and did not properly handle non-UTF-8 sequences. With this new approach, invalid UTF-8 sequences are left encoded and valid ones are normalized one character (not byte) at a time.