### PR TITLE
Fix hard-coded footnote ID config

### DIFF
--- a/src/Extension/Footnote/Event/AnonymousFootnotesListener.php
+++ b/src/Extension/Footnote/Event/AnonymousFootnotesListener.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Footnote\Event;
 
 use League\CommonMark\Block\Element\Paragraph;
-use League\CommonMark\Configuration\ConfigurationAwareInterface;
-use League\CommonMark\Configuration\ConfigurationInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;

--- a/src/Extension/Footnote/Event/AnonymousFootnotesListener.php
+++ b/src/Extension/Footnote/Event/AnonymousFootnotesListener.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Footnote\Event;
 
 use League\CommonMark\Block\Element\Paragraph;
+use League\CommonMark\Configuration\ConfigurationAwareInterface;
+use League\CommonMark\Configuration\ConfigurationInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;
@@ -22,8 +24,11 @@ use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Reference\Reference;
 
-final class AnonymousFootnotesListener
+final class AnonymousFootnotesListener implements ConfigurationAwareInterface
 {
+    /** @var ConfigurationInterface */
+    private $config;
+
     public function onDocumentParsed(DocumentParsedEvent $event): void
     {
         $document = $event->getDocument();
@@ -36,7 +41,7 @@ final class AnonymousFootnotesListener
                 $existingReference = $node->getReference();
                 $reference = new Reference(
                     $existingReference->getLabel(),
-                    '#fnref:' . $existingReference->getLabel(),
+                    '#' . $this->config->get('footnote/ref_id_prefix', 'fnref:') . $existingReference->getLabel(),
                     $existingReference->getTitle()
                 );
                 $footnote = new Footnote($reference);
@@ -47,5 +52,10 @@ final class AnonymousFootnotesListener
                 $document->appendChild($footnote);
             }
         }
+    }
+
+    public function setConfiguration(ConfigurationInterface $config): void
+    {
+        $this->config = $config;
     }
 }

--- a/src/Extension/Footnote/Event/AnonymousFootnotesListener.php
+++ b/src/Extension/Footnote/Event/AnonymousFootnotesListener.php
@@ -15,14 +15,14 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Footnote\Event;
 
 use League\CommonMark\Block\Element\Paragraph;
