### PR TITLE
Rename "symbol" option to "prefix"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 ### Changed
 
  - `CommonMarkConverter::convertToHtml()` now returns an instance of `RenderedContentInterface`. This can be cast to a string for backward compatibility with 1.x.
+ - Renamed the `symbol` configuration key for custom Mentions to `prefix`
  - Event dispatching is now fully PSR-14 compliant
  - Moved and renamed several classes - [see the full list here](https://commonmark.thephpleague.com/2.0/upgrading/#classesnamespaces-renamed)
  - Implemented a new approach to block parsing. This was a massive change, so here are the highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
  - Added new `FrontMatterExtension` ([see documentation](https://commonmark.thephpleague.com/extensions/front-matter/))
  - Added the ability to delegate event dispatching to PSR-14 compliant event dispatcher libraries
  - Added the ability to configure disallowed raw HTML tags (#507)
+ - Added the ability for Mentions to use multiple characters for their symbol (#514, #550)
  - Added `heading_permalink/min_heading_level` and `heading_permalink/max_heading_level` options to control which headings get permalinks (#519)
  - Added `footnote/backref_symbol` option for customizing backreference link appearance (#522)
  - Added new `HtmlFilter` and `StringContainerHelper` utility classes

--- a/src/Extension/Mention/Mention.php
+++ b/src/Extension/Mention/Mention.php
@@ -22,17 +22,17 @@ use League\CommonMark\Node\Inline\Text;
 class Mention extends Link
 {
     /** @var string */
-    private $symbol;
+    private $prefix;
 
     /** @var string */
     private $identifier;
 
-    public function __construct(string $symbol, string $identifier, ?string $label = null)
+    public function __construct(string $prefix, string $identifier, ?string $label = null)
     {
-        $this->symbol     = $symbol;
+        $this->prefix     = $prefix;
         $this->identifier = $identifier;
 
-        parent::__construct('', $label ?? \sprintf('%s%s', $symbol, $identifier));
+        parent::__construct('', $label ?? \sprintf('%s%s', $prefix, $identifier));
     }
 
     public function getLabel(): ?string
@@ -49,9 +49,9 @@ class Mention extends Link
         return $this->identifier;
     }
 
-    public function getSymbol(): string
+    public function getPrefix(): string
     {
-        return $this->symbol;
+        return $this->prefix;
     }
 
     public function hasUrl(): bool

--- a/src/Extension/Mention/MentionExtension.php
+++ b/src/Extension/Mention/MentionExtension.php
@@ -23,18 +23,18 @@ final class MentionExtension implements ExtensionInterface
     {
         $mentions = $environment->getConfig('mentions', []);
         foreach ($mentions as $name => $mention) {
-            foreach (['symbol', 'regex', 'generator'] as $key) {
+            foreach (['prefix', 'regex', 'generator'] as $key) {
                 if (! \array_key_exists($key, $mention)) {
                     throw new \RuntimeException(\sprintf('Missing "%s" from MentionParser configuration', $key));
                 }
             }
 
             if ($mention['generator'] instanceof MentionGeneratorInterface) {
-                $environment->addInlineParser(new MentionParser($mention['symbol'], $mention['regex'], $mention['generator']));
+                $environment->addInlineParser(new MentionParser($mention['prefix'], $mention['regex'], $mention['generator']));
             } elseif (\is_string($mention['generator'])) {
-                $environment->addInlineParser(MentionParser::createWithStringTemplate($mention['symbol'], $mention['regex'], $mention['generator']));
+                $environment->addInlineParser(MentionParser::createWithStringTemplate($mention['prefix'], $mention['regex'], $mention['generator']));
             } elseif (\is_callable($mention['generator'])) {
-                $environment->addInlineParser(MentionParser::createWithCallback($mention['symbol'], $mention['regex'], $mention['generator']));
+                $environment->addInlineParser(MentionParser::createWithCallback($mention['prefix'], $mention['regex'], $mention['generator']));
             } else {
                 throw new \RuntimeException(\sprintf('The "generator" provided for the MentionParser configuration must be a string template, callable, or an object that implements %s.', MentionGeneratorInterface::class));
             }

--- a/src/Extension/Mention/MentionParser.php
+++ b/src/Extension/Mention/MentionParser.php
@@ -70,7 +70,7 @@ final class MentionParser implements InlineParserInterface
         $previousState = $cursor->saveState();
 
         // Advance past the symbol to keep parsing simpler
-        $cursor->advance();
+        $cursor->advanceBy(\mb_strlen($this->symbol));
 
         // Parse the identifier
         $identifier = $cursor->match($this->mentionRegex);

--- a/tests/functional/Extension/Mention/MentionExtensionTest.php
+++ b/tests/functional/Extension/Mention/MentionExtensionTest.php
@@ -58,7 +58,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => 'https://github.com/%s',
                 ],
@@ -86,7 +86,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => static function (Mention $mention) {
                         $mention->setUrl(\sprintf('https://github.com/%s', $mention->getIdentifier()));
@@ -118,7 +118,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => new class () implements MentionGeneratorInterface {
                         public function generateMention(Mention $mention): ?AbstractInline
@@ -146,7 +146,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => new \stdClass(),
                 ],
@@ -156,5 +156,26 @@ EOT;
         $converter = new CommonMarkConverter([], $environment);
 
         $converter->convertToHtml('');
+    }
+
+    public function testLegacySymbolOption(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new MentionExtension());
+        $environment->setConfig([
+            'mentions' => [
+                'github_handle' => [
+                    'symbol'    => '@',
+                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'generator' => 'https://github.com/%s',
+                ],
+            ],
+        ]);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $converter->convertToHtml('foo');
     }
 }

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -40,7 +40,7 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
-    public function testMentionParserWithMultiCharacterSymbol(): void
+    public function testMentionParserWithMultiCharacterPrefix(): void
     {
         $input    = 'Try asking u:colinodell about that.';
         $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
@@ -55,7 +55,7 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
-    public function testMentionParserWithMultiCharacterSymbolContainingSpecialRegexCharsThatShouldBeEscaped(): void
+    public function testMentionParserWithMultiCharacterPrefixContainingSpecialRegexCharsThatShouldBeEscaped(): void
     {
         $input    = 'I spend too much time on the /r/php subreddit.';
         $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
@@ -85,7 +85,7 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
-    public function testMentionParserWithNonMatchingSymbol(): void
+    public function testMentionParserWithNonMatchingPrefix(): void
     {
         $input    = 'See #123 for more information.';
         $expected = '<p>See #123 for more information.</p>';
@@ -137,7 +137,7 @@ final class MentionParserTest extends TestCase
     {
         $callable = static function (Mention $mention) {
             // Stuff the three params into the URL just to prove we received them all properly
-            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getSymbol()));
+            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getPrefix()));
             // Change the label
             $mention->setLabel('Replaced Label');
 

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -40,6 +40,36 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
+    public function testMentionParserWithMultiCharacterSymbol(): void
+    {
+        $input    = 'Try asking u:colinodell about that.';
+        $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
+
+        $mentionParser = new MentionParser('u:', '/^\w+/', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
+    }
+
+    public function testMentionParserWithMultiCharacterSymbolContainingSpecialRegexCharsThatShouldBeEscaped(): void
+    {
+        $input    = 'I spend too much time on the /r/php subreddit.';
+        $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
+
+        $mentionParser = new MentionParser('/r/', '/^\w+/', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
+    }
+
     public function testMentionParserWithoutSpaceInFront(): void
     {
         $input    = 'See#123 for more information.';

--- a/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
+++ b/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
@@ -25,7 +25,7 @@ final class CallbackGeneratorTest extends TestCase
     {
         $generator = new CallbackGenerator(static function (Mention $mention) {
             // Stuff the three params into the URL just to prove we received them all properly
-            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getSymbol()));
+            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getPrefix()));
             // Change the label
             $mention->setLabel('New Label');
 

--- a/tests/unit/Extension/Mention/MentionTest.php
+++ b/tests/unit/Extension/Mention/MentionTest.php
@@ -23,7 +23,7 @@ final class MentionTest extends TestCase
     {
         $mention = new Mention('@', 'colinodell');
 
-        $this->assertSame('@', $mention->getSymbol());
+        $this->assertSame('@', $mention->getPrefix());
         $this->assertSame('colinodell', $mention->getIdentifier());
         $this->assertSame('@colinodell', $mention->getLabel());
         $this->assertSame('', $mention->getUrl());
@@ -38,7 +38,7 @@ final class MentionTest extends TestCase
     {
         $mention = new Mention('#', '123', 'Issue #123');
 
-        $this->assertSame('#', $mention->getSymbol());
+        $this->assertSame('#', $mention->getPrefix());
         $this->assertSame('123', $mention->getIdentifier());
         $this->assertSame('Issue #123', $mention->getLabel());
         $this->assertSame('', $mention->getUrl());


### PR DESCRIPTION
Once #550 is merged we should also consider renaming "symbol" (which implies a single character) to "prefix" for v2.0 onwards.

Because this would be a breaking change to configuration inputs (against the spirit of #475) we could release a new patch version for 1.x where both `symbol` and `prefix` are allowed as configuration keys but a deprecation notice is raised if `symbol` is used.

WDYT @markcarver?

(Note that this PR is based directly on the commit history present in #550)