### PR TITLE
Remove unnecessary `(string)` type cast

### DIFF
--- a/tests/functional/Extension/FrontMatterExtension/FrontMatterExtensionTest.php
+++ b/tests/functional/Extension/FrontMatterExtension/FrontMatterExtensionTest.php
@@ -82,7 +82,7 @@ EOT;
 
         $expectedHtml = "<h1>Hello World!</h1>\n";
 
-        $this->assertSame($expectedHtml, (string) $result->getContent());
+        $this->assertSame($expectedHtml, $result->getContent());
         $this->assertSame($expectedHtml, (string) $result);
 
         $this->assertSame(1, $result->getDocument()->getStartLine());

--- a/tests/unit/Renderer/HtmlRendererTest.php
+++ b/tests/unit/Renderer/HtmlRendererTest.php
@@ -44,7 +44,7 @@ class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer($environment);
         $output   = $renderer->renderNodes($ast->children());
 
-        $this->assertSame("::block::\n::block::", (string) $output);
+        $this->assertSame("::block::\n::block::", $output);
     }
 
     public function testRenderNodesWithInlines(): void
@@ -62,7 +62,7 @@ class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer($environment);
         $output   = $renderer->renderNodes($ast->children());
 
-        $this->assertSame('::inline::::inline::', (string) $output);
+        $this->assertSame('::inline::::inline::', $output);
     }
 
     public function testRenderNodesFallsBackWhenFirstRendererReturnsNull(): void
@@ -80,7 +80,7 @@ class HtmlRendererTest extends TestCase
         $renderer = new HtmlRenderer($environment);
         $output   = $renderer->renderNodes([new Text()]);
 
-        $this->assertSame('::result::', (string) $output);
+        $this->assertSame('::result::', $output);
     }
 
     public function testRenderNodesWithMissingRenderer(): void


### PR DESCRIPTION
 - Remove unnecessary `(string)` type cast on \League\CommonMark\Output\RenderedContent::getContent whose interface is declared with a `string` return type and is guaranteed to be a string.
 - Remove a few similar `(string)` type casts in \League\CommonMark\Tests\Unit\Renderer\HtmlRendererTest class.

Thank you.