### PR TITLE
[2.0] Front matter extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
             - run: vendor/bin/phpcs
 
     phpunit:
-        name: PHPUnit on ${{ matrix.php }}
+        name: PHPUnit on ${{ matrix.php }} ${{ matrix.composer-flags }}
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -46,6 +46,9 @@ jobs:
                     - php: '8.0'
                       coverage: false
                       composer-flags: '--ignore-platform-reqs'
+                    - php: '7.2'
+                      coverage: false
+                      composer-flags: '--prefer-lowest'
 
         steps:
             - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
    - `InlineParserEngineInterface`
    - `MarkdownParserState`
    - `MarkdownParserStateInterface`
+   - `RenderedContent`
+   - `RenderedContentInterface`
  - Added several new methods:
    - `FencedCode::setInfo()`
    - `Heading::setLevel()`
@@ -40,6 +42,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 
 ### Changed
 
+ - `CommonMarkConverter::convertToHtml()` now returns an instance of `RenderedContentInterface`. This can be cast to a string for backward compatibility with 1.x.
  - Moved and renamed several classes - [see the full list here](https://commonmark.thephpleague.com/2.0/upgrading/#classesnamespaces-renamed)
  - Implemented a new approach to block parsing. This was a massive change, so here are the highlights:
    - Functionality previously found in block parsers and node elements has moved to block parser factories and block parsers, respectively ([more details](https://commonmark.thephpleague.com/2.0/upgrading/#new-block-parsing-approach))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 
 ### Added
 
+ - Added new `FrontMatterExtension` ([see documentation](https://commonmark.thephpleague.com/extensions/front-matter/))
  - Added new `HtmlFilter` and `StringContainerHelper` utility classes
  - Added new `AbstractBlockContinueParser` class to simplify the creation of custom block parsers
  - Added several new classes and interfaces:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
    - `ChildNodeRendererInterface`
    - `CursorState`
    - `DocumentBlockParser`
+   - `DocumentRenderedEvent`
    - `HtmlRendererInterface`
    - `InlineParserEngineInterface`
    - `MarkdownParserState`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
  - `Cursor::saveState()` and `Cursor::restoreState()` now use `CursorState` objects instead of arrays
  - `NodeWalker::next()` now enters, traverses any children, and leaves all elements which may have children (basically all blocks plus any inlines with children). Previously, it only did this for elements explicitly marked as "containers".
  - `InvalidOptionException` now extends from `UnexpectedValueException`
+ - The line numbers (keys) returned via `MarkdownInput::getLines()` now start at 1 instead of 0
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,12 @@
         "phpunit/phpunit": "^8.5",
         "scrutinizer/ocular": "^1.5",
         "symfony/finder": "^4.2",
+        "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0",
         "unleashedtech/php-coding-standard": "^2.2",
         "vimeo/psalm": "^3.11"
+    },
+    "suggest": {
+        "symfony/yaml": "v2.3+ required if using the Front Matter extension"
     },
     "conflict": {
         "scrutinizer/ocular": "1.7.*"

--- a/docs/2.0/basic-usage.md
+++ b/docs/2.0/basic-usage.md
@@ -41,3 +41,7 @@ echo $converter->convertToHtml('# Hello World!');
 ## Supported Character Encodings
 
 Please note that only UTF-8 and ASCII encodings are supported.  If your Markdown uses a different encoding please convert it to UTF-8 before running it through this library.
+
+## Return Value
+
+The `convertToHtml()` method actually returns an instance of `League\CommonMark\Output\RenderedContentInterface`.  You can cast this (implicitly, as shown above, or explicitly) to a `string` or call `getContent()` to get the final HTML output.

--- a/docs/2.0/customization/event-dispatcher.md
+++ b/docs/2.0/customization/event-dispatcher.md
@@ -75,6 +75,10 @@ This event is dispatched just before any processing is done. It can be used to p
 
 This event is dispatched once all other processing is done.  This offers extensions the opportunity to inspect and modify the [Abstract Syntax Tree](/2.0/customization/abstract-syntax-tree/) prior to rendering.
 
+### `League\CommonMark\Event\DocumentRenderedEvent`
+
+This event is dispatched once the rendering step has been completed, just before the output is returned.  The final output can be adjusted at this point or additional metadata can be attached to the return object.
+
 ## Example
 
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:

--- a/docs/2.0/extensions/front-matter.md
+++ b/docs/2.0/extensions/front-matter.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: Front Matter Extension
+description: The Front Matter extension automatically parses YAML front matter from your Markdown.
+redirect_from: /extensions/front-matter/
+---
+
+# Front Matter Extension
+
+The `FrontMatterExtension` adds the ability to parse YAML front matter from the Markdown document and include that in the return result.
+
+## Installation
+
+This extension is bundled with `league/commonmark`. This library can be installed via Composer:
+
+~~~bash
+composer require league/commonmark
+~~~
+
+See the [installation](/2.0/installation/) section for more details.
+
+You will also need to install `symfony/yaml` version 2.3 or higher to use this extension:
+
+~~~bash
+composer require symfony/yaml
+~~~
+
+## Front Matter Syntax
+
+This extension follows the [Jekyll Front Matter syntax](https://jekyllrb.com/docs/front-matter/). The front matter must be the first thing in the file and must take the form of valid YAML set between triple-dashed lines. Here is a basic example:
+
+```md
+---
+layout: post
+title: I Love Markdown
+tags:
+  - test
+  - example
+---
+
+# Hello World!
+```
+
+This will produce a front matter array similar to this:
+
+```php
+$parsedFrontMatter = [
+    'layout' => 'post',
+    'title' => 'I Love Markdown',
+    'tags' => [
+        'test',
+        'example',
+    ],
+];
+```
+
+And the HTML output will only contain the one heading:
+
+```html
+<h1>Hello World!</h1>
+```
+
+## Usage
+
+Configure your `Environment` as usual and add the `FrontMatterExtension`:
+
+```php
+<?php
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\FrontMatter\RenderedContentWithFrontMatter;
+
+// Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
+$environment = Environment::createCommonMarkEnvironment();
+
+// Add the extension
+$environment->addExtension(new FrontMatterExtension());
+
+// Set your configuration if needed
+$config = [
+    // ...
+];
+
+// Instantiate the converter engine and start converting some Markdown!
+$converter = new CommonMarkConverter($config, $environment);
+
+$markdown = <<<MD
+---
+layout: post
+title: I Love Markdown
+tags:
+  - test
+  - example
+---
+
+# Hello World!
+MD;
+
+$result = $converter->convertToHtml($markdown);
+
+// Check if front matter is present:
+if ($result instanceof RenderedContentWithFrontMatter) {
+    $frontMatter = $result->getFrontMatter();
+}
+
+// Output the HTML using any of these:
+echo $result;               // implicit string cast
+// or:
+echo (string) $result;      // explicit string cast
+// or:
+echo $result->getContent();
+```

--- a/docs/2.0/extensions/overview.md
+++ b/docs/2.0/extensions/overview.md
@@ -73,6 +73,7 @@ These extensions are not part of GFM, but can be useful in many cases:
 | `AttributesExtension` | Add HTML attributes (like `id` and `class`) from within the Markdown content | [Documentation](/2.0/extensions/attributes/) |
 | `ExternalLinkExtension` | Tags external links with additional markup | [Documentation](/2.0/extensions/external-links/) |
 | `FootnoteExtension` | Add footnote references throughout the document and show a listing of them at the bottom | [Documentation](/2.0/extensions/footnotes/) |
+| `FrontMatterExtension` | Parses YAML front matter from your Markdown input | [Documentation](/2.0/extensions/front-matter/) |
 | `HeadingPermalinkExtension` | Makes heading elements linkable | [Documentation](/2.0/extensions/heading-permalinks/) |
 | `InlinesOnlyExtension` | Only includes standard CommonMark inline elements - perfect for handling comments and other short bits of text where you only want bold, italic, links, etc. | [Documentation](/2.0/extensions/inlines-only/) |
 | `MentionParser` | Easy parsing of `@mention` and `#123`-style references | [Documentation](/2.0/extensions/mention/) |

--- a/docs/2.0/upgrading.md
+++ b/docs/2.0/upgrading.md
@@ -10,6 +10,10 @@ description: Guide to upgrading to newer versions of this library
 
 The minimum supported PHP version was increased from 7.1 to 7.2.
 
+## `CommonMarkConverter` Return Type
+
+In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast it to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
+
 ## Method Return Types
 
 Return types have been added to virtually all class and interface methods.  If you implement or extend anything from this library, ensure you also have the proper return types added.

--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -19,6 +19,7 @@ namespace League\CommonMark;
 use League\CommonMark\Environment\ConfigurableEnvironmentInterface;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Environment\EnvironmentInterface;
+use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Parser\MarkdownParserInterface;
 use League\CommonMark\Renderer\HtmlRenderer;
@@ -69,11 +70,11 @@ class CommonMarkConverter implements MarkdownConverterInterface
      *
      * @param string $commonMark The Markdown to convert
      *
-     * @return string Rendered HTML
+     * @return RenderedContentInterface Rendered HTML
      *
      * @throws \RuntimeException
      */
-    public function convertToHtml(string $commonMark): string
+    public function convertToHtml(string $commonMark): RenderedContentInterface
     {
         $documentAST = $this->markdownParser->parse($commonMark);
 
@@ -87,7 +88,7 @@ class CommonMarkConverter implements MarkdownConverterInterface
      *
      * @throws \RuntimeException
      */
-    public function __invoke(string $commonMark): string
+    public function __invoke(string $commonMark): RenderedContentInterface
     {
         return $this->convertToHtml($commonMark);
     }

--- a/src/Event/DocumentRenderedEvent.php
+++ b/src/Event/DocumentRenderedEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Event;
+
+use League\CommonMark\Output\RenderedContentInterface;
+
+final class DocumentRenderedEvent extends AbstractEvent
+{
+    /** @var RenderedContentInterface */
+    private $output;
+
+    public function __construct(RenderedContentInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function getOutput(): RenderedContentInterface
+    {
+        return $this->output;
+    }
+
+    /**
+     * @psalm-external-mutation-free
+     */
+    public function replaceOutput(RenderedContentInterface $output): void
+    {
+        $this->output = $output;
+    }
+}

--- a/src/Extension/FrontMatter/FrontMatterExtension.php
+++ b/src/Extension/FrontMatter/FrontMatterExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\FrontMatter;
+
+use League\CommonMark\Environment\ConfigurableEnvironmentInterface;
+use League\CommonMark\Event\DocumentPreParsedEvent;
+use League\CommonMark\Event\DocumentRenderedEvent;
+use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\FrontMatter\Yaml\FrontMatterParserInterface;
+use League\CommonMark\Extension\FrontMatter\Yaml\SymfonyFrontMatterParser;
+
+final class FrontMatterExtension implements ExtensionInterface
+{
+    /**
+     * @var FrontMatterParserInterface
+     *
+     * @psalm-readonly
+     */
+    private $frontMatterParser;
+
+    public function __construct(?FrontMatterParserInterface $frontMatterParser = null)
+    {
+        $this->frontMatterParser = $frontMatterParser ?? new SymfonyFrontMatterParser();
+    }
+
+    public function register(ConfigurableEnvironmentInterface $environment): void
+    {
+        $environment->addEventListener(DocumentPreParsedEvent::class, new FrontMatterParserListener($this->frontMatterParser));
+        $environment->addEventListener(DocumentRenderedEvent::class, new FrontMatterRenderListener(), -500);
+    }
+}

--- a/src/Extension/FrontMatter/FrontMatterParserListener.php
+++ b/src/Extension/FrontMatter/FrontMatterParserListener.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\FrontMatter;
+
+use League\CommonMark\Event\DocumentPreParsedEvent;
+use League\CommonMark\Extension\FrontMatter\Yaml\FrontMatterParserInterface;
+use League\CommonMark\Input\MarkdownInput;
+use League\CommonMark\Parser\Cursor;
+
+final class FrontMatterParserListener
+{
+    /**
+     * @var FrontMatterParserInterface
+     *
+     * @psalm-readonly
+     */
+    private $frontMatterParser;
+
+    private const REGEX_FRONT_MATTER = '/^---\\n.*\\n---\n/s';
+
+    public function __construct(FrontMatterParserInterface $frontMatterParser)
+    {
+        $this->frontMatterParser = $frontMatterParser;
+    }
+
+    public function __invoke(DocumentPreParsedEvent $event): void
+    {
+        $content = $event->getMarkdown()->getContent();
+
+        $cursor = new Cursor($content);
+
+        // Locate the front matter
+        $frontMatter = $cursor->match(self::REGEX_FRONT_MATTER);
+        if ($frontMatter === null) {
+            return;
+        }
+
+        // Trim the last 4 characters (ending ---s and newline)
+        $frontMatter = \substr($frontMatter, 0, -4);
+
+        // Parse the resulting YAML data
+        $data = $this->frontMatterParser->parse($frontMatter);
+
+        // Store the parsed data in the Document
+        $event->getDocument()->data['front_matter'] = $data;
+
+        // Advance through any remaining newlines which separated the front matter from the Markdown text
+        $cursor->match('/^\n+/');
+
+        $event->replaceMarkdown(new MarkdownInput($cursor->getRemainder()));
+    }
+}

--- a/src/Extension/FrontMatter/FrontMatterParserListener.php
+++ b/src/Extension/FrontMatter/FrontMatterParserListener.php
@@ -56,8 +56,12 @@ final class FrontMatterParserListener
         $event->getDocument()->data['front_matter'] = $data;
 
         // Advance through any remaining newlines which separated the front matter from the Markdown text
-        $cursor->match('/^\n+/');
+        $trailingNewlines = $cursor->match('/^\n+/');
 
-        $event->replaceMarkdown(new MarkdownInput($cursor->getRemainder()));
+        // Calculate how many lines the Markdown is offset from the front matter by counting the number of newlines
+        // Don't forget to add 1 because we stripped one out when trimming the trailing delims
+        $lineOffset = \preg_match_all('/\n/', $frontMatter . $trailingNewlines) + 1;
+
+        $event->replaceMarkdown(new MarkdownInput($cursor->getRemainder(), $lineOffset));
     }
 }

--- a/src/Extension/FrontMatter/FrontMatterRenderListener.php
+++ b/src/Extension/FrontMatter/FrontMatterRenderListener.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Extension\FrontMatter;
+
+use League\CommonMark\Event\DocumentRenderedEvent;
+
+final class FrontMatterRenderListener
+{
+    public function __invoke(DocumentRenderedEvent $event): void
+    {
+        $frontMatter = $event->getOutput()->getDocument()->getData('front_matter');
+        if ($frontMatter === null) {
+            return;
+        }
+
+        $event->replaceOutput(new RenderedContentWithFrontMatter(
+            $event->getOutput()->getDocument(),
+            $event->getOutput()->getContent(),
+            $frontMatter
+        ));
+    }
+}

--- a/src/Extension/FrontMatter/RenderedContentWithFrontMatter.php
+++ b/src/Extension/FrontMatter/RenderedContentWithFrontMatter.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Extension\FrontMatter;
+
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Output\RenderedContent;
+
+/**
+ * @psalm-immutable
+ */
+final class RenderedContentWithFrontMatter extends RenderedContent
+{
+    /**
+     * @var mixed
+     *
+     * @psalm-readonly
+     */
+    private $frontMatter;
+
+    /**
+     * @param mixed $frontMatter
+     */
+    public function __construct(Document $document, string $html, $frontMatter)
+    {
+        parent::__construct($document, $html);
+
+        $this->frontMatter = $frontMatter;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFrontMatter()
+    {
+        return $this->frontMatter;
+    }
+}

--- a/src/Extension/FrontMatter/Yaml/FrontMatterParserInterface.php
+++ b/src/Extension/FrontMatter/Yaml/FrontMatterParserInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\FrontMatter\Yaml;
+
+interface FrontMatterParserInterface
+{
+    /**
+     * @return mixed
+     *
+     * @throws \RuntimeException if parsing failed
+     */
+    public function parse(string $frontMatter);
+}

--- a/src/Extension/FrontMatter/Yaml/SymfonyFrontMatterParser.php
+++ b/src/Extension/FrontMatter/Yaml/SymfonyFrontMatterParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\FrontMatter\Yaml;
+
+use Symfony\Component\Yaml\Yaml;
+
+final class SymfonyFrontMatterParser implements FrontMatterParserInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function parse(string $frontMatter)
+    {
+        if (! \class_exists(Yaml::class)) {
+            throw new \RuntimeException('Failed to parse yaml: "symfony/yaml" library is missing');
+        }
+
+        return Yaml::parse($frontMatter);
+    }
+}

--- a/src/Input/MarkdownInput.php
+++ b/src/Input/MarkdownInput.php
@@ -38,13 +38,21 @@ final class MarkdownInput implements MarkdownInputInterface
      */
     private $lineCount;
 
-    public function __construct(string $content)
+    /**
+     * @var int
+     *
+     * @psalm-readonly
+     */
+    private $lineOffset = 0;
+
+    public function __construct(string $content, int $lineOffset = 0)
     {
         if (! \mb_check_encoding($content, 'UTF-8')) {
             throw new UnexpectedEncodingException('Unexpected encoding - UTF-8 or ASCII was expected');
         }
 
-        $this->content = $content;
+        $this->content    = $content;
+        $this->lineOffset = $lineOffset;
     }
 
     public function getContent(): string
@@ -60,8 +68,8 @@ final class MarkdownInput implements MarkdownInputInterface
         $this->splitLinesIfNeeded();
 
         /** @psalm-suppress PossiblyNullIterator */
-        foreach ($this->lines as $lineNumber => $line) {
-            yield $lineNumber => $line;
+        foreach ($this->lines as $i => $line) {
+            yield $this->lineOffset + $i + 1 => $line;
         }
     }
 
@@ -72,6 +80,11 @@ final class MarkdownInput implements MarkdownInputInterface
         \assert($this->lineCount !== null);
 
         return $this->lineCount;
+    }
+
+    public function getLineOffset(): int
+    {
+        return $this->lineOffset;
     }
 
     private function splitLinesIfNeeded(): void

--- a/src/MarkdownConverterInterface.php
+++ b/src/MarkdownConverterInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark;
 
+use League\CommonMark\Output\RenderedContentInterface;
+
 /**
  * Interface for a service which converts Markdown to HTML.
  */
@@ -21,11 +23,7 @@ interface MarkdownConverterInterface
     /**
      * Converts Markdown to HTML.
      *
-     * @param string $markdown Markdown input
-     *
-     * @return string HTML output
-     *
      * @throws \RuntimeException
      */
-    public function convertToHtml(string $markdown): string;
+    public function convertToHtml(string $markdown): RenderedContentInterface;
 }

--- a/src/Output/RenderedContent.php
+++ b/src/Output/RenderedContent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Output;
+
+use League\CommonMark\Node\Block\Document;
+
+class RenderedContent implements RenderedContentInterface
+{
+    /**
+     * @var Document
+     *
+     * @psalm-readonly
+     */
+    private $document;
+
+    /**
+     * @var string
+     *
+     * @psalm-readonly
+     */
+    private $html;
+
+    public function __construct(Document $document, string $html)
+    {
+        $this->document = $document;
+        $this->html     = $html;
+    }
+
+    public function getDocument(): Document
+    {
+        return $this->document;
+    }
+
+    public function getContent(): string
+    {
+        return $this->html;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __toString(): string
+    {
+        return $this->html;
+    }
+}

--- a/src/Output/RenderedContentInterface.php
+++ b/src/Output/RenderedContentInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Output;
+
+use League\CommonMark\Node\Block\Document;
+
+interface RenderedContentInterface extends \Stringable
+{
+    /**
+     * @psalm-mutation-free
+     */
+    public function getDocument(): Document;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function getContent(): string;
+}

--- a/src/Parser/MarkdownParser.php
+++ b/src/Parser/MarkdownParser.php
@@ -110,8 +110,8 @@ final class MarkdownParser implements MarkdownParserInterface
         $this->environment->dispatch($preParsedEvent);
         $markdown = $preParsedEvent->getMarkdown();
 
-        foreach ($markdown->getLines() as $line) {
-            ++$this->lineNumber;
+        foreach ($markdown->getLines() as $lineNumber => $line) {
+            $this->lineNumber = $lineNumber;
             $this->incorporateLine($line);
         }
 

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -20,6 +20,8 @@ use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Node;
+use League\CommonMark\Output\RenderedContent;
+use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Util\HtmlElement;
 
 final class HtmlRenderer implements HtmlRendererInterface, ChildNodeRendererInterface
@@ -36,9 +38,9 @@ final class HtmlRenderer implements HtmlRendererInterface, ChildNodeRendererInte
         $this->environment = $environment;
     }
 
-    public function renderDocument(Document $node): string
+    public function renderDocument(Document $node): RenderedContentInterface
     {
-        return (string) $this->renderNode($node);
+        return new RenderedContent($node, (string) $this->renderNode($node));
     }
 
     /**

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Renderer;
 
 use League\CommonMark\Environment\EnvironmentInterface;
+use League\CommonMark\Event\DocumentRenderedEvent;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Node;
@@ -40,7 +41,12 @@ final class HtmlRenderer implements HtmlRendererInterface, ChildNodeRendererInte
 
     public function renderDocument(Document $node): RenderedContentInterface
     {
-        return new RenderedContent($node, (string) $this->renderNode($node));
+        $output = new RenderedContent($node, (string) $this->renderNode($node));
+
+        $event = new DocumentRenderedEvent($output);
+        $this->environment->dispatch($event);
+
+        return $event->getOutput();
     }
 
     /**

--- a/src/Renderer/HtmlRendererInterface.php
+++ b/src/Renderer/HtmlRendererInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Renderer;
 
 use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Output\RenderedContentInterface;
 
 /**
  * Renders a parsed Document AST to HTML
@@ -21,7 +22,7 @@ use League\CommonMark\Node\Block\Document;
 interface HtmlRendererInterface
 {
     /**
-     * Render the given Document node (and all of its children) to HTML
+     * Render the given Document node (and all of its children)
      */
-    public function renderDocument(Document $node): string;
+    public function renderDocument(Document $node): RenderedContentInterface;
 }

--- a/tests/functional/AbstractLocalDataTest.php
+++ b/tests/functional/AbstractLocalDataTest.php
@@ -38,7 +38,7 @@ abstract class AbstractLocalDataTest extends TestCase
      */
     protected function assertMarkdownRendersAs(string $markdown, string $html, string $testName): void
     {
-        $actualResult = $this->converter->convertToHtml($markdown);
+        $actualResult = (string) $this->converter->convertToHtml($markdown);
 
         $failureMessage  = \sprintf('Unexpected result for "%s" test', $testName);
         $failureMessage .= "\n=== markdown ===============\n" . $markdown;

--- a/tests/functional/AbstractSpecTest.php
+++ b/tests/functional/AbstractSpecTest.php
@@ -41,7 +41,7 @@ abstract class AbstractSpecTest extends TestCase
         $markdown = \str_replace('→', "\t", $markdown);
         $html     = \str_replace('→', "\t", $html);
 
-        $actualResult = $this->converter->convertToHtml($markdown);
+        $actualResult = (string) $this->converter->convertToHtml($markdown);
 
         $failureMessage  = 'Unexpected result:';
         $failureMessage .= "\n=== markdown ===============\n" . $this->showSpaces($markdown);

--- a/tests/functional/Extension/DisallowedRawHtml/DisallowedRawHtmlExtensionTest.php
+++ b/tests/functional/Extension/DisallowedRawHtml/DisallowedRawHtmlExtensionTest.php
@@ -42,7 +42,7 @@ HTML;
         $environment->addExtension(new DisallowedRawHtmlExtension());
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertSame($expected, $converter->convertToHtml($input));
+        $this->assertSame($expected, (string) $converter->convertToHtml($input));
     }
 
     public function testIndividualHtmlTagsAsBlocks(): void
@@ -88,6 +88,6 @@ HTML;
         $environment->addExtension(new DisallowedRawHtmlExtension());
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertSame($expected, $converter->convertToHtml($input));
+        $this->assertSame($expected, (string) $converter->convertToHtml($input));
     }
 }

--- a/tests/functional/Extension/FrontMatterExtension/FrontMatterExtensionTest.php
+++ b/tests/functional/Extension/FrontMatterExtension/FrontMatterExtensionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Functional\Extension\FrontMatterExtension;
+
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\FrontMatter\RenderedContentWithFrontMatter;
+use League\CommonMark\Output\RenderedContentInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Exception\ParseException;
+
+final class FrontMatterExtensionTest extends TestCase
+{
+    /** @var Environment */
+    private $environment;
+
+    protected function setUp(): void
+    {
+        $this->environment = Environment::createCommonMarkEnvironment();
+        $this->environment->addExtension(new FrontMatterExtension());
+    }
+
+    public function testWithSampleData(): void
+    {
+        $markdown     = <<<EOT
+---
+layout: post
+title: Blogging Like a Hacker
+redirect_from:
+  - /blog/my-post
+  - /blog/2020-04/my-post
+---
+
+# Hello World!
+
+This is my awesome blog post
+
+EOT;
+        $expectedHtml = <<<EOT
+<h1>Hello World!</h1>
+<p>This is my awesome blog post</p>
+
+EOT;
+
+        $expectedFrontMatter = [
+            'layout' => 'post',
+            'title' => 'Blogging Like a Hacker',
+            'redirect_from' => [
+                '/blog/my-post',
+                '/blog/2020-04/my-post',
+            ],
+        ];
+
+        $converter = new CommonMarkConverter([], $this->environment);
+        $result    = $converter->convertToHtml($markdown);
+
+        $this->assertInstanceOf(RenderedContentWithFrontMatter::class, $result);
+        $this->assertInstanceOf(\Stringable::class, $result);
+
+        \assert($result instanceof RenderedContentWithFrontMatter);
+        $this->assertSame($expectedFrontMatter, $result->getFrontMatter());
+
+        $this->assertSame($expectedHtml, (string) $result->getContent());
+        $this->assertSame($expectedHtml, (string) $result);
+    }
+
+    public function testWithNoFrontMatter(): void
+    {
+        $markdown  = '# Hello World!';
+        $converter = new CommonMarkConverter([], $this->environment);
+        $result    = $converter->convertToHtml($markdown);
+
+        $this->assertInstanceOf(RenderedContentInterface::class, $result);
+        $this->assertNotInstanceOf(RenderedContentWithFrontMatter::class, $result);
+        $this->assertInstanceOf(\Stringable::class, $result);
+
+        $expectedHtml = "<h1>Hello World!</h1>\n";
+
+        $this->assertSame($expectedHtml, (string) $result->getContent());
+        $this->assertSame($expectedHtml, (string) $result);
+    }
+
+    public function testWithInvalidYaml(): void
+    {
+        $this->expectException(ParseException::class);
+
+        $markdown  = <<<EOT
+---
+  this: list
+    is: not
+ valid:::
+---
+
+# Oh no!
+
+EOT;
+        $converter = new CommonMarkConverter([], $this->environment);
+        $converter->convertToHtml($markdown);
+    }
+}

--- a/tests/functional/Extension/FrontMatterExtension/FrontMatterExtensionTest.php
+++ b/tests/functional/Extension/FrontMatterExtension/FrontMatterExtensionTest.php
@@ -65,6 +65,9 @@ EOT;
 
         $this->assertSame($expectedHtml, (string) $result->getContent());
         $this->assertSame($expectedHtml, (string) $result);
+
+        $this->assertSame(1, $result->getDocument()->getStartLine());
+        $this->assertSame(9, $result->getDocument()->firstChild()->getStartLine());
     }
 
     public function testWithNoFrontMatter(): void
@@ -81,6 +84,9 @@ EOT;
 
         $this->assertSame($expectedHtml, (string) $result->getContent());
         $this->assertSame($expectedHtml, (string) $result);
+
+        $this->assertSame(1, $result->getDocument()->getStartLine());
+        $this->assertSame(1, $result->getDocument()->firstChild()->getStartLine());
     }
 
     public function testWithInvalidYaml(): void

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -31,7 +31,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \trim((string) $converter->convertToHtml($input)));
     }
 
     public function dataProviderForTestHeadingPermalinksWithDefaultOptions(): \Generator
