### PR TITLE
Removed a typo from the sponsors block.

### DIFF
--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -115,7 +115,7 @@
           </li>
           <li>
             <a href="https://www.ripstech.com/">RIPS Technologies</a> for supporting this project with a complimentary
-            <a href="https://www.ripstech.com/product/">RIPS SaaS</a>a> license
+            <a href="https://www.ripstech.com/product/">RIPS SaaS</a> license
           </li>
           <li>
             <a href="https://www.jetbrains.com/">JetBrains</a> for supporting this project with complimentary


### PR DESCRIPTION
On the website the displayed: 
`RIPS SaaSa>` 
Which wasn't intended as far as I know.
So I removed it.