### PR TITLE
Fix LSP incompatibility in \League\CommonMark\Environment\Environment::getConfig

### DIFF
--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -144,7 +144,7 @@ final class Environment implements ConfigurableEnvironmentInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfig($key = null, $default = null)
+    public function getConfig(?string $key = null, $default = null)
     {
         return $this->config->get($key, $default);
     }


### PR DESCRIPTION
Fixes a missing scalar type in the first parameter of `\League\CommonMark\Environment\Environment::getConfig()`. This method does not follow [LSP](https://php.watch/articles/php-lsp) and errors out.