@@ -62,7 +62,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
 
         $converter = new CommonMarkConverter($config, $environment);
 
-        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \trim((string) $converter->convertToHtml($input)));
     }
 
     public function dataProviderForTestHeadingPermalinksWithCustomOptions(): \Generator
@@ -88,7 +88,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
         $input    = '# Hello World!';
         $expected = \sprintf('<h1><a id="hello-world" href="#hello-world" name="hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_INNER_CONTENTS);
 
-        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \trim((string) $converter->convertToHtml($input)));
     }
 
     public function testHeadingPermalinksWithInvalidInsertConfigurationValue(): void

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -34,7 +34,7 @@ final class MentionParserTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \rtrim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
     public function testMentionParserWithoutSpaceInFront(): void
@@ -49,7 +49,7 @@ final class MentionParserTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \rtrim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
     public function testMentionParserWithNonMatchingSymbol(): void
@@ -64,7 +64,7 @@ final class MentionParserTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \rtrim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
     public function testMentionParserWithNonMatchingRegex(): void
@@ -79,7 +79,7 @@ final class MentionParserTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \rtrim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
     public function testMentionParserWithNullUrl(): void
@@ -97,7 +97,7 @@ final class MentionParserTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \rtrim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
     public function testMentionParserUsingCallback(): void
