### PR TITLE
Fix tests on PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,10 @@ jobs:
 
             - run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+            - name: "Use PHPUnit 9.3+ on PHP 8"
+              run: composer require --no-update --dev phpunit/phpunit:^9.3
+              if: "matrix.php == '8.0'"
+
             - run: composer update --no-progress ${{ matrix.composer-flags }}
 
             - run: vendor/bin/phpunit --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
         "scrutinizer/ocular": "^1.5",
         "symfony/finder": "^4.2"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "conflict": {
         "scrutinizer/ocular": "1.7.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "michelf/php-markdown": "~1.4",
         "mikehaertl/php-shellcommand": "^1.4",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
         "scrutinizer/ocular": "^1.5",
         "symfony/finder": "^4.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,8 +20,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage" />
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,11 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="league/commonmark Test Suite">
-            <directory>tests</directory>
+        <testsuite name="league/commonmark Functional Tests">
+            <directory>tests/functional</directory>
+        </testsuite>
+        <testsuite name="league/commonmark Unit Tests">
+            <directory>tests/unit</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Reference/Reference.php
+++ b/src/Reference/Reference.php
@@ -65,6 +65,7 @@ final class Reference implements ReferenceInterface
      * @return string
      *
      * @deprecated Use TextNormalizer::normalize() instead
+     * @group legacy
      */
     public static function normalizeReference(string $string): string
     {

--- a/tests/functional/AbstractSpecTest.php
+++ b/tests/functional/AbstractSpecTest.php
@@ -24,7 +24,7 @@ abstract class AbstractSpecTest extends TestCase
      */
     protected $converter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->converter = new CommonMarkConverter();
     }

--- a/tests/functional/BinTest.php
+++ b/tests/functional/BinTest.php
@@ -35,7 +35,7 @@ class BinTest extends AbstractBinTest
         $this->assertEquals(1, $cmd->getExitCode());
 
         if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            $this->assertContains('Usage:', $cmd->getError());
+            $this->assertStringContainsString('Usage:', $cmd->getError());
         }
     }
 
@@ -49,7 +49,7 @@ class BinTest extends AbstractBinTest
         $cmd->execute();
 
         $this->assertEquals(0, $cmd->getExitCode());
-        $this->assertContains('Usage:', $cmd->getOutput());
+        $this->assertStringContainsString('Usage:', $cmd->getOutput());
     }
 
     /**
@@ -62,7 +62,7 @@ class BinTest extends AbstractBinTest
         $cmd->execute();
 
         $this->assertEquals(0, $cmd->getExitCode());
-        $this->assertContains('Usage:', $cmd->getOutput());
+        $this->assertStringContainsString('Usage:', $cmd->getOutput());
     }
 
     /**
@@ -77,7 +77,7 @@ class BinTest extends AbstractBinTest
         $this->assertEquals(1, $cmd->getExitCode());
 
         if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            $this->assertContains('Unknown option', $cmd->getError());
+            $this->assertStringContainsString('Unknown option', $cmd->getError());
         }
     }
 
@@ -92,7 +92,7 @@ class BinTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('atx_heading.html')));
-        $this->assertContains($expectedContents, $cmd->getOutput());
+        $this->assertStringContainsString($expectedContents, $cmd->getOutput());
     }
 
     /**
@@ -109,7 +109,7 @@ class BinTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('atx_heading.html')));
-        $this->assertContains($expectedContents, $cmd->getOutput());
+        $this->assertStringContainsString($expectedContents, $cmd->getOutput());
     }
 
     /**
@@ -123,7 +123,7 @@ class BinTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('safe/unsafe_output.html')));
-        $this->assertContains($expectedContents, $cmd->getOutput());
+        $this->assertStringContainsString($expectedContents, $cmd->getOutput());
     }
 
     /**
@@ -138,7 +138,7 @@ class BinTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('safe/safe_output.html')));
-        $this->assertContains($expectedContents, $cmd->getOutput());
+        $this->assertStringContainsString($expectedContents, $cmd->getOutput());
     }
 
     /**
@@ -152,7 +152,7 @@ class BinTest extends AbstractBinTest
             $cmd->execute();
 
             $this->assertEquals(0, $cmd->getExitCode());
-            $this->assertContains(CommonMarkConverter::VERSION, trim($cmd->getOutput()));
+            $this->assertStringContainsString(CommonMarkConverter::VERSION, trim($cmd->getOutput()));
         }
     }
 

--- a/tests/functional/Delimiter/DelimiterProcessingTest.php
+++ b/tests/functional/Delimiter/DelimiterProcessingTest.php
@@ -73,11 +73,9 @@ final class DelimiterProcessingTest extends TestCase
         $this->assertEquals("<p>(1)(2)both(/2)(/1)</p>\n", $c->convertToHtml('@@@both@@@'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMultipleDelimitersWithSameLength()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $e = Environment::createCommonMarkEnvironment();
         $e->addDelimiterProcessor(new TestDelimiterProcessor('@', 1));
         $e->addDelimiterProcessor(new TestDelimiterProcessor('@', 1));

--- a/tests/functional/EmphasisTest.php
+++ b/tests/functional/EmphasisTest.php
@@ -44,7 +44,7 @@ class EmphasisTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('emstrong.html')));
-        $this->assertContains($expectedContents, trim($cmd->getOutput()));
+        $this->assertStringContainsString($expectedContents, trim($cmd->getOutput()));
     }
 
     /**
@@ -59,7 +59,7 @@ class EmphasisTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('em.html')));
-        $this->assertContains($expectedContents, trim($cmd->getOutput()));
+        $this->assertStringContainsString($expectedContents, trim($cmd->getOutput()));
     }
 
     /**
@@ -74,7 +74,7 @@ class EmphasisTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('strong.html')));
-        $this->assertContains($expectedContents, trim($cmd->getOutput()));
+        $this->assertStringContainsString($expectedContents, trim($cmd->getOutput()));
     }
 
     /**
@@ -90,7 +90,7 @@ class EmphasisTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('disabled.html')));
-        $this->assertContains($expectedContents, trim($cmd->getOutput()));
+        $this->assertStringContainsString($expectedContents, trim($cmd->getOutput()));
     }
 
     /**
@@ -105,7 +105,7 @@ class EmphasisTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('asterisks.html')));
-        $this->assertContains($expectedContents, trim($cmd->getOutput()));
+        $this->assertStringContainsString($expectedContents, trim($cmd->getOutput()));
     }
 
     /**
@@ -120,6 +120,6 @@ class EmphasisTest extends AbstractBinTest
 
         $this->assertEquals(0, $cmd->getExitCode());
         $expectedContents = trim(file_get_contents($this->getPathToData('underscores.html')));
-        $this->assertContains($expectedContents, trim($cmd->getOutput()));
+        $this->assertStringContainsString($expectedContents, trim($cmd->getOutput()));
     }
 }

--- a/tests/functional/Extension/GithubFlavoredMarkdownExtensionTest.php
+++ b/tests/functional/Extension/GithubFlavoredMarkdownExtensionTest.php
@@ -16,7 +16,7 @@ use League\CommonMark\Tests\Functional\AbstractSpecTest;
 
 class GithubFlavoredMarkdownExtensionTest extends AbstractSpecTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->converter = new GithubFlavoredMarkdownConverter();
     }

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -77,6 +77,9 @@ final class HeadingPermalinkExtensionTest extends TestCase
         yield ["Test\n----", '<h2>Test<a id="custom-prefix-test" href="#test" name="test" class="custom-class" aria-hidden="true" title="Link">¶ 🦄️ &lt;3 You</a></h2>'];
     }
 
+    /**
+     * @group legacy
+     */
     public function testHeadingPermalinksWithDeprecatedInnerContents()
     {
         $environment = Environment::createCommonMarkEnvironment();

--- a/tests/functional/Extension/InlinesOnly/InlinesOnlyFunctionalTest.php
+++ b/tests/functional/Extension/InlinesOnly/InlinesOnlyFunctionalTest.php
@@ -26,7 +26,7 @@ class InlinesOnlyFunctionalTest extends TestCase
      */
     protected $converter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $environment = new Environment();
         $environment->addExtension(new InlinesOnlyExtension());

--- a/tests/functional/Extension/SmartPunct/SmartPunctFunctionalTest.php
+++ b/tests/functional/Extension/SmartPunct/SmartPunctFunctionalTest.php
@@ -12,7 +12,7 @@
  * file that was distributed with this source code.
  */
 
-namespace League\CommonMark\Tests\Unit\Extension\SmartPunct;
+namespace League\CommonMark\Tests\Functional\Extension\SmartPunct;
 
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
@@ -29,7 +29,7 @@ class SmartPunctFunctionalTest extends TestCase
      */
     protected $converter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addExtension(new SmartPunctExtension());

--- a/tests/functional/LocalDataTest.php
+++ b/tests/functional/LocalDataTest.php
@@ -26,7 +26,7 @@ class LocalDataTest extends AbstractLocalDataTest
      */
     protected $converter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->converter = new CommonMarkConverter();
     }

