### PR TITLE
Code block consistency

### DIFF
--- a/docs/1.5/basic-usage.md
+++ b/docs/1.5/basic-usage.md
@@ -10,22 +10,18 @@ Basic Usage
 
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Or if you want Github-Flavored Markdown:
 
 ```php
-<?php
-
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 $converter = new GithubFlavoredMarkdownConverter();

--- a/docs/1.5/command-line.md
+++ b/docs/1.5/command-line.md
@@ -13,7 +13,9 @@ Markdown can be converted at the command line using the `./bin/commonmark` scrip
 
 ## Usage
 
-    ./bin/commonmark [OPTIONS] [FILE]
+```bash
+./bin/commonmark [OPTIONS] [FILE]
+```
 
 * `-h`, `--help`: Shows help and usage information
 * `--enable-em`: Disable `<em>` parsing by setting to `0`; enable with `1` (default: `1`)
@@ -29,16 +31,24 @@ Output will be written to STDOUT.
 
 ### Converting a file named document.md
 
-    ./bin/commonmark document.md
+```bash
+./bin/commonmark document.md
+```
 
 ### Converting a file and saving its output
 
-    ./bin/commonmark document.md > output.html
+```bash
+./bin/commonmark document.md > output.html
+```
 
 ### Converting from STDIN
 
-    echo -e '# Hello World!' | ./bin/commonmark
+```bash
+echo -e '# Hello World!' | ./bin/commonmark
+```
 
 ### Converting from STDIN and saving the output
 
-    echo -e '# Hello World!' | ./bin/commonmark > output.html
+```bash
+echo -e '# Hello World!' | ./bin/commonmark > output.html
+```

--- a/docs/1.5/configuration.md
+++ b/docs/1.5/configuration.md
@@ -9,9 +9,7 @@ Configuration
 
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter([
@@ -29,7 +27,7 @@ $converter = new CommonMarkConverter([
     'allow_unsafe_links' => false,
     'max_nesting_level' => INF,
 ]);
-~~~
+```
 
 Here's a list of currently-supported options:
 

--- a/docs/1.5/customization/abstract-syntax-tree.md
+++ b/docs/1.5/customization/abstract-syntax-tree.md
@@ -32,9 +32,7 @@ The following methods can be used to traverse the AST:
 
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Node\NodeWalker;
 
 /** @var NodeWalker $walker */
@@ -42,7 +40,7 @@ $walker = $document->walker();
 while ($event = $walker->next()) {
     echo 'I am ' . ($event->isEntering() ? 'entering' : 'leaving') . ' a ' . get_class($event->getNode()) . ' node' . "\n";
 }
-~~~
+```
 
 This walker doesn't use recursion, so you won't blow the stack when working with deeply-nested nodes.
 

--- a/docs/1.5/customization/block-parsing.md
+++ b/docs/1.5/customization/block-parsing.md
@@ -12,11 +12,9 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 
 ## parse()
 
-~~~php
-<?php
-
+```php
 public function parse(ContextInterface $context, Cursor $cursor): bool;
-~~~
+```
 
 When parsing a new line, the `DocParser` iterates through all registered block parsers and calls their `parse()` method.  Each parser must determine whether it can handle the given line; if so, it should parse the given block and return `true`.
 

--- a/docs/1.5/customization/block-rendering.md
+++ b/docs/1.5/customization/block-rendering.md
@@ -14,11 +14,9 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 
 ## render()
 
-~~~php
-<?php
-
+```php
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
-~~~
+```
 
 The `HtmlRenderer` will call this method whenever a supported block element is encountered in the AST being rendered.
 
@@ -40,22 +38,18 @@ If you choose to return an HTML `string` you are responsible for handling any es
 
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
 $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
-~~~
+```
 
 ## Designating Block Renderers
 
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Environment;
 
@@ -64,13 +58,11 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the block class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
-~~~
+```
 
 A single renderer could even be used for multiple block types:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Block\Element\IndentedCode;
 use League\CommonMark\Environment;
@@ -81,7 +73,7 @@ $myRenderer = new MyCustomCodeRenderer();
 
 $environment->addBlockRenderer(FencedCode::class, $myRenderer, 10);
 $environment->addBlockRenderer(IndentedCode::class, $myRenderer, 20);
-~~~
+```
 
 Multiple renderers can be added per element type - when this happens, we use the result from the highest-priority renderer that returns a non-`null` result.
 