@@ -122,7 +122,7 @@ final class MentionParserTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \rtrim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
     public function testTwitterMentionParser(): void

--- a/tests/functional/HtmlInputTest.php
+++ b/tests/functional/HtmlInputTest.php
@@ -28,7 +28,7 @@ class HtmlInputTest extends TestCase
         $expectedOutput = \trim(\file_get_contents(__DIR__ . '/data/html_input/unsafe_output.html'));
 
         $converter    = new CommonMarkConverter();
-        $actualOutput = \trim($converter->convertToHtml($input));
+        $actualOutput = \trim((string) $converter->convertToHtml($input));
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }
@@ -39,7 +39,7 @@ class HtmlInputTest extends TestCase
         $expectedOutput = \trim(\file_get_contents(__DIR__ . '/data/html_input/unsafe_output.html'));
 
         $converter    = new CommonMarkConverter(['html_input' => HtmlFilter::ALLOW]);
-        $actualOutput = \trim($converter->convertToHtml($input));
+        $actualOutput = \trim((string) $converter->convertToHtml($input));
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }
@@ -50,7 +50,7 @@ class HtmlInputTest extends TestCase
         $expectedOutput = \trim(\file_get_contents(__DIR__ . '/data/html_input/escaped_output.html'));
 
         $converter    = new CommonMarkConverter(['html_input' => HtmlFilter::ESCAPE]);
