### PR TITLE
Replace a strlen() call in FencedCodeRenderer with an empty string check

### DIFF
--- a/src/Extension/CommonMark/Renderer/Block/FencedCodeRenderer.php
+++ b/src/Extension/CommonMark/Renderer/Block/FencedCodeRenderer.php
@@ -41,7 +41,7 @@ final class FencedCodeRenderer implements NodeRendererInterface
         $attrs = $node->getData('attributes', []);
 
         $infoWords = $node->getInfoWords();
-        if (\count($infoWords) !== 0 && \strlen($infoWords[0]) !== 0) {
+        if (\count($infoWords) !== 0 && $infoWords[0] !== '') {
             $attrs['class']  = isset($attrs['class']) ? $attrs['class'] . ' ' : '';
             $attrs['class'] .= 'language-' . $infoWords[0];
         }


### PR DESCRIPTION
Replace a `strlen()` call in `\League\CommonMark\Extension\CommonMark\Renderer\Block\FencedCodeRenderer::render()` with an empty string check.

`strlen()` returns `0` only on an empty string (`""`), so I think it makes sense to simply compare to an empty string, and avoid the `strlen` call.