### PR TITLE
Autoloader instructions

### DIFF
--- a/docs/0.19/basic-usage.md
+++ b/docs/0.19/basic-usage.md
@@ -11,6 +11,8 @@ The `CommonMarkConverter` class provides a simple wrapper for converting CommonM
 ~~~php
 <?php
 
+require __DIR__ . '/vendor/autoload.php';
+
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
@@ -32,6 +34,8 @@ You can do this yourself if you wish:
 
 ~~~php
 <?php
+
+require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;

--- a/docs/0.19/installation.md
+++ b/docs/0.19/installation.md
@@ -13,7 +13,7 @@ In your project root just run:
 composer require league/commonmark:^0.19
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.0/basic-usage.md
+++ b/docs/1.0/basic-usage.md
@@ -13,6 +13,8 @@ The `CommonMarkConverter` class provides a simple wrapper for converting CommonM
 ~~~php
 <?php
 
+require __DIR__ . '/vendor/autoload.php';
+
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
@@ -34,6 +36,8 @@ The actual conversion process has three steps:
 
 ~~~php
 <?php
+
+require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;

--- a/docs/1.0/installation.md
+++ b/docs/1.0/installation.md
@@ -15,7 +15,7 @@ In your project root just run:
 composer require league/commonmark:^1.0
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.3/basic-usage.md
+++ b/docs/1.3/basic-usage.md
@@ -12,6 +12,8 @@ The `CommonMarkConverter` class provides a simple wrapper for converting Markdow
 ~~~php
 <?php
 
+require __DIR__ . '/vendor/autoload.php';
+
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
@@ -46,6 +48,8 @@ The actual conversion process has three steps:
 
 ~~~php
 <?php
+
+require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;

--- a/docs/1.3/installation.md
+++ b/docs/1.3/installation.md
@@ -14,7 +14,7 @@ In your project root just run:
 composer require league/commonmark:^1.3
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.4/basic-usage.md
+++ b/docs/1.4/basic-usage.md
@@ -12,6 +12,8 @@ The `CommonMarkConverter` class provides a simple wrapper for converting Markdow
 ~~~php
 <?php
 
+require __DIR__ . '/vendor/autoload.php';
+
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
@@ -24,6 +26,8 @@ Or if you want Github-Flavored Markdown:
 
 ```php
 <?php
+
+require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 

--- a/docs/1.4/installation.md
+++ b/docs/1.4/installation.md
@@ -14,7 +14,7 @@ In your project root just run:
 composer require league/commonmark:^1.4
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/1.5/basic-usage.md
+++ b/docs/1.5/basic-usage.md
@@ -11,6 +11,8 @@ Basic Usage
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
 ```php
+require __DIR__ . '/vendor/autoload.php';
+
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
@@ -22,6 +24,8 @@ echo $converter->convertToHtml('# Hello World!');
 Or if you want Github-Flavored Markdown:
 
 ```php
+require __DIR__ . '/vendor/autoload.php';
+
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 $converter = new GithubFlavoredMarkdownConverter();

--- a/docs/1.5/installation.md
+++ b/docs/1.5/installation.md
@@ -15,7 +15,7 @@ In your project root just run:
 composer require league/commonmark:^1.5
 ```
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 

--- a/docs/2.0/basic-usage.md
+++ b/docs/2.0/basic-usage.md
@@ -11,6 +11,7 @@ The `CommonMarkConverter` class provides a simple wrapper for converting Markdow
 
 ~~~php
 <?php
+require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\CommonMarkConverter;
 

--- a/docs/2.0/installation.md
+++ b/docs/2.0/installation.md
@@ -14,7 +14,7 @@ In your project root just run:
 composer require league/commonmark:^2.0
 ~~~
 
-Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/00-intro.md#autoloading).
+Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
 ## Versioning
 


### PR DESCRIPTION
 If someone is new with composer (which is entirely possible) it might be confusing to get a "class not found" error when copy/pasting the example code.

This commit adds including the autoloader to the examples for basic usage, so they can be literally copy/pasted in a text editor and will work right away.

This can make it easier to get started for beginners.