### PR TITLE
Update the link for autoloading with composer

### DIFF
--- a/docs/0.19/installation.md
+++ b/docs/0.19/installation.md
@@ -13,7 +13,7 @@ In your project root just run:
 composer require league/commonmark:^0.19
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.0/installation.md
+++ b/docs/1.0/installation.md
@@ -15,7 +15,7 @@ In your project root just run:
 composer require league/commonmark:^1.0
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.3/installation.md
+++ b/docs/1.3/installation.md
@@ -14,7 +14,7 @@ In your project root just run:
 composer require league/commonmark:^1.3
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.4/installation.md
+++ b/docs/1.4/installation.md
@@ -14,7 +14,7 @@ In your project root just run:
 composer require league/commonmark:^1.4
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.5/installation.md
+++ b/docs/1.5/installation.md
@@ -15,7 +15,7 @@ In your project root just run:
 composer require league/commonmark:^1.5
 ```
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/2.0/installation.md
+++ b/docs/2.0/installation.md
@@ -14,7 +14,7 @@ In your project root just run:
 composer require league/commonmark:^2.0
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 


### PR DESCRIPTION
The installation instructions mention enabling "autoloading" for
composer-installed packages.

The composer project has moved this documentation from the intro-page,
to the "basic usage"-page, which broke the link in our docs.

This commit fixes it for all versions of the documentation.