-        $actualOutput = \trim($converter->convertToHtml($input));
+        $actualOutput = \trim((string) $converter->convertToHtml($input));
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }
@@ -61,7 +61,7 @@ class HtmlInputTest extends TestCase
         $expectedOutput = \trim(\file_get_contents(__DIR__ . '/data/html_input/safe_output.html'));
 
         $converter    = new CommonMarkConverter(['html_input' => HtmlFilter::STRIP]);
-        $actualOutput = \trim($converter->convertToHtml($input));
+        $actualOutput = \trim((string) $converter->convertToHtml($input));
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }

--- a/tests/functional/SafeLinksTest.php
+++ b/tests/functional/SafeLinksTest.php
@@ -27,7 +27,7 @@ class SafeLinksTest extends TestCase
         $expectedOutput = \trim(\file_get_contents(__DIR__ . '/data/safe_links/unsafe_output.html'));
 
         $converter    = new CommonMarkConverter();
-        $actualOutput = \trim($converter->convertToHtml($input));
+        $actualOutput = \trim((string) $converter->convertToHtml($input));
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }
@@ -38,7 +38,7 @@ class SafeLinksTest extends TestCase
         $expectedOutput = \trim(\file_get_contents(__DIR__ . '/data/safe_links/safe_output.html'));
 
         $converter    = new CommonMarkConverter(['allow_unsafe_links' => false]);
