### PR TITLE
Fix non-static methods called as static '::' methods

### DIFF
--- a/src/Extension/Table/TableParser.php
+++ b/src/Extension/Table/TableParser.php
@@ -114,7 +114,7 @@ final class TableParser extends AbstractBlockContinueParser
         $head->appendChild($headerRow);
         for ($i = 0; $i < $headerColumns; $i++) {
             $cell      = $this->headerCells[$i];
-            $tableCell = self::parseCell($cell, $i, $inlineParser);
+            $tableCell = $this->parseCell($cell, $i, $inlineParser);
             $tableCell->setType(TableCell::TYPE_HEAD);
             $headerRow->appendChild($tableCell);
         }
@@ -127,7 +127,7 @@ final class TableParser extends AbstractBlockContinueParser
             // Body can not have more columns than head
             for ($i = 0; $i < $headerColumns; $i++) {
                 $cell      = $cells[$i] ?? '';
-                $tableCell = self::parseCell($cell, $i, $inlineParser);
+                $tableCell = $this->parseCell($cell, $i, $inlineParser);
                 $row->appendChild($tableCell);
             }
 


### PR DESCRIPTION
Fixes a couple static calls in `TableParser` class that used static method call pattern (`::`) on non-static calls ('->`).

Thank you.