--- a/tests/unit/Block/Element/AbstractBlockTest.php
+++ b/tests/unit/Block/Element/AbstractBlockTest.php
@@ -33,11 +33,10 @@ class AbstractBlockTest extends TestCase
         $this->assertNull($block->parent());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetParentWithInvalidNode()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $block = $this->getMockForAbstractClass(AbstractBlock::class);
 
         $inline = $this->getMockForAbstractClass(AbstractInline::class);

--- a/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
+++ b/tests/unit/Block/Renderer/BlockQuoteRendererTest.php
@@ -29,7 +29,7 @@ class BlockQuoteRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new BlockQuoteRenderer();
     }
@@ -58,15 +58,14 @@ class BlockQuoteRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('blockquote', $result->getTagName());
-        $this->assertContains('::blocks::', $result->getContents(true));
+        $this->assertStringContainsString('::blocks::', $result->getContents(true));
         $this->assertEquals(['id' => 'id'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/DocumentRendererTest.php
+++ b/tests/unit/Block/Renderer/DocumentRendererTest.php
@@ -28,7 +28,7 @@ class DocumentRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new DocumentRenderer();
     }
@@ -40,7 +40,7 @@ class DocumentRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
+        $this->assertIsString($result);
         $this->assertEmpty($result);
     }
 
@@ -51,15 +51,14 @@ class DocumentRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('::blocks::', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('::blocks::', $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/FencedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/FencedCodeRendererTest.php
@@ -31,7 +31,7 @@ class FencedCodeRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new FencedCodeRenderer();
     }
@@ -59,8 +59,8 @@ class FencedCodeRendererTest extends TestCase
         $code = $result->getContents(false);
         $this->assertTrue($code instanceof HtmlElement);
         $this->assertEquals('code', $code->getTagName());
-        $this->assertContains('bar language-php', $code->getAttribute('class'));
-        $this->assertContains('hello world', $code->getContents(true));
+        $this->assertStringContainsString('bar language-php', $code->getAttribute('class'));
+        $this->assertStringContainsString('hello world', $code->getContents(true));
     }
 
     public function testRenderWithoutLanguageSpecified()
@@ -87,14 +87,13 @@ class FencedCodeRendererTest extends TestCase
         $this->assertTrue($code instanceof HtmlElement);
         $this->assertEquals('code', $code->getTagName());
         $this->assertEquals('bar', $code->getAttribute('class'));
-        $this->assertContains('hello world', $code->getContents(true));
+        $this->assertStringContainsString('hello world', $code->getContents(true));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/HeadingRendererTest.php
+++ b/tests/unit/Block/Renderer/HeadingRendererTest.php
@@ -28,7 +28,7 @@ class HeadingRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new HeadingRenderer();
     }
@@ -49,7 +49,7 @@ class HeadingRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals($expectedTag, $result->getTagName());
-        $this->assertContains('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
         $this->assertEquals(['id' => 'foo'], $result->getAllAttributes());
     }
 
@@ -65,11 +65,10 @@ class HeadingRendererTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/HtmlBlockRendererTest.php
@@ -29,7 +29,7 @@ class HtmlBlockRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new HtmlBlockRenderer();
         $this->renderer->setConfiguration(new Configuration());
@@ -37,7 +37,7 @@ class HtmlBlockRendererTest extends TestCase
 
     public function testRender()
     {
-        /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
+        /** @var HtmlBlock|\PHPUnit\Framework\MockObject\MockObject $block */
         $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
@@ -49,8 +49,8 @@ class HtmlBlockRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('<button>Test</button>', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('<button>Test</button>', $result);
     }
 
     public function testRenderAllowHtml()
@@ -59,7 +59,7 @@ class HtmlBlockRendererTest extends TestCase
             'html_input' => Environment::HTML_INPUT_ALLOW,
         ]));
 
-        /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
+        /** @var HtmlBlock|\PHPUnit\Framework\MockObject\MockObject $block */
         $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
@@ -71,8 +71,8 @@ class HtmlBlockRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('<button>Test</button>', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('<button>Test</button>', $result);
     }
 
     public function testRenderEscapeHtml()
@@ -81,7 +81,7 @@ class HtmlBlockRendererTest extends TestCase
             'html_input' => Environment::HTML_INPUT_ESCAPE,
         ]));
 
-        /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
+        /** @var HtmlBlock|\PHPUnit\Framework\MockObject\MockObject $block */
         $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
@@ -93,8 +93,8 @@ class HtmlBlockRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('&lt;button class="test"&gt;Test&lt;/button&gt;', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('&lt;button class="test"&gt;Test&lt;/button&gt;', $result);
     }
 
     public function testRenderStripHtml()
@@ -103,7 +103,7 @@ class HtmlBlockRendererTest extends TestCase
             'html_input' => Environment::HTML_INPUT_STRIP,
         ]));
 
-        /** @var HtmlBlock|\PHPUnit_Framework_MockObject_MockObject $block */
+        /** @var HtmlBlock|\PHPUnit\Framework\MockObject\MockObject $block */
         $block = $this->getMockBuilder(\League\CommonMark\Block\Element\HtmlBlock::class)
             ->setConstructorArgs([HtmlBlock::TYPE_6_BLOCK_ELEMENT])
             ->getMock();
@@ -115,15 +115,14 @@ class HtmlBlockRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
+        $this->assertIsString($result);
         $this->assertEquals('', $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
+++ b/tests/unit/Block/Renderer/IndentedCodeRendererTest.php
@@ -31,7 +31,7 @@ class IndentedCodeRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new IndentedCodeRenderer();
     }
@@ -60,14 +60,13 @@ class IndentedCodeRendererTest extends TestCase
         $this->assertEquals('code', $code->getTagName());
         $this->assertNull($code->getAttribute('class'));
         $this->assertEquals(['id' => 'foo'], $code->getAllAttributes());
-        $this->assertContains('hello world', $code->getContents(true));
+        $this->assertStringContainsString('hello world', $code->getContents(true));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/ListBlockRendererTest.php
+++ b/tests/unit/Block/Renderer/ListBlockRendererTest.php
@@ -29,7 +29,7 @@ class ListBlockRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new ListBlockRenderer();
     }
@@ -50,7 +50,7 @@ class ListBlockRendererTest extends TestCase
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('ol', $result->getTagName());
         $this->assertSame($expectedAttributeValue, $result->getAttribute('start'));
-        $this->assertContains('::blocks::', $result->getContents(true));
+        $this->assertStringContainsString('::blocks::', $result->getContents(true));
         $this->assertEquals('foo', $result->getAttribute('id'));
     }
 
@@ -74,15 +74,14 @@ class ListBlockRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('ul', $result->getTagName());
-        $this->assertContains('::blocks::', $result->getContents(true));
+        $this->assertStringContainsString('::blocks::', $result->getContents(true));
         $this->assertEquals(['id' => 'foo'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/ListItemRendererTest.php
+++ b/tests/unit/Block/Renderer/ListItemRendererTest.php
@@ -29,7 +29,7 @@ class ListItemRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new ListItemRenderer();
     }
@@ -47,11 +47,10 @@ class ListItemRendererTest extends TestCase
         $this->assertEquals('<li id="foo">::blocks::</li>', $result->__toString());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/ParagraphRendererTest.php
+++ b/tests/unit/Block/Renderer/ParagraphRendererTest.php
@@ -28,7 +28,7 @@ class ParagraphRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new ParagraphRenderer();
     }
