### PR TITLE
Document potential issues with additional HTML post-processing

### DIFF
--- a/docs/1.4/security.md
+++ b/docs/1.4/security.md
@@ -87,3 +87,8 @@ echo $converter->convertToHtml($markdown);
 ~~~
 
 See the [configuration](/1.4/configuration/) section for more information.
+
+
+## Additional Filtering
+
+Although this library does offer these security features out-of-the-box, some users may opt to also run the HTML output through additional filtering layers (like HTMLPurifier).  If you do this, make sure you **thoroughly** test your additional post-processing steps and configure them to work properly with the types of HTML elements and attributes that converted Markdown might produce, otherwise, you may end up with weird behavior like missing images, broken links, mismatched HTML tags, etc.


### PR DESCRIPTION
Add note that `inner_contents` might be filtered out by HTML post-processing or input filtering.

My use case was that post-processor removed the default `<svg>` node by htmlpurifier (with html5purifier):
- https://github.com/eventum/eventum/blob/v3.8.9/src/Markdown.php#L59