-        $actualOutput = \trim($converter->convertToHtml($input));
+        $actualOutput = \trim((string) $converter->convertToHtml($input));
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }

--- a/tests/unit/CommonMarkConverterTest.php
+++ b/tests/unit/CommonMarkConverterTest.php
@@ -78,6 +78,6 @@ class CommonMarkConverterTest extends TestCase
 
         $converter = new CommonMarkConverter();
 
-        $this->assertSame($converter->convertToHtml($inputMarkdown), $converter($inputMarkdown));
+        $this->assertEquals($converter->convertToHtml($inputMarkdown), $converter($inputMarkdown));
     }
 }

--- a/tests/unit/Event/DocumentRenderedEventTest.php
+++ b/tests/unit/Event/DocumentRenderedEventTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Unit\Event;
+
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Event\DocumentRenderedEvent;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Output\RenderedContent;
+use League\CommonMark\Output\RenderedContentInterface;
+use League\CommonMark\Renderer\HtmlRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class DocumentRenderedEventTest extends TestCase
+{
+    public function testGettersAndReplacers(): void
+    {
+        $output = $this->createMock(RenderedContentInterface::class);
+
+        $event = new DocumentRenderedEvent($output);
+
+        $this->assertSame($output, $event->getOutput());
+
+        // Replace the output with something else - the getter should return something different now
+        $event->replaceOutput($this->createMock(RenderedContentInterface::class));
+
+        $this->assertNotSame($output, $event->getOutput());
+    }
+
+    public function testEventDispatchedAtCorrectTime(): void
+    {
+        $wasCalled = false;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addEventListener(DocumentRenderedEvent::class, static function (DocumentRenderedEvent $event) use (&$wasCalled): void {
+            $wasCalled = true;
+            $event->replaceOutput(new RenderedContent(new Document(), 'foo'));
+        });
+
+        $renderer = new HtmlRenderer($environment);
+        $result   = $renderer->renderDocument(new Document());
+
+        $this->assertTrue($wasCalled);
+        $this->assertSame('foo', (string) $result);
+    }
+}

