### PR TITLE
Make PSR-14 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 ### Added
 
  - Added new `FrontMatterExtension` ([see documentation](https://commonmark.thephpleague.com/extensions/front-matter/))
+ - Added the ability to delegate event dispatching to PSR-14 compliant event dispatcher libraries
  - Added the ability to configure disallowed raw HTML tags (#507)
  - Added `heading_permalink/min_heading_level` and `heading_permalink/max_heading_level` options to control which headings get permalinks (#519)
  - Added `footnote/backref_symbol` option for customizing backreference link appearance (#522)
@@ -31,6 +32,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
    - `RenderedContent`
    - `RenderedContentInterface`
  - Added several new methods:
+   - `Environment::setEventDispatcher()`
    - `FencedCode::setInfo()`
    - `Heading::setLevel()`
    - `HtmlRenderer::renderDocument()`
@@ -49,6 +51,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 ### Changed
 
  - `CommonMarkConverter::convertToHtml()` now returns an instance of `RenderedContentInterface`. This can be cast to a string for backward compatibility with 1.x.
+ - Event dispatching is now fully PSR-14 compliant
  - Moved and renamed several classes - [see the full list here](https://commonmark.thephpleague.com/2.0/upgrading/#classesnamespaces-renamed)
  - Implemented a new approach to block parsing. This was a massive change, so here are the highlights:
    - Functionality previously found in block parsers and node elements has moved to block parser factories and block parsers, respectively ([more details](https://commonmark.thephpleague.com/2.0/upgrading/#new-block-parsing-approach))

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-mbstring": "*",
+        "psr/event-dispatcher": "^1.0",
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {

--- a/docs/2.0/customization/event-dispatcher.md
+++ b/docs/2.0/customization/event-dispatcher.md
@@ -7,11 +7,11 @@ description: How to leverage the event dispatcher to hook into the library
 Event Dispatcher
 ================
 
-This library includes basic event dispatcher functionality.  This makes it possible to add hook points throughout the library and third-party extensions which other code can listen for and execute code.  If you're familiar with [Symfony's EventDispatcher](https://symfony.com/doc/current/components/event_dispatcher.html) or [PSR-14](https://www.php-fig.org/psr/psr-14/) then this should be very familiar to you.
+This library includes basic, [PSR-14](https://www.php-fig.org/psr/psr-14/)-compliant event dispatcher functionality.  This makes it possible to add hook points throughout the library and third-party extensions which other code can listen for and execute code.
 
 ## Event Class
 
-All events must extend from the `AbstractEvent` class:
+Any [PSR-14 compliant event](https://www.php-fig.org/psr/psr-14/#events) can be used, though we also provide an `AbstractEvent` class you can use to easily create your own events:
 
 ```php
 use League\CommonMark\Event\AbstractEvent;
@@ -53,7 +53,7 @@ $environment->addEventListener(MyCustomEvent::class, function (MyCustomEvent $ev
 
 ## Dispatching Events
 
-Events can be dispatched via the `$environment->dispatch()` method which takes a single argument - an instance of `AbstractEvent` to dispatch:
+Events can be dispatched via the `$environment->dispatch()` method which takes a single argument - the event object to dispatch:
 
 ```php
 $environment->dispatch(new MyCustomEvent());
@@ -78,6 +78,20 @@ This event is dispatched once all other processing is done.  This offers extensi
 ### `League\CommonMark\Event\DocumentRenderedEvent`
 
 This event is dispatched once the rendering step has been completed, just before the output is returned.  The final output can be adjusted at this point or additional metadata can be attached to the return object.
+
+
+## Bring Your Own PSR-14 Event Dispatcher
+
+Although this library provides PSR-14 compliant event dispatching out-of-the-box, you may want to use your own PSR-14 event dispatcher instead.  This is possible as long as that third-party library both:
+
+ 1. Implements the PSR-14 `EventDispatcherInterface`; and,
+ 2. Allows you to register additional `ListenerProviderInterface` instances with that dispatcher library
+
+Not all libraries support this so please check carefully!  Assuming yours does, delegating all the event behavior to that library can be done with two steps:
+
+First, call the `setEventDispatcher()` method on the `Environment` to register that other implementation.  With that done, any calls to `Environment::dispatch()` will be passed through to that other dispatcher.  But we still need to let that dispatcher know about the events registered by CommonMark extensions, otherwise nothing will happen when events are dispatched.
+
+Because the `Environment` implements PSR-14's `ListenerProviderInterface` you'll also need to pass the configured `Environment` object to your event dispatcher so that it becomes aware of those available events.
 
 ## Example
 

--- a/src/Environment/EnvironmentInterface.php
+++ b/src/Environment/EnvironmentInterface.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace League\CommonMark\Environment;
 
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorCollection;
-use League\CommonMark\Event\AbstractEvent;
 use League\CommonMark\Parser\Block\BlockStartParserInterface;
 use League\CommonMark\Parser\Inline\InlineParserInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
-interface EnvironmentInterface
+interface EnvironmentInterface extends EventDispatcherInterface
 {
     /**
      * @param string|null $key     Configuration option key
@@ -54,9 +54,4 @@ interface EnvironmentInterface
      * This allows us to parse multiple non-special characters at once
      */
     public function getInlineParserCharacterRegex(): string;
-
-    /**
-     * Dispatches the given event to listeners
-     */
-    public function dispatch(AbstractEvent $event): void;
 }

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Event;
 
+use Psr\EventDispatcher\StoppableEventInterface;
+
 /**
  * Base class for classes containing event data.
  *
@@ -25,7 +27,7 @@ namespace League\CommonMark\Event;
  * You can call the method stopPropagation() to abort the execution of
  * further listeners in your event listener.
  */
-abstract class AbstractEvent
+abstract class AbstractEvent implements StoppableEventInterface
 {
     /**
      * @var bool

--- a/src/Event/ListenerData.php
+++ b/src/Event/ListenerData.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Event;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class ListenerData
+{
+    /** @var string */
+    private $event;
+
+    /** @var callable */
+    private $listener;
+
+    public function __construct(string $event, callable $listener)
+    {
+        $this->event    = $event;
+        $this->listener = $listener;
+    }
+
+    public function getEvent(): string
+    {
+        return $this->event;
+    }
+
+    public function getListener(): callable
+    {
+        return $this->listener;
+    }
+}

--- a/tests/unit/Event/FakeEventParent.php
+++ b/tests/unit/Event/FakeEventParent.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Event;
 
-class FakeEvent extends FakeEventParent
+use League\CommonMark\Event\AbstractEvent;
+
+class FakeEventParent extends AbstractEvent
 {
 }


### PR DESCRIPTION
This PR makes the event system fully compatible with PSR-14! :tada: 

Users can even swap in their own PSR-14 event dispatcher, though this does require that external dispatcher to support registering events via `ListenerProviderInterface` instances, which not all do.

Resolves #436 