### PR TITLE
[2.0] Nice actions output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,11 @@ jobs:
                   php-version: 7.2
                   extensions: curl, mbstring
                   coverage: none
-                  tools: composer:v2
+                  tools: composer:v2, cs2pr
 
             - run: composer update --no-progress
 
-            - run: vendor/bin/phpcs
+            - run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
 
     phpunit:
         name: PHPUnit on ${{ matrix.php }}
@@ -93,4 +93,4 @@ jobs:
 
             - run: composer update --no-progress
 
-            - run: vendor/bin/psalm
+            - run: vendor/bin/psalm --no-progress --output-format=github


### PR DESCRIPTION
These changes allow the tools to annotate the code with their errors. Note that phpstan already does this as of the most recent patch release 6 days ago, or whenever it was. The other tools need a little bit of help to detect GitHub actions.

The quiet and no-progress flags are not strictly necessary, but they prevent garbled output where progress bars are not rendered correctly (just like you already had).