--- a/tests/unit/Extension/Autolink/EmailAutolinkProcessorTest.php
+++ b/tests/unit/Extension/Autolink/EmailAutolinkProcessorTest.php
@@ -30,7 +30,7 @@ final class EmailAutolinkProcessorTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \trim((string) $converter->convertToHtml($input)));
     }
 
     /**

--- a/tests/unit/Extension/Autolink/UrlAutolinkProcessorTest.php
+++ b/tests/unit/Extension/Autolink/UrlAutolinkProcessorTest.php
@@ -30,7 +30,7 @@ final class UrlAutolinkProcessorTest extends TestCase
 
         $converter = new CommonMarkConverter([], $environment);
 
-        $this->assertEquals($expected, \trim($converter->convertToHtml($input)));
+        $this->assertEquals($expected, \trim((string) $converter->convertToHtml($input)));
     }
 
     /**

--- a/tests/unit/Extension/ExternalLink/ExternalLinkProcessorTest.php
+++ b/tests/unit/Extension/ExternalLink/ExternalLinkProcessorTest.php
@@ -64,7 +64,7 @@ final class ExternalLinkProcessorTest extends TestCase
 
         $c = new CommonMarkConverter($config, $e);
 
-        return \rtrim($c->convertToHtml($markdown));
+        return \rtrim((string) $c->convertToHtml($markdown));
     }
 
     /**

--- a/tests/unit/Extension/FrontMatter/FrontMatterParserListenerTest.php
+++ b/tests/unit/Extension/FrontMatter/FrontMatterParserListenerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Unit\Extension\FrontMatter;
+
+use League\CommonMark\Event\DocumentPreParsedEvent;
+use League\CommonMark\Extension\FrontMatter\FrontMatterParserListener;
+use League\CommonMark\Extension\FrontMatter\Yaml\SymfonyFrontMatterParser;
+use League\CommonMark\Input\MarkdownInput;
+use League\CommonMark\Node\Block\Document;
+use PHPUnit\Framework\TestCase;
+
+final class FrontMatterParserListenerTest extends TestCase
+{
+    /**
+     * @dataProvider dataForTestExamples
+     *
+     * @param string $input               The raw Markdown document input
+     * @param mixed  $expectedFrontMatter What the front matter should contain
+     * @param string $expectedContent     What the Markdown (less the front matter) should be
+     */
+    public function testExamples(string $input, $expectedFrontMatter, string $expectedContent): void
+    {
+        $document = new Document();
+        $markdown = new MarkdownInput($input);
+        $parser   = new FrontMatterParserListener(new SymfonyFrontMatterParser());
+
+        $event = new DocumentPreParsedEvent($document, $markdown);
+        $parser->__invoke($event);
+
+        $this->assertSame($expectedFrontMatter, $document->getData('front_matter'));
+        $this->assertSame($expectedContent, $event->getMarkdown()->getContent());
+
+        $this->assertSame($expectedOffset, $event->getMarkdown()->getLineOffset());
+    }
+
+    /**
+     * @return iterable<mixed>
+     */
+    public function dataForTestExamples(): iterable
+    {
+        yield [
+            "---\ntitle: Hello World!\npublished: true\n---\nYay\n---",
+            [
+                'title' => 'Hello World!',
+                'published' => true,
+            ],
+            "Yay\n---",
+        ];
+
+        yield [
+            "---\nJust a string\n---\nYay\n---",
+            'Just a string',
+            "Yay\n---",
+        ];
+
+        yield [
+            "Hello World!\n---",
+            null,
+            "Hello World!\n---",
+        ];
+
+        yield [
+            "---\nThis is a heading\n-----------------",
+            null,
+            "---\nThis is a heading\n-----------------",
+        ];
+
+        yield [
+            "---\nfront_matter_only: true\n---\n",
+            [
+                'front_matter_only' => true,
+            ],
+            '',
+        ];
+
+        yield [
+            "---\nfront_matter_only: true\n---\n\n\n\n\n",
+            [
+                'front_matter_only' => true,
+            ],
+            '',
+        ];
+
+        yield [
+            "\n---\ninvalid_because: front matter must be first\n---",
+            null,
+            "\n---\ninvalid_because: front matter must be first\n---",
+        ];
+
+        yield [
+            "---\nMissing the closer",
+            null,
+            "---\nMissing the closer",
+        ];
+
+        yield [
+            "---\ndelimiter: ---inside\n---\ntest",
+            [
+                'delimiter' => '---inside',
+            ],
+            'test',
+        ];
+
+        yield [
+            "---\ninvalid: closer\n--- can't have text here\n",
+            null,
+            "---\ninvalid: closer\n--- can't have text here\n",
+        ];
+
+        yield [
+            "---\n---\nInvalid front matter",
+            null,
+            "---\n---\nInvalid front matter",
+        ];
+
+        yield [
+            "---\n\n---\nEmpty front matter",
+            null,
+            'Empty front matter',
+        ];
+    }
+}

