### PR TITLE
Improve DefaultSlugGenerator to preserve complex unicode letters, numbers, and marks

### DIFF
--- a/src/Extension/HeadingPermalink/Slug/DefaultSlugGenerator.php
+++ b/src/Extension/HeadingPermalink/Slug/DefaultSlugGenerator.php
@@ -24,8 +24,8 @@ final class DefaultSlugGenerator implements SlugGeneratorInterface
         $slug = \mb_strtolower($slug);
         // Try replacing whitespace with a dash
         $slug = \preg_replace('/\s+/u', '-', $slug) ?? $slug;
-        // Try removing non-alphanumeric and non-dash characters
-        $slug = \preg_replace('/[^\p{Lu}\p{Ll}\p{Lt}\p{Nd}\p{Nl}\-]/u', '', $slug) ?? $slug;
+        // Try removing characters other than letters, numbers, and marks.
+        $slug = \preg_replace('/[^\p{L}\p{Nd}\p{Nl}\p{M}-]+/u', '', $slug) ?? $slug;
 
         return $slug;
     }

--- a/tests/unit/Extension/HeadingPermalink/Slug/DefaultSlugGeneratorTest.php
+++ b/tests/unit/Extension/HeadingPermalink/Slug/DefaultSlugGeneratorTest.php
@@ -49,5 +49,15 @@ final class DefaultSlugGeneratorTest extends TestCase
         yield ['ŤĘŜŦ', 'ťęŝŧ'];
 
         yield ["\nWho\nput\n\n newlines  \nin here?!\n", 'who-put-newlines-in-here'];
+
+        yield ['අත්හදා බලන මාතෘකාව',    'අත්හදා-බලන-මාතෘකාව'];
+        yield ['අත්හදා බලන මාතෘකාව -',  'අත්හදා-බලන-මාතෘකාව--'];
+        yield ['අත්හදා බලන මාතෘකාව - ', 'අත්හදා-බලන-මාතෘකාව--'];
+        yield ['අත්හදා බලන මාතෘකාව - අ', 'අත්හදා-බලන-මාතෘකාව---අ'];
+
+        yield ['测试标题',     '测试标题'];
+        yield ['测试 # 标题',  '测试--标题'];
+        yield ['测试 x² 标题', '测试-x-标题'];
+        yield ['試験タイトル', '試験タイトル'];
     }
 }


### PR DESCRIPTION
The `DefaultSlugGenerator` implementation currently strips out certain unicode code-points that can render titles in many languages not work properly. 

Test: https://gist.github.com/Ayesh/f357dcc18b60e117ab771476606dda3a

|Heading text|GitHub slug|`league/commonmark` slug|
|---|---|---|
|`Test`|`#test`|`#test`|
|`අත්හදා බලන මාතෘකාව`|`#අත්හදා-බලන-මාතෘකාව`|`#--`|
|`අත්හදා බලන මාතෘකාව -`|`#අත්හදා-බලන-මාතෘකාව---`|`#----`|
|`测试标题`|`#测试标题`|`#`|
|`試験タイトル`|`#試験タイトル`|`#`|

The last second and third strings are from my native Sinhalese language. Some of the glyphs are letters (`\p{L)`), but we also have marks (`\p{M}`). These marks are **not** symbols (`\p{S}`) or punctuation (`\p{P}`). I think the current slug-ify process makes it not possible to use the HeadingPermalink extension in a meaningful way for those who write in complex scripts, which includes Eastern Asian and South Asian languages (which, statistically, accounts for more than half of the world population)

Pretty much every news site, and even [WikiPedia](https://si.wikipedia.org/wiki/%E0%B7%81%E0%B7%8A%E2%80%8D%E0%B6%BB%E0%B7%93_%E0%B6%AF%E0%B7%85%E0%B6%AF%E0%B7%8F_%E0%B6%B8%E0%B7%8F%E0%B7%85%E0%B7%92%E0%B6%9C%E0%B7%8F%E0%B7%80#%E0%B6%9A%E0%B7%9E%E0%B6%AD%E0%B7%94%E0%B6%9A%E0%B7%8F%E0%B6%9C%E0%B7%8F%E0%B6%BB%E0%B6%BA) processes slugs this way.

This PR relaxes the stripping logic to allow complex scripts to preserve the title. Punctuation, symbols, emoji, etc are still removed. After this change, `league/commonmark` slugs match GitHub's slugs verbatim.