### PR TITLE
[WIP] Fix link parsing edge case

### DIFF
--- a/src/Util/LinkParserHelper.php
+++ b/src/Util/LinkParserHelper.php
@@ -98,7 +98,7 @@ final class LinkParserHelper
 
         $openParens = 0;
         while (($c = $cursor->getCharacter()) !== null) {
-            if ($c === '\\' && RegexHelper::isEscapable($cursor->peek())) {
+            if ($c === '\\' && $cursor->peek() !== null && RegexHelper::isEscapable($cursor->peek())) {
                 $cursor->advanceBy(2);
             } elseif ($c === '(') {
                 $cursor->advanceBy(1);


### PR DESCRIPTION
Peaking at the next character could be null, if we are at the end, and so we need to take this into account. TODO:

- [ ] Add test(s)
- [x] Fix implementation

---

Closes #403.