--- a/tests/unit/Extension/FrontMatter/FrontMatterParserListenerTest.php
+++ b/tests/unit/Extension/FrontMatter/FrontMatterParserListenerTest.php
@@ -28,8 +28,9 @@ final class FrontMatterParserListenerTest extends TestCase
      * @param string $input               The raw Markdown document input
      * @param mixed  $expectedFrontMatter What the front matter should contain
      * @param string $expectedContent     What the Markdown (less the front matter) should be
+     * @param int    $expectedOffset      The 0-based starting line of the resulting Markdown (less the front matter)
      */
-    public function testExamples(string $input, $expectedFrontMatter, string $expectedContent): void
+    public function testExamples(string $input, $expectedFrontMatter, string $expectedContent, int $expectedOffset): void
     {
         $document = new Document();
         $markdown = new MarkdownInput($input);
@@ -56,24 +57,28 @@ final class FrontMatterParserListenerTest extends TestCase
                 'published' => true,
             ],
             "Yay\n---",
+            4,
         ];
 
         yield [
             "---\nJust a string\n---\nYay\n---",
             'Just a string',
             "Yay\n---",
+            3,
         ];
 
         yield [
             "Hello World!\n---",
             null,
             "Hello World!\n---",
+            0,
         ];
 
         yield [
             "---\nThis is a heading\n-----------------",
             null,
             "---\nThis is a heading\n-----------------",
+            0,
         ];
 
         yield [
@@ -82,6 +87,7 @@ final class FrontMatterParserListenerTest extends TestCase
                 'front_matter_only' => true,
             ],
             '',
+            3,
         ];
 
         yield [
@@ -90,18 +96,21 @@ final class FrontMatterParserListenerTest extends TestCase
                 'front_matter_only' => true,
             ],
             '',
+            7,
         ];
 
         yield [
             "\n---\ninvalid_because: front matter must be first\n---",
             null,
             "\n---\ninvalid_because: front matter must be first\n---",
+            0,
         ];
 
         yield [
             "---\nMissing the closer",
             null,
             "---\nMissing the closer",
+            0,
         ];
 
         yield [
@@ -110,24 +119,28 @@ final class FrontMatterParserListenerTest extends TestCase
                 'delimiter' => '---inside',
             ],
             'test',
