### PR TITLE
Deprecate CommonMarkConverter::VERSION

### DIFF
--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -23,6 +23,9 @@ class CommonMarkConverter extends Converter
      * The currently-installed version.
      *
      * This might be a typical `x.y.z` version, or `x.y-dev`.
+     *
+     * @deprecated in 1.5.0 and will be removed from 2.0.0.
+     *   Use \Composer\InstalledVersions provided by composer-runtime-api instead.
      */
     public const VERSION = '1.5-dev';
 


### PR DESCRIPTION
Composer finally added a way to query installed versions during runtime:

https://blog.packagist.com/composer-2-development-update/#changelog-

https://github.com/composer/composer/blob/d89342dc434d52c88e0e06ce3982da739a467f13/src/Composer/InstalledVersions.php#L93-L108