@@ -43,15 +43,14 @@ class ParagraphRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('p', $result->getTagName());
-        $this->assertContains('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
         $this->assertEquals(['id' => 'foo'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
+++ b/tests/unit/Block/Renderer/ThematicBreakRendererTest.php
@@ -28,7 +28,7 @@ class ThematicBreakRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new ThematicBreakRenderer();
     }
@@ -44,11 +44,10 @@ class ThematicBreakRendererTest extends TestCase
         $this->assertEquals('hr', $result->getTagName());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(BlockElement\AbstractBlock::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/CommonMarkConverterTest.php
+++ b/tests/unit/CommonMarkConverterTest.php
@@ -17,6 +17,7 @@ namespace League\CommonMark\Tests\Unit;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Environment;
+use League\CommonMark\Exception\UnexpectedEncodingException;
 use League\CommonMark\Extension\CommonMarkCoreExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -61,11 +62,10 @@ class CommonMarkConverterTest extends TestCase
         $this->assertSame($mockEnvironment, $environment);
     }
 
-    /**
-     * @expectedException \League\CommonMark\Exception\UnexpectedEncodingException
-     */
     public function testConvertingInvalidUTF8()
     {
+        $this->expectException(UnexpectedEncodingException::class);
+
         $converter = new CommonMarkConverter();
         $converter->convertToHtml("\x09\xca\xca");
     }

--- a/tests/unit/ConverterTest.php
+++ b/tests/unit/ConverterTest.php
@@ -17,6 +17,9 @@ namespace League\CommonMark\Tests\Unit;
 use League\CommonMark\Converter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class ConverterTest extends TestCase
 {
     public function testInvokeReturnsSameOutputAsConvertToHtml()

--- a/tests/unit/ConverterTest.php
+++ b/tests/unit/ConverterTest.php
@@ -16,7 +16,6 @@ namespace League\CommonMark\Tests\Unit;
 
 use League\CommonMark\Converter;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 
 class ConverterTest extends TestCase
 {
@@ -25,7 +24,7 @@ class ConverterTest extends TestCase
         $inputMarkdown = '**Strong**';
         $expectedHtml = '<strong>Strong</strong>';
 
-        /** @var Converter|PHPUnit_Framework_MockObject_MockObject $converter */
+        /** @var Converter|\PHPUnit\Framework\MockObject\MockObject $converter */
         $converter = $this->getMockBuilder(Converter::class)
             ->disableOriginalConstructor()
             ->setMethods(['convertToHtml'])

--- a/tests/unit/Delimiter/DelimiterProcessorCollectionTest.php
+++ b/tests/unit/Delimiter/DelimiterProcessorCollectionTest.php
@@ -35,12 +35,11 @@ class DelimiterProcessorCollectionTest extends TestCase
         $this->assertSame($processor2, $collection->getDelimiterProcessor('_'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Delim processor for character "*" already exists
-     */
     public function testAddProcessorForCharacterAlreadyRegistered()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->expectExceptionMessage('Delim processor for character "*" already exists');
         $collection = new DelimiterProcessorCollection();
 
         $processor1 = $this->getMockForAbstractClass(DelimiterProcessorInterface::class);

--- a/tests/unit/DocParserTest.php
+++ b/tests/unit/DocParserTest.php
@@ -13,15 +13,14 @@ namespace League\CommonMark\Tests\Unit;
 
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
+use League\CommonMark\Exception\UnexpectedEncodingException;
 use PHPUnit\Framework\TestCase;
 
 class DocParserTest extends TestCase
 {
-    /**
-     * @expectedException \League\CommonMark\Exception\UnexpectedEncodingException
-     */
     public function testParsingWithInvalidUTF8()
     {
+        $this->expectException(UnexpectedEncodingException::class);
         $environment = Environment::createCommonMarkEnvironment();
         $docParser = new DocParser($environment);
 

--- a/tests/unit/Environment/AbstractFakeInjectable.php
+++ b/tests/unit/Environment/AbstractFakeInjectable.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Environment;
+
+use League\CommonMark\EnvironmentAwareInterface;
+use League\CommonMark\EnvironmentInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
+
+abstract class AbstractFakeInjectable implements ConfigurationAwareInterface, EnvironmentAwareInterface
+{
+    /** @var ConfigurationInterface|null */
+    private $config;
+
+    /** @var EnvironmentInterface|null */
+    private $environment;
+
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->config = $configuration;
+    }
+
+    public function setEnvironment(EnvironmentInterface $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    public function getConfig(): ?ConfigurationInterface
+    {
+        return $this->config;
+    }
+
+    public function getEnvironment(): ?EnvironmentInterface
+    {
+        return $this->environment;
+    }
+}

--- a/tests/unit/Environment/FakeBlockParser.php
+++ b/tests/unit/Environment/FakeBlockParser.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Environment;
+
+use League\CommonMark\Block\Parser\BlockParserInterface;
+use League\CommonMark\ContextInterface;
+use League\CommonMark\Cursor;
+
+class FakeBlockParser extends AbstractFakeInjectable implements BlockParserInterface
+{
+    public function parse(ContextInterface $context, Cursor $cursor): bool
+    {
+        return false;
+    }
+}

--- a/tests/unit/Environment/FakeBlockRenderer.php
+++ b/tests/unit/Environment/FakeBlockRenderer.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Environment;
+
+use League\CommonMark\Block\Element\AbstractBlock;
+use League\CommonMark\Block\Renderer\BlockRendererInterface;
+use League\CommonMark\ElementRendererInterface;
+
+class FakeBlockRenderer extends AbstractFakeInjectable implements BlockRendererInterface
+{
+    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false)
+    {
+        return '';
+    }
+}

--- a/tests/unit/Environment/FakeDelimiterProcessor.php
+++ b/tests/unit/Environment/FakeDelimiterProcessor.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Environment;
+
+use League\CommonMark\Delimiter\DelimiterInterface;
+use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
+
+class FakeDelimiterProcessor extends AbstractFakeInjectable implements DelimiterProcessorInterface
+{
+    public function getOpeningCharacter(): string
+    {
+        return '[';
+    }
+
+    public function getClosingCharacter(): string
+    {
+        return ']';
+    }
+
+    public function getMinLength(): int
+    {
+        return 1;
+    }
+
+    public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int
+    {
+        return 1;
+    }
+
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
+    {
+    }
+}

--- a/tests/unit/Environment/FakeInlineParser.php
+++ b/tests/unit/Environment/FakeInlineParser.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Environment;
+
+use League\CommonMark\Inline\Parser\InlineParserInterface;
+use League\CommonMark\InlineParserContext;
+
+class FakeInlineParser extends AbstractFakeInjectable implements InlineParserInterface
+{
+    public function getCharacters(): array
+    {
+        return [];
+    }
+
+    public function parse(InlineParserContext $inlineContext): bool
+    {
+        return false;
+    }
+}

--- a/tests/unit/Environment/FakeInlineRenderer.php
+++ b/tests/unit/Environment/FakeInlineRenderer.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\CommonMark\Tests\Unit\Environment;
+
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+
+class FakeInlineRenderer extends AbstractFakeInjectable implements InlineRendererInterface
+{
+    public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
+    {
+        return '';
+    }
+}

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -19,19 +19,22 @@ use League\CommonMark\Block\Parser\BlockParserInterface;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
 use League\CommonMark\Environment;
-use League\CommonMark\EnvironmentAwareInterface;
 use League\CommonMark\Event\AbstractEvent;
 use League\CommonMark\Extension\ExtensionInterface;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\Inline\Renderer\InlineRendererInterface;
 use League\CommonMark\Tests\Unit\Environment\FakeBlock1;
 use League\CommonMark\Tests\Unit\Environment\FakeBlock3;
+use League\CommonMark\Tests\Unit\Environment\FakeBlockParser;
+use League\CommonMark\Tests\Unit\Environment\FakeBlockRenderer;
+use League\CommonMark\Tests\Unit\Environment\FakeDelimiterProcessor;
 use League\CommonMark\Tests\Unit\Environment\FakeInline1;
 use League\CommonMark\Tests\Unit\Environment\FakeInline3;
+use League\CommonMark\Tests\Unit\Environment\FakeInlineParser;
+use League\CommonMark\Tests\Unit\Environment\FakeInlineRenderer;
 use League\CommonMark\Tests\Unit\Event\FakeEvent;
 use League\CommonMark\Tests\Unit\Event\FakeEventListener;
 use League\CommonMark\Tests\Unit\Event\FakeEventListenerInvokable;
-use League\CommonMark\Util\ConfigurationAwareInterface;
 use PHPUnit\Framework\TestCase;
 
 class EnvironmentTest extends TestCase
@@ -117,7 +120,7 @@ class EnvironmentTest extends TestCase
 
     public function testSetConfigAfterInit()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
 
         $environment = new Environment();
         // This triggers the initialization
@@ -135,7 +138,7 @@ class EnvironmentTest extends TestCase
 
     public function testMergeConfigAfterInit()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
 
         $environment = new Environment();
         // This triggers the initialization
@@ -153,11 +156,9 @@ class EnvironmentTest extends TestCase
         $this->assertContains($parser, $environment->getBlockParsers());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddBlockParserFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
 
         // This triggers the initialization
@@ -177,11 +178,9 @@ class EnvironmentTest extends TestCase
         $this->assertContains($renderer, $environment->getBlockRenderersForClass('MyClass'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddBlockRendererFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
 
         // This triggers the initialization
@@ -206,11 +205,9 @@ class EnvironmentTest extends TestCase
         $this->assertEquals(1, preg_match($environment->getInlineParserCharacterRegex(), 'foo/bar'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddInlineParserFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
 
         // This triggers the initialization
@@ -252,11 +249,9 @@ class EnvironmentTest extends TestCase
         $this->assertSame($processor, $environment->getDelimiterProcessors()->getDelimiterProcessor('*'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddDelimiterProcessorFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
 
         // This triggers the initialization
@@ -276,11 +271,9 @@ class EnvironmentTest extends TestCase
         $this->assertContains($renderer, $environment->getInlineRenderersForClass('MyClass'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddInlineRendererFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
 
         // This triggers the initialization
@@ -342,11 +335,9 @@ class EnvironmentTest extends TestCase
         $this->assertContains($extension, $environment->getExtensions());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddExtensionFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
 
         // This triggers the initialization
@@ -375,70 +366,70 @@ class EnvironmentTest extends TestCase
     {
         $environment = new Environment();
 
-        $parser = $this->getMockBuilder([BlockParserInterface::class, EnvironmentAwareInterface::class, ConfigurationAwareInterface::class])->getMock();
-        $parser->expects($this->once())->method('setEnvironment')->with($environment);
-        $parser->expects($this->once())->method('setConfiguration');
-
+        $parser = new FakeBlockParser();
         $environment->addBlockParser($parser);
 
         // Trigger initialization
         $environment->getBlockParsers();
+
+        $this->assertSame($environment, $parser->getEnvironment());
+        $this->assertNotNull($parser->getConfig());
     }
 
     public function testInjectableBlockRenderersGetInjected()
     {
         $environment = new Environment();
 
-        $renderer = $this->getMockBuilder([BlockRendererInterface::class, EnvironmentAwareInterface::class, ConfigurationAwareInterface::class])->getMock();
-        $renderer->expects($this->once())->method('setEnvironment')->with($environment);
-        $renderer->expects($this->once())->method('setConfiguration');
-
+        $renderer = new FakeBlockRenderer();
         $environment->addBlockRenderer('', $renderer);
 
         // Trigger initialization
         $environment->getBlockParsers();
+
+        $this->assertSame($environment, $renderer->getEnvironment());
+        $this->assertNotNull($renderer->getConfig());
     }
 
     public function testInjectableInlineParsersGetInjected()
     {
         $environment = new Environment();
 
-        $parser = $this->getMockBuilder([InlineParserInterface::class, EnvironmentAwareInterface::class, ConfigurationAwareInterface::class])->getMock();
-        $parser->expects($this->once())->method('setEnvironment')->with($environment);
-        $parser->expects($this->once())->method('setConfiguration');
-
+        $parser = new FakeInlineParser();
         $environment->addInlineParser($parser);
 
         // Trigger initialization
         $environment->getBlockParsers();
+
+        $this->assertSame($environment, $parser->getEnvironment());
+        $this->assertNotNull($parser->getConfig());
     }
 
     public function testInjectableInlineRenderersGetInjected()
     {
         $environment = new Environment();
 
-        $renderer = $this->getMockBuilder([InlineRendererInterface::class, EnvironmentAwareInterface::class, ConfigurationAwareInterface::class])->getMock();
-        $renderer->expects($this->once())->method('setEnvironment')->with($environment);
-        $renderer->expects($this->once())->method('setConfiguration');
-
+        $renderer = new FakeInlineRenderer();
         $environment->addInlineRenderer('', $renderer);
 
         // Trigger initialization
         $environment->getBlockParsers();
+
+        $this->assertSame($environment, $renderer->getEnvironment());
+        $this->assertNotNull($renderer->getConfig());
     }
 
     public function testInjectableDelimiterProcessorsGetInjected()
     {
         $environment = new Environment();
 
-        $processor = $this->getMockBuilder([DelimiterProcessorInterface::class, EnvironmentAwareInterface::class, ConfigurationAwareInterface::class])->getMock();
-        $processor->expects($this->once())->method('setEnvironment')->with($environment);
-        $processor->expects($this->once())->method('setConfiguration');
-
+        $processor = new FakeDelimiterProcessor();
         $environment->addDelimiterProcessor($processor);
 
         // Trigger initialization
         $environment->getBlockParsers();
+
+        $this->assertSame($environment, $processor->getEnvironment());
+        $this->assertNotNull($processor->getConfig());
     }
 
     public function testInjectableEventListenersGetInjected()
@@ -575,11 +566,9 @@ class EnvironmentTest extends TestCase
         $this->assertEquals('b', $actualOrder[2]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testAddEventListenerFailsAfterInitialization()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = new Environment();
         $event = $this->createMock(AbstractEvent::class);
 

--- a/tests/unit/Extension/Autolink/InlineMentionParserTest.php
+++ b/tests/unit/Extension/Autolink/InlineMentionParserTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @deprecated
+ *
+ * @group legacy
  */
 final class InlineMentionParserTest extends TestCase
 {

--- a/tests/unit/Extension/HeadingPermalink/Slug/DefaultSlugGeneratorTest.php
+++ b/tests/unit/Extension/HeadingPermalink/Slug/DefaultSlugGeneratorTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @deprecated
+ *
+ * @group legacy
  */
 final class DefaultSlugGeneratorTest extends TestCase
 {

--- a/tests/unit/Extension/SmartPunct/QuoteRendererTest.php
+++ b/tests/unit/Extension/SmartPunct/QuoteRendererTest.php
@@ -31,17 +31,16 @@ final class QuoteRendererTest extends TestCase
     /** @var ElementRendererInterface */
     private $htmlRenderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new QuoteRenderer();
         $this->htmlRenderer = $this->createMock(ElementRendererInterface::class);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidInlineType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->createMock(Text::class);
 
         $this->renderer->render($inline, $this->htmlRenderer);

--- a/tests/unit/Extension/SmartPunct/SmartPunctExtensionTest.php
+++ b/tests/unit/Extension/SmartPunct/SmartPunctExtensionTest.php
@@ -29,7 +29,7 @@ final class SmartPunctExtensionTest extends TestCase
      */
     protected $environment;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->environment = Environment::createCommonMarkEnvironment();
         $this->environment->addExtension(new SmartPunctExtension());

--- a/tests/unit/Extension/Strikethrough/StrikethroughRendererTest.php
+++ b/tests/unit/Extension/Strikethrough/StrikethroughRendererTest.php
@@ -25,7 +25,7 @@ class StrikethroughRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new StrikethroughRenderer();
     }
@@ -40,15 +40,14 @@ class StrikethroughRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('del', $result->getTagName());
-        $this->assertContains('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
         $this->assertEquals(['id' => 'some"&amp;id'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidNodeType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = new Text('ruh roh');
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Extension/TableOfContents/TableOfContentsDeprecationTest.php
+++ b/tests/unit/Extension/TableOfContents/TableOfContentsDeprecationTest.php
@@ -16,6 +16,9 @@ use League\CommonMark\Extension\TableOfContents\Node\TableOfContents as NewTable
 use League\CommonMark\Extension\TableOfContents\TableOfContents as DeprecatedTableOfContents;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TableOfContentsDeprecationTest extends TestCase
 {
     /**

--- a/tests/unit/Extension/TaskList/TaskListItemMarkerRendererTest.php
+++ b/tests/unit/Extension/TaskList/TaskListItemMarkerRendererTest.php
@@ -50,11 +50,10 @@ class TaskListItemMarkerRendererTest extends TestCase
         $this->assertNull($result->getAttribute('checked'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testWithInvalidInlineElement()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $renderer = new TaskListItemMarkerRenderer();
         $htmlRenderer = $this->getMockForAbstractClass(ElementRendererInterface::class);
 

--- a/tests/unit/HtmlElementTest.php
+++ b/tests/unit/HtmlElementTest.php
@@ -89,7 +89,7 @@ class HtmlElementTest extends TestCase
         $div = new HtmlElement('div');
         $div->setContents([$p, $img]);
 
-        $this->assertInternalType('string', $div->getContents(true));
+        $this->assertIsString($div->getContents(true));
         $this->assertEquals('<p></p><img />', $div->getContents(true));
 
         $this->assertEquals('<div><p></p><img /></div>', $div->__toString());

--- a/tests/unit/HtmlRendererTest.php
+++ b/tests/unit/HtmlRendererTest.php
@@ -24,11 +24,9 @@ class HtmlRendererTest extends TestCase
         $renderer->renderBlock(new Paragraph());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testRenderBlockWithMissingRenderer()
     {
+        $this->expectException(\RuntimeException::class);
         $environment = $this->createMock(EnvironmentInterface::class);
         $environment->method('getBlockRenderersForClass')->willReturn([]);
 
@@ -48,11 +46,10 @@ class HtmlRendererTest extends TestCase
         $renderer->renderInline(new Text());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testRenderInlineWithMissingRenderer()
     {
+        $this->expectException(\RuntimeException::class);
+
         $environment = $this->createMock(EnvironmentInterface::class);
         $environment->method('getInlineRenderersForClass')->willReturn([]);
 

--- a/tests/unit/Inline/Renderer/CodeRendererTest.php
+++ b/tests/unit/Inline/Renderer/CodeRendererTest.php
@@ -28,7 +28,7 @@ class CodeRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new CodeRenderer();
     }
@@ -43,15 +43,14 @@ class CodeRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('code', $result->getTagName());
-        $this->assertContains('echo &quot;hello world&quot;;', $result->getContents(true));
+        $this->assertStringContainsString('echo &quot;hello world&quot;;', $result->getContents(true));
         $this->assertEquals(['id' => 'foo'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Inline/Renderer/EmphasisRendererTest.php
+++ b/tests/unit/Inline/Renderer/EmphasisRendererTest.php
@@ -28,7 +28,7 @@ class EmphasisRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new EmphasisRenderer();
     }
@@ -43,15 +43,14 @@ class EmphasisRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('em', $result->getTagName());
-        $this->assertContains('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
         $this->assertEquals(['id' => 'foo'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/HtmlInlineRendererTest.php
@@ -29,7 +29,7 @@ class HtmlInlineRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new HtmlInlineRenderer();
         $this->renderer->setConfiguration(new Configuration());
@@ -42,8 +42,8 @@ class HtmlInlineRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('<h1>Test</h1>', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('<h1>Test</h1>', $result);
     }
 
     public function testRenderAllowHtml()
@@ -57,8 +57,8 @@ class HtmlInlineRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('<h1>Test</h1>', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('<h1>Test</h1>', $result);
     }
 
     public function testRenderEscapeHtml()
@@ -72,8 +72,8 @@ class HtmlInlineRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('&lt;h1 class="test"&gt;Test&lt;/h1&gt;', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('&lt;h1 class="test"&gt;Test&lt;/h1&gt;', $result);
     }
 
     public function testRenderStripHtml()
@@ -87,15 +87,14 @@ class HtmlInlineRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
+        $this->assertIsString($result);
         $this->assertEquals('', $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Inline/Renderer/ImageRendererTest.php
+++ b/tests/unit/Inline/Renderer/ImageRendererTest.php
@@ -29,7 +29,7 @@ class ImageRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new ImageRenderer();
         $this->renderer->setConfiguration(new Configuration());
@@ -45,11 +45,11 @@ class ImageRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('img', $result->getTagName());
-        $this->assertContains('http://example.com/foo.jpg', $result->getAttribute('src'));
-        $this->assertContains('foo.jpg', $result->getAttribute('src'));
-        $this->assertContains('::inlines::', $result->getAttribute('alt'));
-        $this->assertContains('::title::', $result->getAttribute('title'));
-        $this->assertContains('::id::', $result->getAttribute('id'));
+        $this->assertStringContainsString('http://example.com/foo.jpg', $result->getAttribute('src'));
+        $this->assertStringContainsString('foo.jpg', $result->getAttribute('src'));
+        $this->assertStringContainsString('::inlines::', $result->getAttribute('alt'));
+        $this->assertStringContainsString('::title::', $result->getAttribute('title'));
+        $this->assertStringContainsString('::id::', $result->getAttribute('id'));
     }
 
     public function testRenderWithoutTitle()
@@ -61,9 +61,9 @@ class ImageRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('img', $result->getTagName());
-        $this->assertContains('http://example.com/foo.jpg', $result->getAttribute('src'));
-        $this->assertContains('foo.jpg', $result->getAttribute('src'));
-        $this->assertContains('::inlines::', $result->getAttribute('alt'));
+        $this->assertStringContainsString('http://example.com/foo.jpg', $result->getAttribute('src'));
+        $this->assertStringContainsString('foo.jpg', $result->getAttribute('src'));
+        $this->assertStringContainsString('::inlines::', $result->getAttribute('alt'));
         $this->assertNull($result->getAttribute('title'));
     }
 
@@ -79,7 +79,7 @@ class ImageRendererTest extends TestCase
         $result = $this->renderer->render($inline, $fakeRenderer);
 
         $this->assertTrue($result instanceof HtmlElement);
-        $this->assertContains('javascript:void(0)', $result->getAttribute('src'));
+        $this->assertStringContainsString('javascript:void(0)', $result->getAttribute('src'));
     }
 
     public function testRenderDisallowUnsafeLink()
@@ -97,11 +97,10 @@ class ImageRendererTest extends TestCase
         $this->assertEquals('', $result->getAttribute('src'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Inline/Renderer/LinkRendererTest.php
+++ b/tests/unit/Inline/Renderer/LinkRendererTest.php
@@ -29,7 +29,7 @@ class LinkRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new LinkRenderer();
         $this->renderer->setConfiguration(new Configuration());
@@ -45,10 +45,10 @@ class LinkRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('a', $result->getTagName());
-        $this->assertContains('http://example.com/foo.html', $result->getAttribute('href'));
-        $this->assertContains('::title::', $result->getAttribute('title'));
-        $this->assertContains('::inlines::', $result->getContents(true));
-        $this->assertContains('::id::', $result->getAttribute('id'));
+        $this->assertStringContainsString('http://example.com/foo.html', $result->getAttribute('href'));
+        $this->assertStringContainsString('::title::', $result->getAttribute('title'));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::id::', $result->getAttribute('id'));
     }
 
     public function testRenderWithoutTitle()
@@ -60,9 +60,9 @@ class LinkRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('a', $result->getTagName());
-        $this->assertContains('http://example.com/foo.html', $result->getAttribute('href'));
+        $this->assertStringContainsString('http://example.com/foo.html', $result->getAttribute('href'));
         $this->assertNull($result->getAttribute('title'));
-        $this->assertContains('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
     }
 
     public function testRenderAllowUnsafeLink()
@@ -77,7 +77,7 @@ class LinkRendererTest extends TestCase
         $result = $this->renderer->render($inline, $fakeRenderer);
 
         $this->assertTrue($result instanceof HtmlElement);
-        $this->assertContains('javascript:void(0)', $result->getAttribute('href'));
+        $this->assertStringContainsString('javascript:void(0)', $result->getAttribute('href'));
     }
 
     public function testRenderDisallowUnsafeLink()
@@ -95,11 +95,10 @@ class LinkRendererTest extends TestCase
         $this->assertEquals('', $result->getAttribute('href'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 
@@ -116,8 +115,8 @@ class LinkRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('a', $result->getTagName());
-        $this->assertContains('http://example.com/foo.html', $result->getAttribute('href'));
-        $this->assertContains('noopener', $result->getAttribute('rel'));
-        $this->assertContains('noreferrer', $result->getAttribute('rel'));
+        $this->assertStringContainsString('http://example.com/foo.html', $result->getAttribute('href'));
+        $this->assertStringContainsString('noopener', $result->getAttribute('rel'));
+        $this->assertStringContainsString('noreferrer', $result->getAttribute('rel'));
     }
 }

--- a/tests/unit/Inline/Renderer/NewlineRendererTest.php
+++ b/tests/unit/Inline/Renderer/NewlineRendererTest.php
@@ -27,7 +27,7 @@ class NewlineRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new NewlineRenderer();
     }
@@ -39,8 +39,8 @@ class NewlineRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('<br />', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('<br />', $result);
     }
 
     public function testRenderSoftbreak()
@@ -51,15 +51,14 @@ class NewlineRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('::softbreakChar::', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('::softbreakChar::', $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Inline/Renderer/StrongRendererTest.php
+++ b/tests/unit/Inline/Renderer/StrongRendererTest.php
@@ -28,7 +28,7 @@ class StrongRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new StrongRenderer();
     }
@@ -43,15 +43,14 @@ class StrongRendererTest extends TestCase
 
         $this->assertTrue($result instanceof HtmlElement);
         $this->assertEquals('strong', $result->getTagName());
-        $this->assertContains('::inlines::', $result->getContents(true));
+        $this->assertStringContainsString('::inlines::', $result->getContents(true));
         $this->assertEquals(['id' => 'foo'], $result->getAllAttributes());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/Inline/Renderer/TextRendererTest.php
+++ b/tests/unit/Inline/Renderer/TextRendererTest.php
@@ -27,7 +27,7 @@ class TextRendererTest extends TestCase
      */
     protected $renderer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->renderer = new TextRenderer();
     }
@@ -39,15 +39,14 @@ class TextRendererTest extends TestCase
 
         $result = $this->renderer->render($inline, $fakeRenderer);
 
-        $this->assertInternalType('string', $result);
-        $this->assertContains('foo bar', $result);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('foo bar', $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRenderWithInvalidType()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $inline = $this->getMockForAbstractClass(InlineElement\AbstractInline::class);
         $fakeRenderer = new FakeHtmlRenderer();
 

--- a/tests/unit/UnmatchedBlockCloserTest.php
+++ b/tests/unit/UnmatchedBlockCloserTest.php
@@ -36,11 +36,10 @@ class UnmatchedBlockCloserTest extends TestCase
         $this->assertTrue($closer->areAllClosed());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testResetTipWithNullTip()
     {
+        $this->expectException(\RuntimeException::class);
+
         $context = $this->getMockForAbstractClass(ContextInterface::class);
         $context->method('getTip')->willReturn(null);
 

--- a/tests/unit/Util/ArrayCollectionTest.php
+++ b/tests/unit/Util/ArrayCollectionTest.php
@@ -52,6 +52,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals($array, $iterator->getArrayCopy());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAdd()
     {
         $collection = new ArrayCollection();
@@ -64,6 +67,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $collection->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testSet()
     {
         $collection = new ArrayCollection(['foo']);
@@ -76,6 +82,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals(['foo', 'foo' => 2], $collection->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGet()
     {
         $collection = new ArrayCollection(['foo' => 1, 'bar']);
@@ -85,6 +94,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertNull($collection->get('bar'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemove()
     {
         $collection = new ArrayCollection(['foo' => 1, 'bar', 'baz']);
@@ -106,6 +118,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals([], $collection->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveNulls()
     {
         $collection = new ArrayCollection(['foo' => null]);
@@ -119,6 +134,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals([], $collection->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testIsEmpty()
     {
         $collection = new ArrayCollection();
@@ -135,6 +153,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertFalse($collection->isEmpty());
     }
 
+    /**
+     * @group legacy
+     */
     public function testContains()
     {
         $object = new \stdClass();
@@ -155,6 +176,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertFalse($collection->contains('FOO'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testIndexOf()
     {
         $object = new \stdClass();
@@ -175,6 +199,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertTrue(false === $collection->indexOf('FOO'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testContainsKey()
     {
         $collection = new ArrayCollection(['foo' => 1, 'bar']);
@@ -197,10 +224,10 @@ class ArrayCollectionTest extends TestCase
         $collection = new ArrayCollection(['foo']);
         $this->assertEquals(1, $collection->count());
 
-        $collection->add('bar');
+        $collection[] = 'bar';
         $this->assertEquals(2, $collection->count());
 
-        $collection->remove(0);
+        unset($collection[0]);
         $this->assertEquals(1, $collection->count());
     }
 
@@ -320,6 +347,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals([2 => 1, 'foo'], $collection->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testReplaceWith()
     {
         $collection = new ArrayCollection(['foo' => 1, 'bar']);
@@ -330,6 +360,9 @@ class ArrayCollectionTest extends TestCase
         $this->assertEquals(['baz', 42], $replaced->toArray());
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveGaps()
     {
         $collection = new ArrayCollection(['', true, false, null, [], 0, '0', 1]);

--- a/tests/unit/Util/Html5EntitiesTest.php
+++ b/tests/unit/Util/Html5EntitiesTest.php
@@ -5,6 +5,9 @@ namespace League\CommonMark\Tests\Unit\Util;
 use League\CommonMark\Util\Html5Entities;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class Html5EntitiesTest extends TestCase
 {
     public function testEntityToChar()

--- a/tests/unit/Util/RegexHelperTest.php
+++ b/tests/unit/Util/RegexHelperTest.php
@@ -23,246 +23,246 @@ class RegexHelperTest extends TestCase
     public function testEscapable()
     {
         $regex = '/^' . RegexHelper::PARTIAL_ESCAPABLE . '$/';
-        $this->assertRegExp($regex, '&');
-        $this->assertRegExp($regex, '/');
-        $this->assertRegExp($regex, '\\');
-        $this->assertRegExp($regex, '(');
-        $this->assertRegExp($regex, ')');
+        $this->assertRegexMatches($regex, '&');
+        $this->assertRegexMatches($regex, '/');
+        $this->assertRegexMatches($regex, '\\');
+        $this->assertRegexMatches($regex, '(');
+        $this->assertRegexMatches($regex, ')');
     }
 
     public function testEscapedChar()
     {
         $regex = '/^' . RegexHelper::PARTIAL_ESCAPED_CHAR . '$/';
-        $this->assertRegExp($regex, '\\&');
-        $this->assertRegExp($regex, '\\/');
-        $this->assertRegExp($regex, '\\\\');
-        $this->assertRegExp($regex, '\)');
-        $this->assertRegExp($regex, '\(');
+        $this->assertRegexMatches($regex, '\\&');
+        $this->assertRegexMatches($regex, '\\/');
+        $this->assertRegexMatches($regex, '\\\\');
+        $this->assertRegexMatches($regex, '\)');
+        $this->assertRegexMatches($regex, '\(');
     }
 
     public function testInDoubleQuotes()
     {
         $regex = '/^' . RegexHelper::PARTIAL_IN_DOUBLE_QUOTES . '$/';
-        $this->assertRegExp($regex, '"\\&"');
-        $this->assertRegExp($regex, '"\\/"');
-        $this->assertRegExp($regex, '"\\\\"');
+        $this->assertRegexMatches($regex, '"\\&"');
+        $this->assertRegexMatches($regex, '"\\/"');
+        $this->assertRegexMatches($regex, '"\\\\"');
     }
 
     public function testInSingleQuotes()
     {
         $regex = '/^' . RegexHelper::PARTIAL_IN_SINGLE_QUOTES . '$/';
-        $this->assertRegExp($regex, '\'\\&\'');
-        $this->assertRegExp($regex, '\'\\/\'');
-        $this->assertRegExp($regex, '\'\\\\\'');
+        $this->assertRegexMatches($regex, '\'\\&\'');
+        $this->assertRegexMatches($regex, '\'\\/\'');
+        $this->assertRegexMatches($regex, '\'\\\\\'');
     }
 
     public function testInParens()
     {
         $regex = '/^' . RegexHelper::PARTIAL_IN_PARENS . '$/';
-        $this->assertRegExp($regex, '(\\&)');
-        $this->assertRegExp($regex, '(\\/)');
-        $this->assertRegExp($regex, '(\\\\)');
+        $this->assertRegexMatches($regex, '(\\&)');
+        $this->assertRegexMatches($regex, '(\\/)');
+        $this->assertRegexMatches($regex, '(\\\\)');
     }
 
     public function testRegChar()
     {
         $regex = '/^' . RegexHelper::PARTIAL_REG_CHAR . '$/';
-        $this->assertRegExp($regex, 'a');
-        $this->assertRegExp($regex, 'A');
-        $this->assertRegExp($regex, '!');
-        $this->assertNotRegExp($regex, ' ');
+        $this->assertRegexMatches($regex, 'a');
+        $this->assertRegexMatches($regex, 'A');
+        $this->assertRegexMatches($regex, '!');
+        $this->assertRegexDoesNotMatch($regex, ' ');
     }
 
     public function testInParensNoSp()
     {
         $regex = '/^' . RegexHelper::PARTIAL_IN_PARENS_NOSP . '$/';
-        $this->assertRegExp($regex, '(a)');
-        $this->assertRegExp($regex, '(A)');
-        $this->assertRegExp($regex, '(!)');
-        $this->assertNotRegExp($regex, '(a )');
+        $this->assertRegexMatches($regex, '(a)');
+        $this->assertRegexMatches($regex, '(A)');
+        $this->assertRegexMatches($regex, '(!)');
+        $this->assertRegexDoesNotMatch($regex, '(a )');
     }
 
     public function testTagname()
     {
         $regex = '/^' . RegexHelper::PARTIAL_TAGNAME . '$/';
-        $this->assertRegExp($regex, 'a');
-        $this->assertRegExp($regex, 'img');
-        $this->assertRegExp($regex, 'h1');
-        $this->assertNotRegExp($regex, '11');
+        $this->assertRegexMatches($regex, 'a');
+        $this->assertRegexMatches($regex, 'img');
+        $this->assertRegexMatches($regex, 'h1');
+        $this->assertRegexDoesNotMatch($regex, '11');
     }
 
     public function testBlockTagName()
     {
         $regex = '/^' . RegexHelper::PARTIAL_BLOCKTAGNAME . '$/';
-        $this->assertRegExp($regex, 'p');
-        $this->assertRegExp($regex, 'div');
-        $this->assertRegExp($regex, 'h1');
-        $this->assertNotRegExp($regex, 'a');
-        $this->assertNotRegExp($regex, 'h7');
+        $this->assertRegexMatches($regex, 'p');
+        $this->assertRegexMatches($regex, 'div');
+        $this->assertRegexMatches($regex, 'h1');
+        $this->assertRegexDoesNotMatch($regex, 'a');
+        $this->assertRegexDoesNotMatch($regex, 'h7');
     }
 
     public function testAttributeName()
     {
         $regex = '/^' . RegexHelper::PARTIAL_ATTRIBUTENAME . '$/';
-        $this->assertRegExp($regex, 'href');
-        $this->assertRegExp($regex, 'class');
-        $this->assertRegExp($regex, 'data-src');
-        $this->assertNotRegExp($regex, '-key');
+        $this->assertRegexMatches($regex, 'href');
+        $this->assertRegexMatches($regex, 'class');
+        $this->assertRegexMatches($regex, 'data-src');
+        $this->assertRegexDoesNotMatch($regex, '-key');
     }
 
     public function testUnquotedValue()
     {
         $regex = '/^' . RegexHelper::PARTIAL_UNQUOTEDVALUE . '$/';
-        $this->assertRegExp($regex, 'foo');
-        $this->assertRegExp($regex, 'bar');
-        $this->assertNotRegExp($regex, '"baz"');
+        $this->assertRegexMatches($regex, 'foo');
+        $this->assertRegexMatches($regex, 'bar');
+        $this->assertRegexDoesNotMatch($regex, '"baz"');
     }
 
     public function testSingleQuotedValue()
     {
         $regex = '/^' . RegexHelper::PARTIAL_SINGLEQUOTEDVALUE . '$/';
-        $this->assertRegExp($regex, '\'foo\'');
-        $this->assertRegExp($regex, '\'bar\'');
-        $this->assertNotRegExp($regex, '"baz"');
+        $this->assertRegexMatches($regex, '\'foo\'');
+        $this->assertRegexMatches($regex, '\'bar\'');
+        $this->assertRegexDoesNotMatch($regex, '"baz"');
     }
 
     public function testDoubleQuotedValue()
     {
         $regex = '/^' . RegexHelper::PARTIAL_DOUBLEQUOTEDVALUE . '$/';
-        $this->assertRegExp($regex, '"foo"');
-        $this->assertRegExp($regex, '"bar"');
-        $this->assertNotRegExp($regex, '\'baz\'');
+        $this->assertRegexMatches($regex, '"foo"');
+        $this->assertRegexMatches($regex, '"bar"');
+        $this->assertRegexDoesNotMatch($regex, '\'baz\'');
     }
 
     public function testAttributeValue()
     {
         $regex = '/^' . RegexHelper::PARTIAL_ATTRIBUTEVALUE . '$/';
-        $this->assertRegExp($regex, 'foo');
-        $this->assertRegExp($regex, '\'bar\'');
-        $this->assertRegExp($regex, '"baz"');
+        $this->assertRegexMatches($regex, 'foo');
+        $this->assertRegexMatches($regex, '\'bar\'');
+        $this->assertRegexMatches($regex, '"baz"');
     }
 
     public function testAttributeValueSpec()
     {
         $regex = '/^' . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . '$/';
-        $this->assertRegExp($regex, '=foo');
-        $this->assertRegExp($regex, '= foo');
-        $this->assertRegExp($regex, ' =foo');
-        $this->assertRegExp($regex, ' = foo');
-        $this->assertRegExp($regex, '=\'bar\'');
-        $this->assertRegExp($regex, '= \'bar\'');
-        $this->assertRegExp($regex, ' =\'bar\'');
-        $this->assertRegExp($regex, ' = \'bar\'');
-        $this->assertRegExp($regex, '="baz"');
-        $this->assertRegExp($regex, '= "baz"');
-        $this->assertRegExp($regex, ' ="baz"');
-        $this->assertRegExp($regex, ' = "baz"');
+        $this->assertRegexMatches($regex, '=foo');
+        $this->assertRegexMatches($regex, '= foo');
+        $this->assertRegexMatches($regex, ' =foo');
+        $this->assertRegexMatches($regex, ' = foo');
+        $this->assertRegexMatches($regex, '=\'bar\'');
+        $this->assertRegexMatches($regex, '= \'bar\'');
+        $this->assertRegexMatches($regex, ' =\'bar\'');
+        $this->assertRegexMatches($regex, ' = \'bar\'');
+        $this->assertRegexMatches($regex, '="baz"');
+        $this->assertRegexMatches($regex, '= "baz"');
+        $this->assertRegexMatches($regex, ' ="baz"');
+        $this->assertRegexMatches($regex, ' = "baz"');
     }
 
     public function testAttribute()
     {
         $regex = '/^' . RegexHelper::PARTIAL_ATTRIBUTE . '$/';
-        $this->assertRegExp($regex, ' disabled');
-        $this->assertRegExp($regex, ' disabled="disabled"');
-        $this->assertRegExp($regex, ' href="http://www.google.com"');
-        $this->assertNotRegExp($regex, 'disabled', 'There must be at least one space at the start');
+        $this->assertRegexMatches($regex, ' disabled');
+        $this->assertRegexMatches($regex, ' disabled="disabled"');
+        $this->assertRegexMatches($regex, ' href="http://www.google.com"');
+        $this->assertRegexDoesNotMatch($regex, 'disabled', 'There must be at least one space at the start');
     }
 
     public function testOpenTag()
     {
         $regex = '/^' . RegexHelper::PARTIAL_OPENTAG . '$/';
-        $this->assertRegExp($regex, '<hr>');
-        $this->assertRegExp($regex, '<a href="http://www.google.com">');
-        $this->assertRegExp($regex, '<img src="http://www.google.com/logo.png" />');
-        $this->assertNotRegExp($regex, '</p>');
+        $this->assertRegexMatches($regex, '<hr>');
+        $this->assertRegexMatches($regex, '<a href="http://www.google.com">');
+        $this->assertRegexMatches($regex, '<img src="http://www.google.com/logo.png" />');
+        $this->assertRegexDoesNotMatch($regex, '</p>');
     }
 
     public function testCloseTag()
     {
         $regex = '/^' . RegexHelper::PARTIAL_CLOSETAG . '$/';
-        $this->assertRegExp($regex, '</p>');
-        $this->assertRegExp($regex, '</a>');
-        $this->assertNotRegExp($regex, '<hr>');
-        $this->assertNotRegExp($regex, '<img src="http://www.google.com/logo.png" />');
+        $this->assertRegexMatches($regex, '</p>');
+        $this->assertRegexMatches($regex, '</a>');
+        $this->assertRegexDoesNotMatch($regex, '<hr>');
+        $this->assertRegexDoesNotMatch($regex, '<img src="http://www.google.com/logo.png" />');
     }
 
     public function testOpenBlockTag()
     {
         $regex = '/^' . RegexHelper::PARTIAL_OPENBLOCKTAG . '$/';
-        $this->assertRegExp($regex, '<body>');
-        $this->assertRegExp($regex, '<hr>');
-        $this->assertRegExp($regex, '<hr />');
-        $this->assertRegExp($regex, '<p id="foo" class="bar">');
-        $this->assertNotRegExp($regex, '<a href="http://www.google.com">', 'This is not a block element');
-        $this->assertNotRegExp($regex, '</p>', 'This is not an opening tag');
+        $this->assertRegexMatches($regex, '<body>');
+        $this->assertRegexMatches($regex, '<hr>');
+        $this->assertRegexMatches($regex, '<hr />');
+        $this->assertRegexMatches($regex, '<p id="foo" class="bar">');
+        $this->assertRegexDoesNotMatch($regex, '<a href="http://www.google.com">', 'This is not a block element');
+        $this->assertRegexDoesNotMatch($regex, '</p>', 'This is not an opening tag');
     }
 
     public function testCloseBlockTag()
     {
         $regex = '/^' . RegexHelper::PARTIAL_CLOSEBLOCKTAG . '$/';
-        $this->assertRegExp($regex, '</body>');
-        $this->assertRegExp($regex, '</p>');
-        $this->assertNotRegExp($regex, '</a>', 'This is not a block element');
-        $this->assertNotRegExp($regex, '<br>', 'This is not a closing tag');
+        $this->assertRegexMatches($regex, '</body>');
+        $this->assertRegexMatches($regex, '</p>');
+        $this->assertRegexDoesNotMatch($regex, '</a>', 'This is not a block element');
+        $this->assertRegexDoesNotMatch($regex, '<br>', 'This is not a closing tag');
     }
 
     public function testHtmlComment()
     {
         $regex = '/^' . RegexHelper::PARTIAL_HTMLCOMMENT . '$/';
-        $this->assertRegExp($regex, '<!---->');
-        $this->assertRegExp($regex, '<!-- -->');
-        $this->assertRegExp($regex, '<!-- HELLO WORLD -->');
-        $this->assertNotRegExp($regex, '<!->');
-        $this->assertNotRegExp($regex, '<!-->');
-        $this->assertNotRegExp($regex, '<!--->');
-        $this->assertNotRegExp($regex, '<!- ->');
+        $this->assertRegexMatches($regex, '<!---->');
+        $this->assertRegexMatches($regex, '<!-- -->');
+        $this->assertRegexMatches($regex, '<!-- HELLO WORLD -->');
+        $this->assertRegexDoesNotMatch($regex, '<!->');
+        $this->assertRegexDoesNotMatch($regex, '<!-->');
+        $this->assertRegexDoesNotMatch($regex, '<!--->');
+        $this->assertRegexDoesNotMatch($regex, '<!- ->');
     }
 
     public function testProcessingInstruction()
     {
         $regex = '/^' . RegexHelper::PARTIAL_PROCESSINGINSTRUCTION . '$/';
-        $this->assertRegExp($regex, '<?PITarget PIContent?>');
-        $this->assertRegExp($regex, '<?xml-stylesheet type="text/xsl" href="style.xsl"?>');
+        $this->assertRegexMatches($regex, '<?PITarget PIContent?>');
+        $this->assertRegexMatches($regex, '<?xml-stylesheet type="text/xsl" href="style.xsl"?>');
     }
 
     public function testDeclaration()
     {
         $regex = '/^' . RegexHelper::PARTIAL_DECLARATION . '$/';
-        $this->assertRegExp($regex, '<!DOCTYPE html>');
-        $this->assertRegExp($regex, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">');
-        $this->assertRegExp($regex, '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">');
+        $this->assertRegexMatches($regex, '<!DOCTYPE html>');
+        $this->assertRegexMatches($regex, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">');
+        $this->assertRegexMatches($regex, '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">');
     }
 
     public function testCDATA()
     {
         $regex = '/^' . RegexHelper::PARTIAL_CDATA . '$/';
-        $this->assertRegExp($regex, '<![CDATA[<sender>John Smith</sender>]]>');
-        $this->assertRegExp($regex, '<![CDATA[]]]]><![CDATA[>]]>');
+        $this->assertRegexMatches($regex, '<![CDATA[<sender>John Smith</sender>]]>');
+        $this->assertRegexMatches($regex, '<![CDATA[]]]]><![CDATA[>]]>');
     }
 
     public function testHtmlTag()
     {
         $regex = '/^' . RegexHelper::PARTIAL_HTMLTAG . '$/';
-        $this->assertRegExp($regex, '<body id="main">');
-        $this->assertRegExp($regex, '</p>');
-        $this->assertRegExp($regex, '<!-- HELLO WORLD -->');
-        $this->assertRegExp($regex, '<?xml-stylesheet type="text/xsl" href="style.xsl"?>');
-        $this->assertRegExp($regex, '<!DOCTYPE html>');
-        $this->assertRegExp($regex, '<![CDATA[<sender>John Smith</sender>]]>');
+        $this->assertRegexMatches($regex, '<body id="main">');
+        $this->assertRegexMatches($regex, '</p>');
+        $this->assertRegexMatches($regex, '<!-- HELLO WORLD -->');
+        $this->assertRegexMatches($regex, '<?xml-stylesheet type="text/xsl" href="style.xsl"?>');
+        $this->assertRegexMatches($regex, '<!DOCTYPE html>');
+        $this->assertRegexMatches($regex, '<![CDATA[<sender>John Smith</sender>]]>');
     }
 
     public function testHtmlBlockOpen()
     {
         $regex = '/^' . RegexHelper::PARTIAL_HTMLBLOCKOPEN . '$/';
-        $this->assertRegExp($regex, '<h1>');
-        $this->assertRegExp($regex, '</p>');
+        $this->assertRegexMatches($regex, '<h1>');
+        $this->assertRegexMatches($regex, '</p>');
     }
 
     public function testLinkTitle()
     {
         $regex = '/^' . RegexHelper::PARTIAL_HTMLBLOCKOPEN . '$/';
-        $this->assertRegExp($regex, '<h1>');
-        $this->assertRegExp($regex, '</p>');
+        $this->assertRegexMatches($regex, '<h1>');
+        $this->assertRegexMatches($regex, '</p>');
     }
 
     public function testUnescape()
@@ -330,11 +330,10 @@ class RegexHelperTest extends TestCase
         yield [HtmlBlock::TYPE_7_MISC_ELEMENT];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidHtmlBlockOpenRegex()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         RegexHelper::getHtmlBlockOpenRegex(8);
     }
 
@@ -361,10 +360,11 @@ class RegexHelperTest extends TestCase
      * @param int $type
      *
      * @dataProvider blockTypesWithInvalidCloserRegexes
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidHtmlBlockCloseRegex(int $type)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         RegexHelper::getHtmlBlockCloseRegex($type);
     }
 
@@ -373,5 +373,23 @@ class RegexHelperTest extends TestCase
         yield [HtmlBlock::TYPE_6_BLOCK_ELEMENT];
         yield [HtmlBlock::TYPE_7_MISC_ELEMENT];
         yield [8];
+    }
+
+    private function assertRegexMatches(string $pattern, string $string, string $message = ''): void
+    {
+        if (\method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            $this->assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    private function assertRegexDoesNotMatch(string $pattern, string $string, string $message = ''): void
+    {
+        if (\method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertDoesNotMatchRegularExpression($pattern, $string, $message);
+        } else {
+            $this->assertNotRegExp($pattern, $string, $message);
+        }
     }
 }


### PR DESCRIPTION
"match" is now a semi-reserved keyword in PHP 8, so we need the patch from https://github.com/sebastianbergmann/phpunit/pull/4374 in order for our tests to run.