### PR TITLE
Update links to the Caret Version Range docs

### DIFF
--- a/docs/0.19/installation.md
+++ b/docs/0.19/installation.md
@@ -17,6 +17,6 @@ Ensure that you’ve set up your project to [autoload Composer-installed package
 
 ## Versioning
 
-[SemVer](http://semver.org/) will be followed closely.  0.x versions will introduce breaking changes, so be careful which version constraints you use.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret) to ensure compatibility**; for example: `^0.18`.  This is equivalent to `>=0.18.0 <0.19.0`.
+[SemVer](http://semver.org/) will be followed closely.  0.x versions will introduce breaking changes, so be careful which version constraints you use.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) to ensure compatibility**; for example: `^0.18`.  This is equivalent to `>=0.18.0 <0.19.0`.
 
 If you're only using the `CommonMarkConverter` class to convert Markdown (no other class references, custom parsers, etc.), then it should be safe to use a broader constraint like `~0.19`, `>0.19`, etc.  I personally promise to never break this specific class in any future 0.x release.

--- a/docs/1.0/installation.md
+++ b/docs/1.0/installation.md
@@ -19,4 +19,4 @@ Ensure that you’ve set up your project to [autoload Composer-installed package
 
 ## Versioning
 
-[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret) to ensure compatibility**; for example: `^1.0`.  This is equivalent to `>=1.0 <2.0`.
+[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) to ensure compatibility**; for example: `^1.0`.  This is equivalent to `>=1.0 <2.0`.

--- a/docs/1.3/installation.md
+++ b/docs/1.3/installation.md
@@ -18,4 +18,4 @@ Ensure that you’ve set up your project to [autoload Composer-installed package
 
 ## Versioning
 
-[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret) to ensure compatibility**; for example: `^1.3`.  This is equivalent to `>=1.3 <2.0`.
+[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) to ensure compatibility**; for example: `^1.3`.  This is equivalent to `>=1.3 <2.0`.

--- a/docs/1.4/installation.md
+++ b/docs/1.4/installation.md
@@ -18,4 +18,4 @@ Ensure that you’ve set up your project to [autoload Composer-installed package
 
 ## Versioning
 
-[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret) to ensure compatibility**; for example: `^1.4`.  This is equivalent to `>=1.4 <2.0`.
+[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) to ensure compatibility**; for example: `^1.4`.  This is equivalent to `>=1.4 <2.0`.

--- a/docs/1.5/installation.md
+++ b/docs/1.5/installation.md
@@ -19,4 +19,4 @@ Ensure that you’ve set up your project to [autoload Composer-installed package
 
 ## Versioning
 
-[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret) to ensure compatibility**; for example: `^1.5`.  This is equivalent to `>=1.5 <2.0`.
+[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) to ensure compatibility**; for example: `^1.5`.  This is equivalent to `>=1.5 <2.0`.

--- a/docs/2.0/installation.md
+++ b/docs/2.0/installation.md
@@ -18,4 +18,4 @@ Ensure that you’ve set up your project to [autoload Composer-installed package
 
 ## Versioning
 
-[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret) to ensure compatibility**; for example: `^2.0`.  This is equivalent to `>=2.0 <3.0`.
+[SemVer](http://semver.org/) will be followed closely.  **It's highly recommended that you use [Composer's caret operator](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) to ensure compatibility**; for example: `^2.0`.  This is equivalent to `>=2.0 <3.0`.


### PR DESCRIPTION
The website for Composer has changed the hash for Caret Version Range
in the docs, so the links in the docs are now incorrect.

This commit simply replaces the "broken" link with the correct one.

Note that the link did not 404, it's just the hash.