### PR TITLE
Add link to lazy image extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Custom parsers/renderers can be bundled into extensions which extend CommonMark.
  - [Alt Three Emoji](https://github.com/AltThree/Emoji) An emoji parser for CommonMark.
  - [Sup Sub extensions](https://github.com/OWS/commonmark-sup-sub-extensions) - Adds support of superscript and subscript (`<sup>` and `<sub>` HTML tags)
  - [YouTube iframe extension](https://github.com/zoonru/commonmark-ext-youtube-iframe) - Replaces youtube link with iframe.
+ - [Lazy Image extension](https://github.com/simonvomeyser/commonmark-ext-lazy-image) - Adds various options for lazy loading of images.
 
 Others can be found on [Packagist under the `commonmark-extension` package type](https://packagist.org/packages/league/commonmark?type=commonmark-extension).
 


### PR DESCRIPTION
Heyho folks!

Thanks for your awesome work on this library :) 

I created a small extension for my own blogging platform which adds options to lazy load images natively or to integrate with various js libs.

Hope everything is fine and dandy with this PR, feel free to give me any hints if something is missing here or in my extension.

Have cool day and best wishes 👍
Simon vom Eyser