### PR TITLE
[1.5] Fixed GFM autolinking spec compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+ - Bumped CommonMark spec compliance to 0.28.2
+
+### Fixed
+
+ - Fixed `textarea` elements not being treated as a type 1 HTML block (like `script`, `style`, or `pre`)
+
 ## [1.5.4] - 2020-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 ### Fixed
 
  - Fixed `textarea` elements not being treated as a type 1 HTML block (like `script`, `style`, or `pre`)
+ - Fixed autolink processor not handling other unmatched trailing parentheses
 
 ## [1.5.4] - 2020-08-17
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "ext-json": "*",
         "cebe/markdown": "~1.0",
-        "commonmark/commonmark.js": "0.29.1",
+        "commonmark/commonmark.js": "0.29.2",
         "erusev/parsedown": "~1.0",
         "github/gfm": "0.29.0",
         "michelf/php-markdown": "~1.4",
@@ -46,9 +46,9 @@
             "type": "package",
             "package": {
                 "name": "commonmark/commonmark.js",
-                "version": "0.29.1",
+                "version": "0.29.2",
                 "dist": {
-                    "url": "https://github.com/commonmark/commonmark.js/archive/0.29.1.zip",
+                    "url": "https://github.com/commonmark/commonmark.js/archive/0.29.2.zip",
                     "type": "zip"
                 }
             }

--- a/src/Extension/Autolink/UrlAutolinkProcessor.php
+++ b/src/Extension/Autolink/UrlAutolinkProcessor.php
@@ -107,9 +107,9 @@ final class UrlAutolinkProcessor
             }
 
             // Does the URL need its closing paren chopped off?
-            if (\substr($content, -1) === ')' && self::hasMoreCloserParensThanOpeners($content)) {
-                $content = \substr($content, 0, -1);
-                $leftovers = ')' . $leftovers;
+            if (\substr($content, -1) === ')' && ($diff = self::diffParens($content)) > 0) {
+                $content = \substr($content, 0, -$diff);
+                $leftovers = str_repeat(')', $diff) . $leftovers;
             }
 
             self::addLink($node, $content);
@@ -133,14 +133,14 @@ final class UrlAutolinkProcessor
     /**
      * @param string $content
      *
-     * @return bool
+     * @return int
      */
-    private static function hasMoreCloserParensThanOpeners(string $content): bool
+    private static function diffParens(string $content): int
     {
         // Scan the entire autolink for the total number of parentheses.
         // If there is a greater number of closing parentheses than opening ones,
-        // we don’t consider the last character part of the autolink, in order to
-        // facilitate including an autolink inside a parenthesis.
+        // we don’t consider ANY of the last characters as part of the autolink,
+        // in order to facilitate including an autolink inside a parenthesis.
         \preg_match_all('/[()]/', $content, $matches);
 
         $charCount = ['(' => 0, ')' => 0];
@@ -148,6 +148,6 @@ final class UrlAutolinkProcessor
             $charCount[$char]++;
         }
 
-        return $charCount[')'] > $charCount['('];
+        return $charCount[')'] - $charCount['('];
     }
 }

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -158,7 +158,7 @@ final class RegexHelper
     {
         switch ($type) {
             case HtmlBlock::TYPE_1_CODE_CONTAINER:
-                return '/^<(?:script|pre|style)(?:\s|>|$)/i';
+                return '/^<(?:script|pre|textarea|style)(?:\s|>|$)/i';
             case HtmlBlock::TYPE_2_COMMENT:
                 return '/^<!--/';
             case HtmlBlock::TYPE_3:
@@ -187,7 +187,7 @@ final class RegexHelper
     {
         switch ($type) {
             case HtmlBlock::TYPE_1_CODE_CONTAINER:
-                return '%<\/(?:script|pre|style)>%i';
+                return '%<\/(?:script|pre|textarea|style)>%i';
             case HtmlBlock::TYPE_2_COMMENT:
                 return '/-->/';
             case HtmlBlock::TYPE_3:

--- a/tests/unit/Extension/Autolink/UrlAutolinkProcessorTest.php
+++ b/tests/unit/Extension/Autolink/UrlAutolinkProcessorTest.php
@@ -60,7 +60,9 @@ final class UrlAutolinkProcessorTest extends TestCase
 
         // Tests involving parentheses
         yield ['www.google.com/search?q=Markup+(business)', '<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>'];
+        yield ['www.google.com/search?q=Markup+(business)))', '<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>'];
         yield ['(www.google.com/search?q=Markup+(business))', '<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>'];
+        yield ['(www.google.com/search?q=Markup+(business)', '<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>'];
         yield ['www.google.com/search?q=(business))+ok', '<p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>'];
         yield ['(https://www.example.com/test).', '<p>(<a href="https://www.example.com/test">https://www.example.com/test</a>).</p>'];
 


### PR DESCRIPTION
So, a funny thing has happened where both commonmark.js and GFM forgot to tag releases, despite commonmark.js saying there was a release (0.19.2) and GFM claiming there is a release (0.29.0.gfm.1) too and quoting it in a security vulnerability report from 7 days ago! With all this in mind, I think we should treat their current states as the intended releases, so I have... GFM seem to have changed their autolinking rules to say that all trailing parens should be treated as not part of the link. I have updated the autolink extension as appropriate (indeed, the old implementation failed their tests before):

```
Unexpected result:
=== markdown ===============
www.google.com/search?q=Markup+(business)

www.google.com/search?q=Markup+(business)))

(www.google.com/search?q=Markup+(business))

(www.google.com/search?q=Markup+(business)

=== expected ===============
<p><a␣href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
<p><a␣href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>
<p>(<a␣href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
<p>(<a␣href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>

=== got ====================
<p><a␣href=""></a></p>
<p><a␣href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>
<p>(<a␣href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
<p>(<a␣href=""></a></p>

Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>\n
+'<p><a href=""></a></p>\n
 <p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>\n
 <p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>\n
-<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>\n
+<p>(<a href=""></a></p>\n
 '
```
