### PR TITLE
Allow more than one character to be used as a symbol for MentionExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
  - Added new `FrontMatterExtension` ([see documentation](https://commonmark.thephpleague.com/extensions/front-matter/))
  - Added the ability to delegate event dispatching to PSR-14 compliant event dispatcher libraries
  - Added the ability to configure disallowed raw HTML tags (#507)
+ - Added the ability for Mentions to use multiple characters for their symbol (#514, #550)
  - Added `heading_permalink/min_heading_level` and `heading_permalink/max_heading_level` options to control which headings get permalinks (#519)
  - Added `footnote/backref_symbol` option for customizing backreference link appearance (#522)
  - Added new `HtmlFilter` and `StringContainerHelper` utility classes

--- a/src/Extension/Mention/MentionParser.php
+++ b/src/Extension/Mention/MentionParser.php
@@ -70,7 +70,7 @@ final class MentionParser implements InlineParserInterface
         $previousState = $cursor->saveState();
 
         // Advance past the symbol to keep parsing simpler
-        $cursor->advance();
+        $cursor->advanceBy(\mb_strlen($this->symbol));
 
         // Parse the identifier
         $identifier = $cursor->match($this->mentionRegex);

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -40,6 +40,36 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
+    public function testMentionParserWithMultiCharacterSymbol(): void
+    {
+        $input    = 'Try asking u:colinodell about that.';
+        $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
+
+        $mentionParser = new MentionParser('u:', '/^\w+/', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
+    }
+
+    public function testMentionParserWithMultiCharacterSymbolContainingSpecialRegexCharsThatShouldBeEscaped(): void
+    {
+        $input    = 'I spend too much time on the /r/php subreddit.';
+        $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
+
+        $mentionParser = new MentionParser('/r/', '/^\w+/', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
+    }
+
     public function testMentionParserWithoutSpaceInFront(): void
     {
         $input    = 'See#123 for more information.';


### PR DESCRIPTION
Thanks to #549 we're able to implement this for the upcoming 2.0 release

Resolves #514