@@ -89,9 +81,7 @@ Multiple renderers can be added per element type - when this happens, we use the
 
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Environment;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Renderer\Block\BlockRendererInterface;
@@ -108,7 +98,7 @@ class TextDividerRenderer implements BlockRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addBlockRenderer('League\CommonMark\Block\Element\ThematicBreak', new TextDividerRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.5/customization/delimiter-processing.md
+++ b/docs/1.5/customization/delimiter-processing.md
@@ -15,9 +15,9 @@ Delimiter runs are a special type of inline:
  - They are denoted by "wrapping" text with one or more characters before **and** after those inner contents
  - They can contain other delimiter runs or inlines inside of them
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 
 When implementing something with these characteristics you should consider leveraging delimiter runs; otherwise, a basic [inline parser](/1.5/inline-parsing/) should be sufficient.
@@ -30,9 +30,9 @@ Delimiter processors have a lower priority than inline parsers - if an [inline p
 
 Implement the `DelimiterProcessorInterface` and add it to your environment:
 
-~~~php
+```php
 $environment->addDelimiterProcessor(new MyCustomDelimiterProcessor());
-~~~
+```
 
 ### `getOpeningCharacter()` and `getClosingCharacter()`
 
@@ -44,21 +44,21 @@ This method tells the engine the minimum number of characters needed to match or
 
 ### `getDelimiterUse()`
 
-~~~php
+```php
 public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int;
-~~~
+```
 
 This method is used to tell the engine how many characters from the matching delimiters should be consumed.  For simple processors you'll likely return `1` (or whatever your minimum length is).  In more advanced cases, you can examine the opening and closing delimiters and perform additional logic to determine whether they should be fully or partially consumed.  You can also return `0` if you'd like.
 
 ### `process()`
 
-~~~php
+```php
 public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse);
-~~~
+```
 
 This is where the magic happens.  Once the engine determines it can use the delimiter it found (by looking at all the other methods above) it'll call this method.  Your job is to take everything between the `$opener` and `$closer` and wrap that in whatever custom inline element you'd like.  Here's a basic example of wrapping the inner contents inside a new `Emphasis` element:
 
-~~~php
+```php
 // Create the outer element
 $emphasis = new Emphasis();
 
@@ -72,7 +72,7 @@ while ($tmp !== null && $tmp !== $closer) {
 
 // Place the outer element into the AST
 $opener->insertAfter($emphasis);
-~~~
+```
 
 Note that `$opener` and `$closer` will be automatically removed for you after this function returns - no need to do that yourself.
 
@@ -84,7 +84,7 @@ Basic delimiter processors, as covered above, do not require any custom inline p
 
 As your identifies potential delimiter-based inlines, it should create a new `AbstractStringContainer` node (either `Text` or something custom) with the inner contents and also push a new `DelimiterInterface` onto the `DelimiterStack`:
 
-~~~php
+```php
 $node = new Text($cursor->getPreviousText(), [
     'delim' => true,
 ]);
@@ -93,7 +93,7 @@ $inlineContext->getContainer()->appendChild($node);
 // Add entry to stack to this opener
 $delimiter = new Delimiter($character, $numDelims, $node, $canOpen, $canClose);
 $inlineContext->getDelimiterStack()->push($delimiter);
-~~~
+```
 
 This basically tells the engine that text was found which _might_ be emphasis, but due to the delimiter run rules we can't make that determination just yet.  That final determination is later on by a "delimiter processor".
 

--- a/docs/1.5/customization/environment.md
+++ b/docs/1.5/customization/environment.md
@@ -12,13 +12,11 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 
 A pre-configured `Environment` can be obtained like this:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
-~~~
+```
 
 All of the core renders, parsers, etc. needed to implement the CommonMark spec will be pre-registered and ready to go.
 
@@ -26,41 +24,33 @@ You can customize this default `Environment` (or even a new, empty one) using an
 
 ## mergeConfig()
 
-~~~php
-<?php
-
+```php
 public function mergeConfig(array $config = []);
-~~~
+```
 
 Merges the given [configuration](/1.5/configuration/) settings into any existing ones.
 
 ## setConfig()
 
-~~~php
-<?php
-
+```php
 public function setConfig(array $config = []);
-~~~
+```
 
 Completely replaces the previous [configuration](/1.5/configuration/) settings with the new `$config` you provide.
 
 ## addExtension()
 
-~~~php
-<?php
-
+```php
 public function addExtension(ExtensionInterface $extension);
-~~~
+```
 
 Registers the given [extension](/1.5/customization/extensions/) with the environment.  This is typically how you'd integrate third-party extensions with this library.
 
 ## addBlockParser()
 
-~~~php
-<?php
-
+```php
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `BlockParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -68,11 +58,9 @@ See [Block Parsing](/1.5/customization/block-parsing/) for details.
 
 ## addBlockRenderer()
 
-~~~php
-<?php
-
+```php
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
-~~~
+```
 
 Registers a `BlockRendererInterface` to handle a specific type of block (`$blockClass`)  with the given priority (a higher number will be executed earlier).
 
@@ -80,11 +68,9 @@ See [Block Rendering](/1.5/customization/block-rendering/) for details.
 
 ## addInlineParser()
 
-~~~php
-<?php
-
+```php
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `InlineParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -92,11 +78,9 @@ See [Inline Parsing](/1.5/customization/inline-parsing/) for details.
 
 ## addInlineRenderer()
 
-~~~php
-<?php
-
+```php
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
-~~~
+```
 
 Registers an `InlineRendererInterface` to handle a specific type of inline (`$inlineClass`) with the given priority (a higher number will be executed earlier).
 A single renderer can handle multiple inline classes, but you must register it separately for each type. (The same renderer instance can be re-used if desired.)
@@ -105,11 +89,9 @@ See [Inline Rendering](/1.5/customization/inline-rendering/) for details.
 
 ## addDelimiterProcessor()
 
-~~~php
-<?php
-
+```php
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
-~~~
+```
 
 Registers the given `DelimiterProcessorInterface` with the environment.
 
@@ -117,11 +99,9 @@ See [Inline Parsing](/1.5/customization/delimiter-processing/) for details.
 
 ## addEventListener()
 
-~~~php
-<?php
-
+```php
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
-~~~
+```
 
 Registers the given event listener with the environment.
 

--- a/docs/1.5/customization/event-dispatcher.md
+++ b/docs/1.5/customization/event-dispatcher.md
@@ -82,9 +82,7 @@ This event is dispatched once all other processing is done.  This offers extensi
 
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Inline\Element\Link;
@@ -129,13 +127,11 @@ class ExternalLinkProcessor
         return $host != $this->environment->getConfig('host');
     }
 }
-~~~
+```
 
 And here's how you'd use it:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;
@@ -150,15 +146,15 @@ $converter = new CommonMarkConverter(['host' => 'commonmark.thephpleague.com'], 
 $input = 'My two favorite sites are <https://google.com> and <https://commonmark.thephpleague.com>';
 
 echo $converter->convertToHtml($input);
-~~~
+```
 
 Output (formatted for readability):
 
-~~~html
+```html
 <p>
     My two favorite sites are
     <a class="external-link" href="https://google.com">https://google.com</a>
     and
     <a href="https://commonmark.thephpleague.com">https://commonmark.thephpleague.com</a>
 </p>
-~~~
+```

--- a/docs/1.5/customization/extensions.md
+++ b/docs/1.5/customization/extensions.md
@@ -35,7 +35,6 @@ To hook up your new extension to the `Environment`, simply do this:
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 
-
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addExtension(new EmojiExtension());
 

--- a/docs/1.5/customization/inline-parsing.md
+++ b/docs/1.5/customization/inline-parsing.md
@@ -20,9 +20,9 @@ The difference between normal inlines and delimiter-run-based inlines is subtle 
 
 An example of this would be emphasis:
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 If your syntax looks like that, consider using a [delimiter processor](/1.5/customization/delimiter-processing/) instead.  Otherwise, an inline parser is your best bet.
 
@@ -60,9 +60,7 @@ Returning `true` tells the engine that you've successfully parsed the character 
 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
@@ -74,6 +72,7 @@ class TwitterHandleParser implements InlineParserInterface
     {
         return ['@'];
     }
+
     public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
@@ -102,15 +101,13 @@ class TwitterHandleParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new TwitterHandleParser());
-~~~
+```
 
 ### Example 2 - Emoticons
 
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Image;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
@@ -150,7 +147,7 @@ class SmilieParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new SmilieParserParser());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.5/customization/inline-rendering.md
+++ b/docs/1.5/customization/inline-rendering.md
@@ -35,9 +35,7 @@ Return `null` if your renderer cannot handle the given inline element - the next
 
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -45,15 +43,13 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the inline class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyCustomLinkRenderer());
-~~~
+```
 
 ## Example
 
 Here's a custom renderer which puts a special class on links to external sites:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;
@@ -99,7 +95,7 @@ class MyCustomLinkRenderer implements InlineRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineRenderer(Link::class, new MyCustomLinkRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.5/customization/overview.md
+++ b/docs/1.5/customization/overview.md
@@ -24,9 +24,7 @@ The actual process of converting Markdown to HTML has several steps:
 
 `CommonMarkConverter` handles all of this for you, but you can execute that process yourself if you wish:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
 use League\CommonMark\HtmlRenderer;
@@ -45,7 +43,7 @@ $document = $parser->parse($markdown);
 echo $htmlRenderer->renderBlock($document);
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Feel free to swap out different components or add your own steps in between.  However, the best way to customize this library is to [create your own extensions](/1.5/customization/extensions/) which hook into the parsing and rendering steps - continue reading to see which kinds of extension points are available to you.
 

--- a/docs/1.5/extensions/attributes.md
+++ b/docs/1.5/extensions/attributes.md
@@ -35,9 +35,9 @@ This is *red*{style="color: red"}.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -46,7 +46,6 @@ See the [installation](/1.5/installation/) section for more details.
 Configure your `Environment` as usual and simply add the `AttributesExtension`:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Extension\Attributes\AttributesExtension;

--- a/docs/1.5/extensions/autolinks.md
+++ b/docs/1.5/extensions/autolinks.md
@@ -15,9 +15,9 @@ The `AutolinkExtension` adds [GFM-style autolinking][link-gfm-spec-autolinking].
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/extensions/commonmark.md
+++ b/docs/1.5/extensions/commonmark.md
@@ -13,9 +13,9 @@ The `CommonMarkCoreExtension` class contains all of the core Markdown syntax - t
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/extensions/disallowed-raw-html.md
+++ b/docs/1.5/extensions/disallowed-raw-html.md
@@ -31,9 +31,9 @@ All other HTML tags are left untouched by this extension.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/extensions/external-links.md
+++ b/docs/1.5/extensions/external-links.md
@@ -17,9 +17,9 @@ This extension can detect links to external sites and adjust the markup accordin
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -101,11 +101,13 @@ These options allow you to configure whether a `rel` attribute should be applied
 When an external link is detected, the `ExternalLinkProcessor` will set the `external` data option on the `Link` node to either `true` or `false`.  You can therefore create a [custom link renderer](/1.5/customization/inline-rendering/) which checks this value and behaves accordingly:
 
 ```php
+
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
 use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+
 class MyCustomLinkRenderer implements InlineRendererInterface
 {
 

--- a/docs/1.5/extensions/footnotes.md
+++ b/docs/1.5/extensions/footnotes.md
@@ -13,9 +13,9 @@ The `FootnoteExtension` adds the ability to create footnotes in Markdown documen
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -23,7 +23,7 @@ See the [installation](/1.5/installation/) section for more details.
 
 Sample Markdown input:
 
-```md
+```markdown
 Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi[^note1] leo risus, porta ac consectetur ac.
 
@@ -32,7 +32,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi[^note1] leo risus
 
 Result:
 
-```md
+```html
 <p>
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -55,7 +55,6 @@ Result:
 Configure your `Environment` as usual and simply add the `FootnoteExtension`:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Extension\Footnote\FootnoteExtension;

--- a/docs/1.5/extensions/heading-permalinks.md
+++ b/docs/1.5/extensions/heading-permalinks.md
@@ -15,9 +15,9 @@ This extension makes all of your heading elements (`<h1>`, `<h2>`, etc) linkable
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -107,8 +107,6 @@ You can change the string that is used as the "slug" by setting the `slug_normal
 For example, if you'd like each slug to be an MD5 hash, you could create a class like this:
 
 ```php
-<?php
-
 use League\CommonMark\Normalizer\TextNormalizerInterface;
 
 final class MD5Normalizer implements TextNormalizerInterface

--- a/docs/1.5/extensions/inlines-only.md
+++ b/docs/1.5/extensions/inlines-only.md
@@ -13,9 +13,9 @@ This extension configures the parser to only render inline elements - no paragra
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/extensions/mentions.md
+++ b/docs/1.5/extensions/mentions.md
@@ -18,7 +18,6 @@ define the starting symbol, a regular expression to match against, and any custo
 generate the URL.
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Mention\MentionExtension;
@@ -213,7 +212,6 @@ You can then hook this class up to a mention definition in the configuration to 
 mentions:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Mention\MentionExtension;

--- a/docs/1.5/extensions/smart-punctuation.md
+++ b/docs/1.5/extensions/smart-punctuation.md
@@ -11,7 +11,7 @@ The `SmartPunctExtension` Intelligently converts ASCII quotes, dashes, and ellip
 
 For example, this Markdown...
 
-```md
+```markdown
 "CommonMark is the PHP League's Markdown parser," she said.  "It's super-configurable... you can even use additional extensions to expand its capabilities -- just like this one!"
 ```
 
@@ -25,9 +25,9 @@ Will result in this HTML:
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -35,7 +35,7 @@ See the [installation](/1.5/installation/) section for more details.
 
 Extensions can be added to any new `Environment`:
 
-``` php
+```php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;

--- a/docs/1.5/extensions/strikethrough.md
+++ b/docs/1.5/extensions/strikethrough.md
@@ -15,9 +15,9 @@ This extension adds support for GFM-style strikethrough syntax.  It allows users
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/extensions/table-of-contents.md
+++ b/docs/1.5/extensions/table-of-contents.md
@@ -15,9 +15,9 @@ The [Heading Permalink](/1.5/extensions/heading-permalinks/) extension must also
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -105,7 +105,7 @@ These two settings control which headings should appear in the list.  By default
 
 Consider this sample Markdown input:
 
-```md
+```markdown
 ## Level 2 Heading
 
 This is a sample document that starts with a level 2 heading

--- a/docs/1.5/extensions/tables.md
+++ b/docs/1.5/extensions/tables.md
@@ -15,9 +15,9 @@ The `TableExtension` adds the ability to create tables in CommonMark documents.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/extensions/task-lists.md
+++ b/docs/1.5/extensions/task-lists.md
@@ -15,9 +15,9 @@ This extension adds support for [GFM-style task lists](https://github.github.com
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 

--- a/docs/1.5/index.md
+++ b/docs/1.5/index.md
@@ -21,9 +21,9 @@ title: Overview
 
 This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.5/installation/) section for more details.
 
@@ -31,16 +31,14 @@ See the [installation](/1.5/installation/) section for more details.
 
 Simply instantiate the converter and start converting some Markdown to HTML!
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [basic usage](/1.5/basic-usage/) and [security](/1.5/security/) sections for important details.

--- a/docs/1.5/installation.md
+++ b/docs/1.5/installation.md
@@ -11,9 +11,9 @@ The recommended installation method is via Composer.
 
 In your project root just run:
 
-~~~bash
+```bash
 composer require league/commonmark:^1.5
-~~~
+```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
 

--- a/docs/1.5/security.md
+++ b/docs/1.5/security.md
@@ -24,24 +24,25 @@ If you're developing an application which renders user-provided Markdown from po
 
 ### Example - Escape all raw HTML input:
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'escape']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // &lt;script&gt;alert("Hello XSS!");&lt;/script&gt;
-~~~
+```
 
 ### Example - Strip all HTML from the input:
-~~~php
+
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'strip']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // (empty output)
-~~~
+```
 
 **Failing to set this option could make your site vulnerable to cross-site scripting (XSS) attacks!**
 
@@ -66,7 +67,7 @@ If you need to parse untrusted input, consider setting a reasonable `max_nesting
 
 ### Example - Prevent deep nesting
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
@@ -84,7 +85,7 @@ echo $converter->convertToHtml($markdown);
 //     </blockquote>
 //   </blockquote>
 // </blockquote>
-~~~
+```
 
 See the [configuration](/1.5/configuration/) section for more information.
 


### PR DESCRIPTION
Made a pass on consistent use of code block formatting through the `1.5` docs. I made a few assumptions in applying the changes:

- Backticks are preferred over indentation and tildes
  - 42 `php` code blocks used backticks (`rg -U '```php\s+' | wc -l`) vs 35 `php` code blocks using tildes (`rg -U '~~~php\s+' | wc -l`)
- `php` code blocks should not include PHP open tags (`<?php`)
  - 88 `php` code blocks did not include an open tag (`rg -U '(```|~~~)php\s+[^<]' | wc -l`) vs 66 `php` code blocks included an open tag (`rg -U '(```|~~~)php\s+[<]' | wc -l`)
- Code blocks should specify their language
- `markdown` is preferred over `md` for it's explicitness

I was unable to covers two points made in #553:

> - Editing documentation for older versions without also applying the same changes to newer versions
> - Sending one giant pull request with TONS of changes - smaller, more-focused PRs are easier and quicker to review

I did not update any other version of the documentation (violating the first point) and my many small changes still resulted in a large, but atomic, PR (violating the second point). @colinodell if this PR looks good, I'll expand my efforts. In that, would you prefer PRs for each version (but limited to code block consistency) or one large PR across all versions (but limited to code block consistency)? Asking in good faith for as I am participating in Hacktoberfest, I know the event brings a spike in load for project maintainers which includes filtering spam PRs, which is not my intent.