### PR TITLE
Implement new heading permalink extension

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -27,7 +27,7 @@ namespace PHPSTORM_META
     expectedArguments(\League\CommonMark\Inline\Element\Newline::__construct(), 0, argumentsSet('league_commonmark_newline_types'));
     expectedReturnValues(\League\CommonMark\Inline\Element\Newline::getType(), argumentsSet('league_commonmark_newline_types'));
 
-    registerArgumentsSet('league_commonmark_options', 'renderer', 'enable_em', 'enable_strong', 'use_asterisk', 'use_underscore', 'unordered_list_markers', 'html_input', 'allow_unsafe_links', 'max_nesting_level');
+    registerArgumentsSet('league_commonmark_options', 'renderer', 'enable_em', 'enable_strong', 'use_asterisk', 'use_underscore', 'unordered_list_markers', 'html_input', 'allow_unsafe_links', 'max_nesting_level', 'heading_permalink', 'heading_permalink/html_class', 'heading_permalink/id_prefix', 'heading_permalink/inner_contents', 'heading_permalink/insert', 'heading_permalink/title');
     expectedArguments(\League\CommonMark\EnvironmentInterface::getConfig(), 0, argumentsSet('league_commonmark_options'));
     expectedArguments(\League\CommonMark\Util\ConfigurationInterface::get(), 0, argumentsSet('league_commonmark_options'));
     expectedArguments(\League\CommonMark\Util\ConfigurationInterface::set(), 0, argumentsSet('league_commonmark_options'));

