### PR TITLE
Add MarkdownConverterInterface; deprecate Converter and ConverterInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 ## Added
 
  - Added new [Heading Permalink extension](https://commonmark.thephpleague.com/extensions/heading-permalinks/) (#420)
+ - Added new `MarkdownConverterInterface` as a long-term replacement for `ConverterInterface`
 
 ## Fixed
 
@@ -14,6 +15,8 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## Deprecated
 
+ - The `Converter` class has been deprecated; use `CommonMarkConverter` instead (#438, #439)
+ - The `ConverterInterface` has been deprecated; use `MarkdownConverterInterface` instead (#438, #439)
  - The `bin/commonmark` script has been deprecated
  - The following methods of `ArrayCollection` have been deprecated:
    - `add()`
@@ -26,7 +29,6 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
    - `containsKey()`
    - `replaceWith()`
    - `removeGaps()`
- - Instantiating the `Converter` by passing a `DocParserInterface` and `ElementRendererInterface` into the constructor is deprecated
 
 ## [1.3.3] - 2020-04-05
 

--- a/docs/1.4/upgrading.md
+++ b/docs/1.4/upgrading.md
@@ -33,6 +33,8 @@ This class has several unused methods, or methods with an existing alternative:
 | `replaceWith()`     | (none provided)                                      |
 | `removeGaps()`      | (none provided)                                      |
 
-### `Converter` constructor
+### `Converter` and `ConverterInterface`
 
-Instantiating the `Converter` by passing a `DocParserInterface` and `ElementRendererInterface` into the constructor is deprecated. You can keep doing this for now, but in 2.0 we'll be changing the constructor instead accept a configuration array and `EnvironmentInterface`, just like `CommonMarkConverter` does today.
+The `Converter` class has been deprecated - switch to using `CommonMarkConverter` instead.
+
+The `ConverterInterface` has been deprecated - switch to using `MarkdownConverterInterface` instead.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,6 @@ parameters:
       message: '#expects League\\CommonMark\\Delimiter\\DelimiterInterface, League\\CommonMark\\Delimiter\\DelimiterInterface\|null given\.$#'
     - path: src/Block/Element/Paragraph.php
       message: '#\$finalStringContents \(string\) does not accept string\|null\.$#'
-    # Error caused by temporary deprecation
-    - path: src/CommonMarkConverter.php
-      message: '#does not call parent constructor#'
+    # "Errors" caused by deprecations
+    - path: src/ConverterInterface.php
+      message: '#If condition is always false#'

--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -47,8 +47,7 @@ class CommonMarkConverter extends Converter
 
         $this->environment = $environment;
 
-        $this->docParser = new DocParser($environment);
-        $this->htmlRenderer = new HtmlRenderer($environment);
+        parent::__construct(new DocParser($environment), new HtmlRenderer($environment));
     }
 
     /**

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -13,8 +13,10 @@ namespace League\CommonMark;
 
 /**
  * Converts CommonMark-compatible Markdown to HTML.
+ *
+ * @deprecated This class is deprecated since league/commonmark 1.4, use CommonMarkConverter instead.
  */
-class Converter implements ConverterInterface
+class Converter implements MarkdownConverterInterface
 {
     /**
      * The document parser instance.
@@ -35,12 +37,12 @@ class Converter implements ConverterInterface
      *
      * @param DocParserInterface       $docParser
      * @param ElementRendererInterface $htmlRenderer
-     *
-     * @deprecated Instantiating a Converter class with a DocParserInterface and ElementRendererInterface is deprecated since league/commonmark 1.4. In 2.0, this constructor will require a configuration array and EnvironmentInterface.
      */
     public function __construct(DocParserInterface $docParser, ElementRendererInterface $htmlRenderer)
     {
-        @trigger_error('Instantiating a "Converter" class with a DocParserInterface and ElementRendererInterface is deprecated since league/commonmark 1.4. In 2.0, this constructor will require a configuration array and EnvironmentInterface.', E_USER_DEPRECATED);
+        if (!($this instanceof CommonMarkConverter)) {
+            @trigger_error(sprintf('The %s class is deprecated since league/commonmark 1.4, use %s instead.', self::class, CommonMarkConverter::class), E_USER_DEPRECATED);
+        }
 
         $this->docParser = $docParser;
         $this->htmlRenderer = $htmlRenderer;

--- a/src/ConverterInterface.php
+++ b/src/ConverterInterface.php
@@ -11,21 +11,17 @@
 
 namespace League\CommonMark;
 
-/**
- * Interface for a service which converts CommonMark to HTML.
- */
-interface ConverterInterface
-{
+@trigger_error(sprintf('The "%s" interface is deprecated since league/commonmark 1.4, use "%s" instead.', 'League\\CommonMark\\ConverterInterface', MarkdownConverterInterface::class), E_USER_DEPRECATED);
+
+if (false) {
     /**
-     * Converts CommonMark to HTML.
+     * Interface for a service which converts CommonMark to HTML.
      *
-     * @param string $commonMark
-     *
-     * @throws \RuntimeException
-     *
-     * @return string HTML
-     *
-     * @api
+     * @deprecated ConverterInterface is deprecated since league/commonmark 1.4, use MarkdownConverterInterface instead
      */
-    public function convertToHtml(string $commonMark): string;
+    interface ConverterInterface extends MarkdownConverterInterface
+    {
+    }
 }
+
+class_alias(MarkdownConverterInterface::class, 'League\\CommonMark\\ConverterInterface');

--- a/src/MarkdownConverterInterface.php
+++ b/src/MarkdownConverterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark;
+
+/**
+ * Interface for a service which converts Markdown to HTML.
+ */
+interface MarkdownConverterInterface
+{
+    /**
+     * Converts Markdown to HTML.
+     *
+     * @param string $markdown
+     *
+     * @throws \RuntimeException
+     *
+     * @return string HTML
+     *
+     * @api
+     */
+    public function convertToHtml(string $markdown): string;
+}

--- a/tests/unit/ConverterInterfaceAliasTest.php
+++ b/tests/unit/ConverterInterfaceAliasTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Unit;
+
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\ConverterInterface;
+use League\CommonMark\MarkdownConverterInterface;
+use PHPUnit\Framework\TestCase;
+
+class ConverterInterfaceAliasTest extends TestCase
+{
+    public function testAlias()
+    {
+        // Ensure the original interface is recognized as both itself and the new interface
+        $converterImplementation = new class() implements ConverterInterface {
+            public function convertToHtml(string $markdown): string
+            {
+                return '<p>test</p>';
+            }
+        };
+
+        $this->assertInstanceOf(ConverterInterface::class, $converterImplementation);
+        $this->assertInstanceOf(MarkdownConverterInterface::class, $converterImplementation);
+
+        // Ensure the new interface is recognized as both itself and the old interface
+        $markdownConverterImplementation = new class() implements MarkdownConverterInterface {
+            public function convertToHtml(string $markdown): string
+            {
+                return '<p>test</p>';
+            }
+        };
+
+        $this->assertInstanceOf(ConverterInterface::class, $markdownConverterImplementation);
+        $this->assertInstanceOf(MarkdownConverterInterface::class, $markdownConverterImplementation);
+
+        // Create a "legacy" function which requires the old interface and ensure we can still pass CommonMarkConverter (which implements the new interface) to it
+        $legacyFunc = function (ConverterInterface $converter, string $markdown) {
+            return $converter->convertToHtml($markdown);
+        };
+
+        // Create a "new" function which requires the new interface and ensure we can still pass CommonMarkConverter to it
+        $newFunc = function (MarkdownConverterInterface $converter, string $markdown) {
+            return $converter->convertToHtml($markdown);
+        };
+
+        $converter = new CommonMarkConverter();
+        $this->assertInstanceOf(MarkdownConverterInterface::class, $converter);
+        $this->assertInstanceOf(ConverterInterface::class, $converter);
+
+        $this->assertSame("<p>test</p>\n", $legacyFunc($converter, 'test'));
+        $this->assertSame("<p>test</p>\n", $newFunc($converter, 'test'));
+    }
+}


### PR DESCRIPTION
Per #438, the `Converter` class doesn't provide any value - it's an unnecessary level of abstraction that nobody really uses.

Deprecating `ConverterInterface` in favor of `MarkdownConverterInterface` is also being done here to make its purpose more clear.  And if we decide to implement HTML-to-Markdown conversion in this library in the future, we can do so by simply implementing a new `HtmlConverterInterface` on the `CommonMarkConverter` in a minor version release (vs adding a new method on the existing interface which would require a major version bump).

Resolves #438 