### PR TITLE
Misc performance and code clarity improvements

### DIFF
--- a/src/Extension/Footnote/Event/GatherFootnotesListener.php
+++ b/src/Extension/Footnote/Event/GatherFootnotesListener.php
@@ -48,7 +48,7 @@ final class GatherFootnotesListener implements ConfigurationAwareInterface
             $ref = $document->getReferenceMap()->get($node->getReference()->getLabel());
             if ($ref !== null) {
                 // Use numeric title to get footnotes order
-                $footnotes[\intval($ref->getTitle())] = $node;
+                $footnotes[(int) $ref->getTitle()] = $node;
             } else {
                 // Footnote call is missing, append footnote at the end
                 $footnotes[\PHP_INT_MAX] = $node;

--- a/src/Extension/Mention/Generator/CallbackGenerator.php
+++ b/src/Extension/Mention/Generator/CallbackGenerator.php
@@ -32,7 +32,7 @@ final class CallbackGenerator implements MentionGeneratorInterface
 
     public function generateMention(Mention $mention): ?AbstractInline
     {
-        $result = \call_user_func_array($this->callback, [$mention]);
+        $result = call_user_func($this->callback, $mention);
         if ($result === null) {
             return null;
         }

--- a/src/Extension/TaskList/TaskListItemMarker.php
+++ b/src/Extension/TaskList/TaskListItemMarker.php
@@ -22,7 +22,7 @@ final class TaskListItemMarker extends AbstractInline
      *
      * @psalm-readonly-allow-private-mutation
      */
-    private $checked = false;
+    private $checked;
 
     public function __construct(bool $isCompleted)
     {

--- a/src/Input/MarkdownInput.php
+++ b/src/Input/MarkdownInput.php
@@ -43,7 +43,7 @@ class MarkdownInput implements MarkdownInputInterface
      *
      * @psalm-readonly
      */
-    private $lineOffset = 0;
+    private $lineOffset;
 
     public function __construct(string $content, int $lineOffset = 0)
     {

--- a/src/Parser/Block/BlockStart.php
+++ b/src/Parser/Block/BlockStart.php
@@ -26,7 +26,7 @@ final class BlockStart
      *
      * @psalm-readonly
      */
-    private $blockParsers = [];
+    private $blockParsers;
 
     /**
      * @var CursorState|null

--- a/tests/benchmark/benchmark.php
+++ b/tests/benchmark/benchmark.php
@@ -255,7 +255,7 @@ $run = function (array $config, string $parser) use ($exec): array {
             exit(1);
         }
 
-        return preg_split('~ ~', $result);
+        return explode(" ", $result);
     }
 
     return $exec($config, $parser);

--- a/tests/functional/AbstractSpecTest.php
+++ b/tests/functional/AbstractSpecTest.php
@@ -97,8 +97,7 @@ abstract class AbstractSpecTest extends TestCase
 
     private function showSpaces(string $str): string
     {
-        $str = \str_replace("\t", '→', $str);
-        $str = \str_replace(' ', '␣', $str);
+        $str = \strtr($str, ["\t" => '→', ' ' => '␣']);
 
         return $str;
     }


### PR DESCRIPTION
 - Removes unnecessary class property default values that are immediately overriden in the constructor. Some of them were left to improve clarity.
 - Replaced cascading `str_replace()` calls that do not contain recurring replacements with a single `strtr` call.
 - Replaced an unnecessary `preg_split()` with `explode()`.
 - Removed an `intval()` call with an `(int)` cast.
 - Replaced a `call_user_func_array()` call with more appropriate `call_user_func` call.