--- a/docs/1.4/extensions/heading-permalinks.md
+++ b/docs/1.4/extensions/heading-permalinks.md
@@ -1,0 +1,141 @@
+---
+layout: default
+title: Heading Permalink Extension
+description: The HeadingPermalinkExtension makes all header elements linkable
+---
+
+# Heading Permalink Extension
+
+This extension makes all of your heading elements (`<h1>`, `<h2>`, etc) linkable so that users can quickly grab a link to that specific part of the document - almost like the headings in this documentation!
+
+## Usage
+
+This extension can be added to any new `Environment`:
+
+```php
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
+
+// Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
+$environment = Environment::createCommonMarkEnvironment();
+
+// Add this extension
+$environment->addExtension(new HeadingPermalinkExtension());
+
+// Set your configuration
+$config = [
+    // Extension defaults are shown below
+    // If you're happy with the defaults, feel free to remove them from this array
+    'heading_permalink' => [
+        'html_class' => 'heading-permalink',
+        'id_prefix' => 'user-content',
+        'inner_contents' => HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS,
+        'insert' => 'before',
+        'title' => 'Permalink',
+    ],
+];
+
+// Instantiate the converter engine and start converting some Markdown!
+$converter = new CommonMarkConverter($config, $environment);
+echo $converter->convertToHtml('# Hello World!');
+```
+
+## Configuration
+
+This extension can be configured by providing a `heading_permalink` array with several nested configuration options.  The defaults are shown in the code example above.
+
+### `html_class`
+
+The value of this nested configuration option should be a `string` that you want set as the `<a>` tag's `class` attribute.  This defaults to `'heading-permalink'`.
+
+### `id_prefix`
+
+This should be a `string` you want prepended to HTML IDs.  This prevents generating HTML ID attributes which might conflict with others in your stylesheet.  A dash separator (`-`) will be added between the prefix and the ID.  You can instead set this to an empty string (`''`) if you don't want a prefix.
+
+### `inner_contents`
+
+This controls the HTML you want to appear inside of the generated `<a>` tag.  Usually this would be something you'd style as some kind of link icon.
+
+By default, we provide an embedded [Octicon link SVG](https://octicons.github.com/icon/link/), but you can replace this with any custom HTML you wish.
+
+### `insert`
+
+This controls whether the anchor is added to the beginning of the `<h1>`, `<h2>` etc. tag or to the end.  Can be set to either `'before'` or `'after'`.
+
+### `title`
+
+This option sets the `title` attribute on the `<a>` tag.  This defaults to `'Permalink'`.
+
+## Example
+
+If you wanted to style your headings exactly like this documentation page does, try this configuration!
+
+```php
+$config = [
+    'heading_permalink' => [
+        'html_class' => 'heading-permalink',
+        'inner_contents' => '¶',
+        'insert' => 'after',
+        'title' => "Permalink",
+    ],
+];
+```
+
+Along with this CSS:
+
+```css
+.heading-permalink {
+    font-size: .8em;
+    vertical-align: super;
+    text-decoration: none;
+    color: transparent;
+}
+
+h1:hover .heading-permalink,
+h2:hover .heading-permalink,
+h3:hover .heading-permalink,
+h4:hover .heading-permalink,
+h5:hover .heading-permalink,
+h6:hover .heading-permalink,
+.heading-permalink:hover {
+    text-decoration: none;
+    color: #777;
+}
+```
+
+## Styling Ideas
+
+This library doesn't provide any CSS styling for the anchor element(s), but here are some ideas you could use in your own stylesheet.
+
+You could hide the icon until the user hovers over the heading:
+
+```css
+.heading-permalink {
+  visibility: hidden;
+}
+
+h1:hover .heading-permalink,
+h2:hover .heading-permalink,
+h3:hover .heading-permalink,
+h4:hover .heading-permalink,
+h5:hover .heading-permalink,
+h6:hover .heading-permalink
+{
+  visibility: visible;
+}
+```
+
+You could also float the icon just a little bit left of the heading:
+
+```css
+.heading-permalink {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+```
+
+These are only ideas - feel free to customize this however you'd like!

--- a/docs/1.4/extensions/overview.md
+++ b/docs/1.4/extensions/overview.md
@@ -71,6 +71,7 @@ These extensions are not part of GFM, but can be useful in many cases:
 | Extension | Purpose | Documentation |
 | --------- | ------- | ------------- |
 | `ExternalLinkExtension` | Tags external links with additional markup | [Documentation](/1.4/extensions/external-links/) |
+| `HeadingPermalinkExtension` | Makes heading elements linkable | [Documentation](/1.4/extensions/heading-permalinks/) |
 | `InlinesOnlyExtension` | Only includes standard CommonMark inline elements - perfect for handling comments and other short bits of text where you only want bold, italic, links, etc. | [Documentation](/1.4/extensions/inlines-only/) |
 | `SmartPunctExtension` | Intelligently converts ASCII quotes, dashes, and ellipses to their fancy Unicode equivalents | [Documentation](/1.4/extensions/smart-punctuation/) |
 

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -17,6 +17,7 @@ version:
             'Autolinks': '/1.4/extensions/autolinks/'
             'Disallowed Raw HTML': '/1.4/extensions/disallowed-raw-html/'
             'External Links': '/1.4/extensions/external-links/'
+            'Heading Permalinks': '/1.4/extensions/heading-permalinks/'
             'Inlines Only': '/1.4/extensions/inlines-only/'
             'Smart Punctuation': '/1.4/extensions/smart-punctuation/'
             'Strikethrough': '/1.4/extensions/strikethrough/'

--- a/src/Extension/HeadingPermalink/HeadingPermalink.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalink.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\HeadingPermalink;
+
+use League\CommonMark\Inline\Element\AbstractInline;
+
+/**
+ * Represents an anchor link within a heading
+ */
+final class HeadingPermalink extends AbstractInline
+{
+    private $slug;
+
+    /**
+     * @param string $slug
+     */
+    public function __construct(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\HeadingPermalink;
+
+use League\CommonMark\ConfigurableEnvironmentInterface;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\ExtensionInterface;
+
+/**
+ * Extension which automatically anchor links to heading elements
+ */
+final class HeadingPermalinkExtension implements ExtensionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register(ConfigurableEnvironmentInterface $environment)
+    {
+        $environment->addEventListener(DocumentParsedEvent::class, new HeadingPermalinkProcessor(), -100);
+        $environment->addInlineRenderer(HeadingPermalink::class, new HeadingPermalinkRenderer());
+    }
+}

--- a/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\HeadingPermalink;
+
+use League\CommonMark\Block\Element\Heading;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\HeadingPermalink\Slug\DefaultSlugGenerator;
+use League\CommonMark\Extension\HeadingPermalink\Slug\SlugGeneratorInterface;
+use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
+
+/**
+ * Searches the Document for Heading elements and adds HeadingPermalinks to each one
+ */
+final class HeadingPermalinkProcessor implements ConfigurationAwareInterface
+{
+    const INSERT_BEFORE = 'before';
+    const INSERT_AFTER = 'after';
+
+    /** @var SlugGeneratorInterface */
+    private $slugGenerator;
+
+    /** @var ConfigurationInterface */
+    private $config;
+
+    /**
+     * @param SlugGeneratorInterface|null $slugGenerator
+     */
+    public function __construct(SlugGeneratorInterface $slugGenerator = null)
+    {
+        $this->slugGenerator = $slugGenerator ?? new DefaultSlugGenerator();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->config = $configuration;
+    }
+
+    /**
+     * @param DocumentParsedEvent $e
+     */
+    public function __invoke(DocumentParsedEvent $e)
+    {
+        $walker = $e->getDocument()->walker();
+
+        while ($event = $walker->next()) {
+            $node = $event->getNode();
+            if ($node instanceof Heading && $event->isEntering()) {
+                $this->addHeadingLink($node);
+            }
+        }
+    }
+
+    private function addHeadingLink(Heading $heading)
+    {
+        $text = $this->getChildText($heading);
+        $slug = $this->slugGenerator->createSlug($text);
+
+        $headingLinkAnchor = new HeadingPermalink($slug);
+
+        switch ($this->config->get('heading_permalink/insert', 'before')) {
+            case self::INSERT_BEFORE:
+                $heading->prependChild($headingLinkAnchor);
+
+                return;
+            case self::INSERT_AFTER:
+                $heading->appendChild($headingLinkAnchor);
+
+                return;
+            default:
+                throw new \RuntimeException("Invalid configuration value for heading_permalink/insert; expected 'before' or 'after'");
+        }
+    }
+
+    private function getChildText(Node $node)
+    {
+        $text = '';
+
+        $walker = $node->walker();
+        while ($event = $walker->next()) {
+            if ($event->isEntering() && ($child = $event->getNode()) instanceof Text) {
+                $text .= $child->getContent();
+            }
+        }
+
+        return $text;
+    }
+}

--- a/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\HeadingPermalink;
+
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
+
+/**
+ * Renders the HeadingPermalink elements
+ */
+final class HeadingPermalinkRenderer implements InlineRendererInterface, ConfigurationAwareInterface
+{
+    const DEFAULT_INNER_CONTENTS = '<svg class="heading-permalink-icon" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>';
+
+    /** @var ConfigurationInterface */
+    private $config;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->config = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
+    {
+        if (!$inline instanceof HeadingPermalink) {
+            throw new \InvalidArgumentException('Incompatible inline type: ' . \get_class($inline));
+        }
+
+        $slug = $inline->getSlug();
+
+        $idPrefix = (string) $this->config->get('heading_permalink/id_prefix', 'user-content');
+        if ($idPrefix !== '') {
+            $idPrefix .= '-';
+        }
+
+        $attrs = [
+            'id'          => $idPrefix . $slug,
+            'href'        => '#' . $slug,
+            'name'        => $slug,
+            'class'       => $this->config->get('heading_permalink/html_class', 'heading-permalink'),
+            'aria-hidden' => 'true',
+            'title'       => $this->config->get('heading_permalink/title', 'Permalink'),
+        ];
+
+        $innerContents = $this->config->get('heading_permalink/inner_contents', self::DEFAULT_INNER_CONTENTS);
+
+        return new HtmlElement('a', $attrs, $innerContents, false);
+    }
+}

--- a/src/Extension/HeadingPermalink/Slug/DefaultSlugGenerator.php
+++ b/src/Extension/HeadingPermalink/Slug/DefaultSlugGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\HeadingPermalink\Slug;
+
+/**
+ * Creates URL-friendly strings
+ */
+final class DefaultSlugGenerator implements SlugGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createSlug(string $input): string
+    {
+        // Trim whitespace
+        $slug = \trim($input);
+        // Convert to lowercase
+        $slug = \mb_strtolower($slug);
+        // Try replacing whitespace with a dash
+        $slug = \preg_replace('/\s+/u', '-', $slug) ?? $slug;
+        // Try removing non-alphanumeric and non-dash characters
+        $slug = \preg_replace('/[^\p{Lu}\p{Ll}\p{Lt}\p{Nd}\p{Nl}\-]/u', '', $slug) ?? $slug;
+
+        return $slug;
+    }
+}

--- a/src/Extension/HeadingPermalink/Slug/SlugGeneratorInterface.php
+++ b/src/Extension/HeadingPermalink/Slug/SlugGeneratorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\HeadingPermalink\Slug;
+
+interface SlugGeneratorInterface
+{
+    /**
+     * Create a URL-friendly slug based on the given input string
+     *
+     * @param string $input
+     *
+     * @return string
+     */
+    public function createSlug(string $input): string;
+}

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Functional\Extension\HeadingPermalink;
+
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class HeadingPermalinkExtensionTest extends TestCase
+{
+    /**
+     * @param string $input
+     * @param string $expected
+     *
+     * @dataProvider dataProviderForTestHeadingPermalinksWithDefaultOptions
+     */
+    public function testHeadingPermalinksWithDefaultOptions(string $input, string $expected)
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+    }
+
+    public function dataProviderForTestHeadingPermalinksWithDefaultOptions()
+    {
+        yield ['# Hello World!', sprintf('<h1><a id="user-content-hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
+        yield ['# Hello *World*', sprintf('<h1><a id="user-content-hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello <em>World</em></h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
+        yield ["Test\n----", sprintf('<h2><a id="user-content-test" href="#test" name="test" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Test</h2>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
+    }
+
+    /**
+     * @param string $input
+     * @param string $expected
+     *
+     * @dataProvider dataProviderForTestHeadingPermalinksWithCustomOptions
+     */
+    public function testHeadingPermalinksWithCustomOptions(string $input, string $expected)
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $config = [
+            'heading_permalink' => [
+                'html_class'     => 'custom-class',
+                'id_prefix'      => 'custom-prefix',
+                'inner_contents' => '<span>custom</span>',
+                'insert'         => 'after',
+                'title'          => 'Link',
+            ],
+        ];
+
+        $converter = new CommonMarkConverter($config, $environment);
+
+        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+    }
+
+    public function dataProviderForTestHeadingPermalinksWithCustomOptions()
+    {
+        yield ['# Hello World!', '<h1>Hello World!<a id="custom-prefix-hello-world" href="#hello-world" name="hello-world" class="custom-class" aria-hidden="true" title="Link"><span>custom</span></a></h1>'];
+        yield ['# Hello *World*', '<h1>Hello <em>World</em><a id="custom-prefix-hello-world" href="#hello-world" name="hello-world" class="custom-class" aria-hidden="true" title="Link"><span>custom</span></a></h1>'];
+        yield ["Test\n----", '<h2>Test<a id="custom-prefix-test" href="#test" name="test" class="custom-class" aria-hidden="true" title="Link"><span>custom</span></a></h2>'];
+    }
+
+    public function testHeadingPermalinksWithEmptyIdPrefix()
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $config = [
+            'heading_permalink' => [
+                'id_prefix' => '',
+            ],
+        ];
+
+        $converter = new CommonMarkConverter($config, $environment);
+
+        $input = '# Hello World!';
+        $expected = sprintf('<h1><a id="hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS);
+
+        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+    }
+
+    public function testHeadingPermalinksWithInvalidInsertConfigurationValue()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $config = [
+            'heading_permalink' => [
+                'insert' => 'invalid value here',
+            ],
+        ];
+
+        $converter = new CommonMarkConverter($config, $environment);
+        $converter->convertToHtml('# This will fail');
+    }
+}

--- a/tests/unit/Extension/HeadingPermalink/Slug/DefaultSlugGeneratorTest.php
+++ b/tests/unit/Extension/HeadingPermalink/Slug/DefaultSlugGeneratorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Unit\Extension\HeadingPermalink\Slug;
+
+use League\CommonMark\Extension\HeadingPermalink\Slug\DefaultSlugGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultSlugGeneratorTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderForTestCreateSlug
+     */
+    public function testCreateSlug($input, $expectedOutput)
+    {
+        $generator = new DefaultSlugGenerator();
+        $this->assertEquals($expectedOutput, $generator->createSlug($input));
+    }
+
+    public function dataProviderForTestCreateSlug()
+    {
+        yield ['', ''];
+        yield ['hello world', 'hello-world'];
+        yield ['hello     world', 'hello-world'];
+        yield ['Hello World!', 'hello-world'];
+
+        yield ['456*(&^3484389462342#$#$#$#$', '4563484389462342'];
+        yield ['me&you', 'meyou'];
+        yield ['special char ὐ here', 'special-char-ὐ-here'];
+        yield ['пристаням стремятся', 'пристаням-стремятся'];
+        yield ['emoji 😂 example', 'emoji--example'];
+        yield ['One ½ half', 'one--half'];
+        yield ['Roman ↁ example', 'roman-ↁ-example'];
+        yield ['Here\'s a Ǆ digraph', 'heres-a-ǆ-digraph'];
+        yield ['Unicode x² superscript', 'unicode-x-superscript'];
+        yield ['Equal = sign', 'equal--sign'];
+        yield ['Tabs	in	here', 'tabs-in-here'];
+        yield ['Tabs-	-in-	-here-too', 'tabs---in---here-too'];
+        yield ['We-love---dashes even with -lots- of    spaces', 'we-love---dashes-even-with--lots--of-spaces'];
+        yield ['LOUD NOISES', 'loud-noises'];
+        yield ['ŤĘŜŦ', 'ťęŝŧ'];
+
+        yield ["\nWho\nput\n\n newlines  \nin here?!\n", 'who-put-newlines-in-here'];
+    }
+}


### PR DESCRIPTION
New extension which automatically adds anchor links to headings, similar to Github:

![image](https://user-images.githubusercontent.com/202034/78453570-9b243200-7660-11ea-9d9b-dcc510ee9016.png)

**Documentation:** https://github.com/thephpleague/commonmark/blob/heading-link-extension/docs/1.3/extensions/heading-permalinks.md