### PR TITLE
Use alternative ascii characters in string template illustration

### DIFF
--- a/docs/1.5/extensions/mentions.md
+++ b/docs/1.5/extensions/mentions.md
@@ -74,9 +74,9 @@ URL templates are perfect for situations where the identifier is inserted direct
 
 ```
 "@colinodell" => https://www.twitter.com/colinodell
- ^      ^                                    ^
- |       \________ Identifier ______________/
-Symbol
+ ▲└────┬───┘                             └───┬────┘
+ │     │                                     │
+Symbol └───────────── Identifier ────────────┘
 ```
 
 Examples of using string-based URL templates can be seen in the usage example above - you simply provide a `string` to the `generator` option.

--- a/docs/2.0/extensions/mentions.md
+++ b/docs/2.0/extensions/mentions.md
@@ -73,9 +73,9 @@ URL templates are perfect for situations where the identifier is inserted direct
 
 ```
 "@colinodell" => https://www.twitter.com/colinodell
- ^      ^                                    ^
- |       \________ Identifier ______________/
-Symbol
+ ▲└────┬───┘                             └───┬────┘
+ │     │                                     │
+Symbol └───────────── Identifier ────────────┘
 ```
 
 Examples of using string-based URL templates can be seen in the usage example above - you simply provide a `string` to the `generator` option.


### PR DESCRIPTION
When reviewing the docs, I was slowed by trying to grok the ascii based illustration of String-Based URL Templates for the Mention extension. It took a moment to understand that the `Identifier` underline wasn't offset, but pointing to two different areas (`colinodell`) and not highlighting the section above it `dell" => https://www.twitter.com/colin`.

![image](https://user-images.githubusercontent.com/1379248/94961382-8a932e00-04c2-11eb-8b73-cdc96738f3e0.png)

I've switched it to use some of the additional ascii characters to highlight that the `colinodell` to the direct right of the `@` symbol was the identifier that was carried over to the value on the right. I also used an arrow instead of carot and put `Symbol` on the same line as `Identifier`, giving them equal weight.

![image](https://user-images.githubusercontent.com/1379248/94961576-e8277a80-04c2-11eb-951b-e8452f1de937.png)

RE: #553 