-use League\CommonMark\Util\ConfigurationAwareInterface;
-use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Reference\Reference;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 
 final class AnonymousFootnotesListener implements ConfigurationAwareInterface
 {

--- a/src/Extension/Footnote/Event/GatherFootnotesListener.php
+++ b/src/Extension/Footnote/Event/GatherFootnotesListener.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Footnote\Event;
 
 use League\CommonMark\Block\Element\Document;
-use League\CommonMark\Configuration\ConfigurationAwareInterface;
-use League\CommonMark\Configuration\ConfigurationInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;

--- a/src/Extension/Footnote/Event/GatherFootnotesListener.php
+++ b/src/Extension/Footnote/Event/GatherFootnotesListener.php
@@ -15,14 +15,19 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Footnote\Event;
 
 use League\CommonMark\Block\Element\Document;
+use League\CommonMark\Configuration\ConfigurationAwareInterface;
+use League\CommonMark\Configuration\ConfigurationInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;
 use League\CommonMark\Extension\Footnote\Node\FootnoteContainer;
 use League\CommonMark\Reference\Reference;
 
-final class GatherFootnotesListener
+final class GatherFootnotesListener implements ConfigurationAwareInterface
 {
+    /** @var ConfigurationInterface */
+    private $config;
+
     public function onDocumentParsed(DocumentParsedEvent $event): void
     {
         $document = $event->getDocument();
@@ -53,12 +58,15 @@ final class GatherFootnotesListener
              * Look for all footnote refs pointing to this footnote
              * and create each footnote backrefs.
              */
-            $backrefs = $document->getData('#fn:' . $node->getReference()->getDestination(), []);
+            $backrefs = $document->getData(
+                '#' . $this->config->get('footnote/footnote_id_prefix', 'fn:') . $node->getReference()->getDestination(),
+                []
+            );
             /** @var Reference $backref */
             foreach ($backrefs as $backref) {
                 $node->addBackref(new FootnoteBackref(new Reference(
                     $backref->getLabel(),
-                    '#fnref:' . $backref->getLabel(),
+                    '#' . $this->config->get('footnote/ref_id_prefix', 'fnref:') . $backref->getLabel(),
                     $backref->getTitle()
                 )));
             }
@@ -83,5 +91,10 @@ final class GatherFootnotesListener
         $document->appendChild($footnoteContainer);
 
         return $footnoteContainer;
+    }
+
+    public function setConfiguration(ConfigurationInterface $config): void
+    {
+        $this->config = $config;
     }
 }

--- a/src/Extension/Footnote/Event/GatherFootnotesListener.php
+++ b/src/Extension/Footnote/Event/GatherFootnotesListener.php
@@ -15,13 +15,13 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Footnote\Event;
 
 use League\CommonMark\Block\Element\Document;
-use League\CommonMark\Util\ConfigurationAwareInterface;
-use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;
 use League\CommonMark\Extension\Footnote\Node\FootnoteContainer;
 use League\CommonMark\Reference\Reference;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 
 final class GatherFootnotesListener implements ConfigurationAwareInterface
 {

--- a/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Footnote\Parser;
 
-use League\CommonMark\Util\ConfigurationAwareInterface;
-use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;
 use League\CommonMark\Normalizer\SlugNormalizer;
 use League\CommonMark\Normalizer\TextNormalizerInterface;
 use League\CommonMark\Reference\Reference;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 
 final class AnonymousFootnoteRefParser implements InlineParserInterface, ConfigurationAwareInterface
 {

--- a/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Footnote\Parser;
 
+use League\CommonMark\Configuration\ConfigurationAwareInterface;
+use League\CommonMark\Configuration\ConfigurationInterface;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;
@@ -21,8 +23,11 @@ use League\CommonMark\Normalizer\SlugNormalizer;
 use League\CommonMark\Normalizer\TextNormalizerInterface;
 use League\CommonMark\Reference\Reference;
 
-final class AnonymousFootnoteRefParser implements InlineParserInterface
+final class AnonymousFootnoteRefParser implements InlineParserInterface, ConfigurationAwareInterface
 {
+    /** @var ConfigurationInterface */
+    private $config;
+
     /** @var TextNormalizerInterface */
     private $slugNormalizer;
 
@@ -66,6 +71,15 @@ final class AnonymousFootnoteRefParser implements InlineParserInterface
         $refLabel = $this->slugNormalizer->normalize($label);
         $refLabel = \mb_substr($refLabel, 0, 20);
 
-        return new Reference($refLabel, '#fn:' . $refLabel, $label);
+        return new Reference(
+            $refLabel,
+            '#' . $this->config->get('footnote/footnote_id_prefix', 'fn:') . $refLabel,
+            $label
+        );
+    }
+
+    public function setConfiguration(ConfigurationInterface $config): void
+    {
+        $this->config = $config;
     }
 }

--- a/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Footnote\Parser;
 
-use League\CommonMark\Configuration\ConfigurationAwareInterface;
-use League\CommonMark\Configuration\ConfigurationInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;

--- a/src/Extension/Footnote/Parser/FootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/FootnoteRefParser.php
@@ -14,13 +14,18 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Footnote\Parser;
 
+use League\CommonMark\Configuration\ConfigurationAwareInterface;
+use League\CommonMark\Configuration\ConfigurationInterface;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;
 use League\CommonMark\Reference\Reference;
 
-final class FootnoteRefParser implements InlineParserInterface
+final class FootnoteRefParser implements InlineParserInterface, ConfigurationAwareInterface
 {
+    /** @var ConfigurationInterface */
+    private $config;
+
     public function getCharacters(): array
     {
         return ['['];
@@ -53,6 +58,15 @@ final class FootnoteRefParser implements InlineParserInterface
 
     private function createReference(string $label): Reference
     {
-        return new Reference($label, '#fn:' . $label, $label);
+        return new Reference(
+            $label,
+            '#' . $this->config->get('footnote/footnote_id_prefix', 'fn:') . $label,
+            $label
+        );
+    }
+
+    public function setConfiguration(ConfigurationInterface $config): void
+    {
+        $this->config = $config;
     }
 }

--- a/src/Extension/Footnote/Parser/FootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/FootnoteRefParser.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Footnote\Parser;
 
-use League\CommonMark\Configuration\ConfigurationAwareInterface;
-use League\CommonMark\Configuration\ConfigurationInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;

--- a/src/Extension/Footnote/Parser/FootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/FootnoteRefParser.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Footnote\Parser;
 
-use League\CommonMark\Util\ConfigurationAwareInterface;
-use League\CommonMark\Util\ConfigurationInterface;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
 use League\CommonMark\InlineParserContext;
 use League\CommonMark\Reference\Reference;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
 
 final class FootnoteRefParser implements InlineParserInterface, ConfigurationAwareInterface
 {

--- a/tests/unit/Extension/Footnote/IntegrationTest.php
+++ b/tests/unit/Extension/Footnote/IntegrationTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Unit\Extension\Footnote;
 
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment\Environment;
+use League\CommonMark\Environment;
 use League\CommonMark\Extension\Footnote\FootnoteExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -33,7 +33,7 @@ class IntegrationTest extends TestCase
 
         $converter = new CommonMarkConverter(['footnote' => $config], $environment);
 
-        $html = trim($converter->convertToHtml($string));
+        $html = \trim($converter->convertToHtml($string));
 
         $this->assertSame($expected, $html);
     }

--- a/tests/unit/Extension/Footnote/IntegrationTest.php
+++ b/tests/unit/Extension/Footnote/IntegrationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com> and uAfrica.com (http://uafrica.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Unit\Extension\Footnote;
+
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Footnote\FootnoteExtension;
+use PHPUnit\Framework\TestCase;
+
+class IntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider dataForIntegrationTest
+     */
+    public function testFootnote(string $string, string $expected, array $config = []): void
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new FootnoteExtension([
+            'ref_id_prefix' => 'custom-ref-',
+            'footnote_id_prefix' => 'custom-',
+        ]));
+
+        $converter = new CommonMarkConverter(['footnote' => $config], $environment);
+
+        $html = trim($converter->convertToHtml($string));
+
+        $this->assertSame($expected, $html);
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public function dataForIntegrationTest(): array
+    {
+        return [
+            [
+                "Here[^note1]\n\n[^note1]: There",
+                '<p>Here<sup id="fnref:note1"><a class="footnote-ref" href="#fn:note1" role="doc-noteref">1</a></sup></p>
+<div class="footnotes" role="doc-endnotes"><hr /><ol><li class="footnote" id="fn:note1" role="doc-endnote"><p>There&nbsp;<a class="footnote-backref" rev="footnote" href="#fnref:note1" role="doc-backlink">&#8617;</a></p></li></ol></div>',
+            ],
+            [
+                "Here[^note1]\n\n[^note1]: There",
+                '<p>Here<sup id="customfnref:note1"><a class="footnote-ref" href="#customfn:note1" role="doc-noteref">1</a></sup></p>
+<div class="footnotes" role="doc-endnotes"><hr /><ol><li class="footnote" id="customfn:note1" role="doc-endnote"><p>There&nbsp;<a class="footnote-backref" rev="footnote" href="#customfnref:note1" role="doc-backlink">&#8617;</a></p></li></ol></div>',
+                ['ref_id_prefix' => 'customfnref:', 'footnote_id_prefix' => 'customfn:'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR fixes #524 by removing hard-coded `fn:` and `fnref:` and ensuring that the `footnote/footnote_id_prefix` and `footnote/footnote_ref_prefix` configuration options are always used.

It updates the `AnonymousFootnotesListener`, `GatherFootnotesListener`, `AnonymousFootnoteRefParser`, and `FootnoteRefParser` classes to all be configuration-aware.

I added an integration test in the style of [`Strikethrough/IntegrationTest`](https://github.com/thephpleague/commonmark/blob/latest/tests/unit/Extension/Strikethrough/IntegrationTest.php) to make sure this works, I tried to add unit tests but I couldn't figure out how to render both a footnote _and_ its reference. I'm happy to add more tests if someone can point me in the right direction.