### PR TITLE
[1.5] Check class_exists before get_parent_class

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -410,7 +410,7 @@ final class Environment implements ConfigurableEnvironmentInterface
             return $list[$class];
         }
 
-        while ($parent = \get_parent_class($parent ?? $class)) {
+        while (\class_exists($parent = $parent ?? $class) && $parent = \get_parent_class($parent)) {
             if (!isset($list[$parent])) {
                 continue;
             }


### PR DESCRIPTION
Should fix the tests on PHP 8.0 again. :)