### PR TITLE
Fix broken link to extensions from "Basic Usage"

### DIFF
--- a/docs/1.3/basic-usage.md
+++ b/docs/1.3/basic-usage.md
@@ -63,7 +63,7 @@ echo $htmlRenderer->renderBlock($document);
 // <h1>Hello World!</h1>
 ~~~
 
-[Additional customization](/1.3/customization/overview/) is also possible, and we have many handy [extensions](/1.3/extensions/) to enable additional syntax and features.
+[Additional customization](/1.3/customization/overview/) is also possible, and we have many handy [extensions](/1.3/extensions/overview/) to enable additional syntax and features.
 
 ## Supported Character Encodings
 

--- a/docs/1.4/basic-usage.md
+++ b/docs/1.4/basic-usage.md
@@ -36,7 +36,7 @@ echo $converter->convertToHtml('# Hello World!');
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [security](/1.4/security/) section for important details on avoiding security misconfigurations.
 
-[Additional customization](/1.4/customization/overview/) is also possible, and we have many handy [extensions](/1.4/extensions/) to enable additional syntax and features.
+[Additional customization](/1.4/customization/overview/) is also possible, and we have many handy [extensions](/1.4/extensions/overview/) to enable additional syntax and features.
 
 ## Supported Character Encodings
 

--- a/docs/1.5/basic-usage.md
+++ b/docs/1.5/basic-usage.md
@@ -33,7 +33,7 @@ echo $converter->convertToHtml('# Hello World!');
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [security](/1.5/security/) section for important details on avoiding security misconfigurations.
 
-[Additional customization](/1.5/customization/overview/) is also possible, and we have many handy [extensions](/1.5/extensions/) to enable additional syntax and features.
+[Additional customization](/1.5/customization/overview/) is also possible, and we have many handy [extensions](/1.5/extensions/overview/) to enable additional syntax and features.
 
 ## Supported Character Encodings
 

--- a/docs/2.0/basic-usage.md
+++ b/docs/2.0/basic-usage.md
@@ -36,7 +36,7 @@ echo $converter->convertToHtml('# Hello World!');
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [security](/2.0/security/) section for important details on avoiding security misconfigurations.
 
-[Additional customization](/2.0/customization/overview/) is also possible, and we have many handy [extensions](/2.0/extensions/) to enable additional syntax and features.
+[Additional customization](/2.0/customization/overview/) is also possible, and we have many handy [extensions](/2.0/extensions/overview/) to enable additional syntax and features.
 
 ## Supported Character Encodings
 


### PR DESCRIPTION
On the "Basic Usage"-pages (e.g. https://commonmark.thephpleague.com/1.5/basic-usage/) the "extensions"-link currently goes to /extensions/ which results in a 404 on the live website.

e.g. https://commonmark.thephpleague.com/1.5/extensions/

This commit changes it to /extensions/overview/ for the relevant versions.

e.g. https://commonmark.thephpleague.com/1.5/extensions/overview/