### PR TITLE
Allow for inline code-blocks to render in Heading Permalink's Attributes

### DIFF
--- a/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
@@ -15,6 +15,7 @@ use League\CommonMark\Block\Element\Heading;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\HeadingPermalink\Slug\DefaultSlugGenerator;
 use League\CommonMark\Extension\HeadingPermalink\Slug\SlugGeneratorInterface;
+use League\CommonMark\Inline\Element\Code;
 use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Util\ConfigurationAwareInterface;
@@ -83,7 +84,7 @@ final class HeadingPermalinkProcessor implements ConfigurationAwareInterface
 
         $walker = $node->walker();
         while ($event = $walker->next()) {
-            if ($event->isEntering() && ($child = $event->getNode()) instanceof Text) {
+            if ($event->isEntering() && (($child = $event->getNode()) instanceof Text || $child instanceof Code)) {
                 $text .= $child->getContent();
             }
         }

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -39,6 +39,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
     {
         yield ['# Hello World!', sprintf('<h1><a id="user-content-hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
         yield ['# Hello *World*', sprintf('<h1><a id="user-content-hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello <em>World</em></h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
+        yield ['# Hello `World`', sprintf('<h1><a id="user-content-hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello <code>World</code></h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
         yield ["Test\n----", sprintf('<h2><a id="user-content-test" href="#test" name="test" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Test</h2>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS)];
     }
 


### PR DESCRIPTION
## Description
The aim of this pull request is to allow text from code-blocks present in Headings to have its text appended during Slug generation, so the contents persist in other attributes, such as the permalink, id and name.

## Motivation
This feature is present currently in GFM, but its not part of the spec. However, it makes sense to keep the inline text, since they're able to be rendered properly, so, why keep the text on the generated slug?

## Example
When processing the following piece of Markdown:
```md
# Using `my code`
```
The output will be:
```html
<!-- Current Output -->
<h1>
    Using <code>my code</code>
    <a id="user-content-using" href="#using" name="using" class="permalink" aria-hidden="true" title="Permalink"><!-- ... --></a>
</h1>

<!-- Improved Output by this PR -->
<h1>
    Using my <code>code</code>
    <a id="user-content-using-my-code" href="#using-my-code" name="using-my-code" class="permalink" aria-hidden="true" title="Permalink"><!-- ... --></a>
</h1>
```