+            3,
         ];
 
         yield [
             "---\ninvalid: closer\n--- can't have text here\n",
             null,
             "---\ninvalid: closer\n--- can't have text here\n",
+            0,
         ];
 
         yield [
             "---\n---\nInvalid front matter",
             null,
             "---\n---\nInvalid front matter",
+            0,
         ];
 
         yield [
             "---\n\n---\nEmpty front matter",
             null,
             'Empty front matter',
+            3,
         ];
     }
 }

--- a/tests/unit/Extension/Strikethrough/IntegrationTest.php
+++ b/tests/unit/Extension/Strikethrough/IntegrationTest.php
@@ -34,7 +34,7 @@ class IntegrationTest extends TestCase
 
         $document = $parser->parse($string);
 
-        $html = $renderer->renderDocument($document);
+        $html = (string) $renderer->renderDocument($document);
 
         $this->assertSame($expected, $html);
     }

--- a/tests/unit/Input/MarkdownInputTest.php
+++ b/tests/unit/Input/MarkdownInputTest.php
@@ -40,9 +40,22 @@ final class MarkdownInputTest extends TestCase
         $lines = $markdown->getLines();
 
         $this->assertSame(\iterator_to_array($lines), [
-            0 => '# Hello World!',
-            1 => '',
-            2 => 'This is just a test.',
+            1 => '# Hello World!',
+            2 => '',
+            3 => 'This is just a test.',
+        ]);
+    }
+
+    public function testLineOffset(): void
+    {
+        $markdown = new MarkdownInput("# Hello World!\n\nThis is just a test.\n", 3);
+
+        $lines = $markdown->getLines();
+
+        $this->assertSame(\iterator_to_array($lines), [
+            4 => '# Hello World!',
+            5 => '',
+            6 => 'This is just a test.',
         ]);
     }
 

--- a/tests/unit/Output/RenderedContentTest.php
+++ b/tests/unit/Output/RenderedContentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Output;
+
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Output\RenderedContent;
+use PHPUnit\Framework\TestCase;
+
+final class RenderedContentTest extends TestCase
+{
+    public function testEverything(): void
+    {
+        $document = $this->createMock(Document::class);
+        $html     = '<h1>Hello World!</h1>';
+        $object   = new RenderedContent($document, $html);
+
+        $this->assertInstanceOf(\Stringable::class, $object);
+
+        $this->assertSame($document, $object->getDocument());
+        $this->assertSame($html, $object->getContent());
+        $this->assertSame($html, $object->__toString());
+        $this->assertSame($html, (string) $object);
+    }
+}

--- a/tests/unit/Renderer/HtmlRendererTest.php
+++ b/tests/unit/Renderer/HtmlRendererTest.php
@@ -26,7 +26,7 @@ class HtmlRendererTest extends TestCase
         $environment->addRenderer(Document::class, $documentRenderer);
         $htmlRenderer = new HtmlRenderer($environment);
 
-        $this->assertSame('::document::', $htmlRenderer->renderDocument($document));
+        $this->assertSame('::document::', (string) $htmlRenderer->renderDocument($document));
     }
 
     public function testRenderNodesWithBlocks(): void
@@ -44,7 +44,7 @@ class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer($environment);
         $output   = $renderer->renderNodes($ast->children());
 
-        $this->assertSame("::block::\n::block::", $output);
+        $this->assertSame("::block::\n::block::", (string) $output);
     }
 
     public function testRenderNodesWithInlines(): void
@@ -62,7 +62,7 @@ class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer($environment);
         $output   = $renderer->renderNodes($ast->children());
 
-        $this->assertSame('::inline::::inline::', $output);
+        $this->assertSame('::inline::::inline::', (string) $output);
     }
 
     public function testRenderNodesFallsBackWhenFirstRendererReturnsNull(): void
@@ -80,7 +80,7 @@ class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer($environment);
         $output   = $renderer->renderNodes([new Text()]);
 
-        $this->assertSame('::result::', $output);
+        $this->assertSame('::result::', (string) $output);
     }
 
     public function testRenderNodesWithMissingRenderer(): void


### PR DESCRIPTION
Implements the Front Matter extension (#442)

The front matter is parsed before the Markdown parsing occurs and gets stashed on the `Document` object.  Later on, we use a new `DocumentRenderedEvent` listener to pull that parsed YAML out and ensure it gets returned via the `convertToHtml()` output.

## Sample Usage

```php
<?php

use League\CommonMark\CommonMarkConverter;
use League\CommonMark\Environment\Environment;
use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
use League\CommonMark\Extension\FrontMatter\RenderedContentWithFrontMatter;

// Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
$environment = Environment::createCommonMarkEnvironment();

// Add the extension
$environment->addExtension(new FrontMatterExtension());

// Set your configuration if needed
$config = [
    // ...
];

// Instantiate the converter engine and start converting some Markdown!
$converter = new CommonMarkConverter($config, $environment);

$markdown = <<<MD
---
layout: post
title: I Love Markdown
tags:
  - test
  - example
---

# Hello World!
MD;

$result = $converter->convertToHtml($markdown);

// Check if front matter is present:
if ($result instanceof RenderedContentWithFrontMatter) {
    $frontMatter = $result->getFrontMatter();
}

// Output the HTML using any of these:
echo $result;               // implicit string cast
// or:
echo (string) $result;      // explicit string cast
// or:
echo $result->getContent();
```

## :warning:  &nbsp; Breaking Change

The main `convertToHtml()` method of the `CommonMarkConverter` class no longer returns a `string`; instead, it returns an object that provides the HTML and other optional bits of information, like the parsed YAML front matter.

This BC-break can be mitigated by casting the result of `convertToHtml()` to a `string`, thus allowing consumers to safely call that method on any 1.x or 2.x version.

To help ensure future compatibility, this return object implements Symfony's polyfill for PHP 8's `Stringable` interface, thus allowing consumers to type-hint against that in 2.x and future versions.

I tried other implementations to avoid this BC-break but ultimately found them to be too kludgy and not developer-friendly.

## Future Scope

This implementation does not include the config override functionality.  I've got it working locally but we'll need to address https://github.com/thephpleague/commonmark/issues/442#issuecomment-615895227 first.  We'll save that config override stuff for a near-future PR :wink: 