### PR TITLE
Refine inline parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 ### Changed
 
  - `CommonMarkConverter::convertToHtml()` now returns an instance of `RenderedContentInterface`. This can be cast to a string for backward compatibility with 1.x.
- - Renamed the `symbol` configuration key for custom Mentions to `prefix`
+ - Changes to configuration options:
+     - `mentions/*/symbol` has been renamed to `mentions/*/prefix`
+     - `mentions/*/regex` now requires partial regular expressions (without delimiters or flags)
  - Event dispatching is now fully PSR-14 compliant
  - Moved and renamed several classes - [see the full list here](https://commonmark.thephpleague.com/2.0/upgrading/#classesnamespaces-renamed)
  - Implemented a new approach to block parsing. This was a massive change, so here are the highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
 ### Changed
 
  - `CommonMarkConverter::convertToHtml()` now returns an instance of `RenderedContentInterface`. This can be cast to a string for backward compatibility with 1.x.
+ - Renamed the `symbol` configuration key for custom Mentions to `prefix`
  - Event dispatching is now fully PSR-14 compliant
  - Moved and renamed several classes - [see the full list here](https://commonmark.thephpleague.com/2.0/upgrading/#classesnamespaces-renamed)
  - Implemented a new approach to block parsing. This was a massive change, so here are the highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
    - `FencedCode::setInfo()`
    - `Heading::setLevel()`
    - `HtmlRenderer::renderDocument()`
+   - `InlineParserContext::getFullMatch()`
+   - `InlineParserContext::getFullMatchLength()`
+   - `InlineParserContext::getMatches()`
+   - `InlineParserContext::getSubMatches()`
    - `InvalidOptionException::forConfigOption()`
    - `InvalidOptionException::forParameter()`
    - `LinkParserHelper::parsePartialLinkLabel()`
@@ -65,7 +69,6 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
    - The paragraph parser no longer needs to be added manually to the environment
  - Implemented a new approach to inline parsing where parsers can now specify longer strings or regular expressions they want to parse (instead of just single characters):
    - `InlineParserInterface::getCharacters()` is now `getMatchDefinition()` and returns an instance of `InlineParserMatch`
-   - `InlineParserInterface::parse()` has a new parameter containing the pre-matched text
    - `InlineParserContext::__construct()` now requires the contents to be provided as a `Cursor` instead of a `string`
  - Implemented delimiter parsing as a special type of inline parser (via the new `DelimiterParser` class)
  - Changed block and inline rendering to use common methods and interfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See <https://commonmark.thephpleague.com/2.0/upgrading/> for detailed informatio
  - Added new `FrontMatterExtension` ([see documentation](https://commonmark.thephpleague.com/extensions/front-matter/))
  - Added the ability to delegate event dispatching to PSR-14 compliant event dispatcher libraries
  - Added the ability to configure disallowed raw HTML tags (#507)
+ - Added the ability for Mentions to use multiple characters for their symbol (#514, #550)
  - Added `heading_permalink/min_heading_level` and `heading_permalink/max_heading_level` options to control which headings get permalinks (#519)
  - Added `footnote/backref_symbol` option for customizing backreference link appearance (#522)
  - Added new `HtmlFilter` and `StringContainerHelper` utility classes

--- a/docs/2.0/upgrading.md
+++ b/docs/2.0/upgrading.md
@@ -132,6 +132,14 @@ As a result of making this change, the `addBlockParser()` method on `Configurabl
 
 See [the block parsing documentation](/2.0/customization/block-parsing/) for more information on this new approach.
 
+## New Inline Parsing Approach
+
+The `getCharacters()` method on `InlineParserInterface` has been replaced with a more-robust `getMatchDefinition()` method which allows your parser to match against more than just single characters.  All custom inline parsers will need to change to this new approach.
+
+Additionally, when the `parse()` method is called, the Cursor is no longer proactively advanced past the matching character/start position for you.  You'll need to advance this yourself.  However, the `InlineParserContext` now provides the fully-matched text and its length, allowing you to easily `advanceBy()` the cursor without having to do an expensive `$cursor->match()` yourself which is a nice performance optimization.
+
+See [the inline parsing documentation](/2.0/customization/inline-parsing/) for more information on this new approach.
+
 ## Rendering Changes
 
 This library no longer differentiates between block renderers and inline renderers - everything now uses "node renderers" which allow us to have a unified approach to rendering!  As a result, the following changes were made, which you may need to change in your custom extensions:

--- a/docs/2.0/upgrading.md
+++ b/docs/2.0/upgrading.md
@@ -245,6 +245,10 @@ This previously-deprecated constant was removed in 2.0. Use `HeadingPermalinkRen
 
 This previously-deprecated configuration option was removed in 2.0. Use `heading_permalink/symbol` instead.
 
+## `mentions/*/regex` configuration option
+
+Full regexes are no longer supported.  Remove the leading/trailing `/` delimiters and any PCRE flags.  For example: `/[\w_]+/iu` should be changed to `[\w_]+`.
+
 ## `ArrayCollection` methods
 
 Several methods were removed from this class - here are the methods along with possible alternatives you can switch to:

--- a/src/Delimiter/DelimiterParser.php
+++ b/src/Delimiter/DelimiterParser.php
@@ -32,9 +32,9 @@ final class DelimiterParser implements InlineParserInterface
         return InlineParserMatch::oneOf(...$this->collection->getDelimiterCharacters());
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        $character = $match;
+        $character = $inlineContext->getFullMatch();
         $numDelims = 0;
         $cursor    = $inlineContext->getCursor();
         $processor = $this->collection->getDelimiterProcessor($character);

--- a/src/Exception/InvalidOptionException.php
+++ b/src/Exception/InvalidOptionException.php
@@ -16,12 +16,18 @@ namespace League\CommonMark\Exception;
 final class InvalidOptionException extends \UnexpectedValueException
 {
     /**
-     * @param string $option     Name/path of the option
-     * @param mixed  $valueGiven The invalid option that was provided
+     * @param string  $option      Name/path of the option
+     * @param mixed   $valueGiven  The invalid option that was provided
+     * @param ?string $description Additional text describing the issue (optional)
      */
-    public static function forConfigOption(string $option, $valueGiven): self
+    public static function forConfigOption(string $option, $valueGiven, ?string $description = null): self
     {
-        return new self(\sprintf('Invalid config option for "%s": %s', $option, self::getDebugValue($valueGiven)));
+        $message = \sprintf('Invalid config option for "%s": %s', $option, self::getDebugValue($valueGiven));
+        if ($description !== null) {
+            $message .= \sprintf(' (%s)', $description);
+        }
+
+        return new self($message);
     }
 
     /**

--- a/src/Extension/Attributes/Parser/AttributesInlineParser.php
+++ b/src/Extension/Attributes/Parser/AttributesInlineParser.php
@@ -27,12 +27,12 @@ final class AttributesInlineParser implements InlineParserInterface
         return InlineParserMatch::oneOf(' ', '{');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        $char   = $match;
+        $char   = $inlineContext->getFullMatch();
         $cursor = $inlineContext->getCursor();
         if ($char === '{') {
-            $char = (string) $cursor->getCharacter($cursor->getPosition() - 1);
+            $char = (string) $cursor->peek(-1);
         }
 
         $attributes = AttributesHelper::parseAttributes($cursor);

--- a/src/Extension/Autolink/EmailAutolinkParser.php
+++ b/src/Extension/Autolink/EmailAutolinkParser.php
@@ -27,20 +27,21 @@ final class EmailAutolinkParser implements InlineParserInterface
         return InlineParserMatch::regex(self::REGEX);
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
+        $email = $inlineContext->getFullMatch();
         // The last character cannot be - or _
-        if (\in_array(\substr($match, -1), ['-', '_'], true)) {
+        if (\in_array(\substr($email, -1), ['-', '_'], true)) {
             return false;
         }
 
         // Does the URL end with punctuation that should be stripped?
-        if (\substr($match, -1) === '.') {
-            $match = \substr($match, 0, -1);
+        if (\substr($email, -1) === '.') {
+            $email = \substr($email, 0, -1);
         }
 
-        $inlineContext->getCursor()->advanceBy(\strlen($match));
-        $inlineContext->getContainer()->appendChild(new Link('mailto:' . $match, $match));
+        $inlineContext->getCursor()->advanceBy(\strlen($email));
+        $inlineContext->getContainer()->appendChild(new Link('mailto:' . $email, $email));
 
         return true;
     }

--- a/src/Extension/Autolink/UrlAutolinkParser.php
+++ b/src/Extension/Autolink/UrlAutolinkParser.php
@@ -76,7 +76,7 @@ final class UrlAutolinkParser implements InlineParserInterface
         return InlineParserMatch::oneOf(...$this->prefixes);
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
 

--- a/src/Extension/CommonMark/Parser/Inline/AutolinkParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/AutolinkParser.php
@@ -25,30 +25,30 @@ use League\CommonMark\Util\UrlEncoder;
 final class AutolinkParser implements InlineParserInterface
 {
     private const EMAIL_REGEX      = '<([a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>';
-    private const OTHER_LINK_REGEX = '<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>';
+    private const OTHER_LINK_REGEX = '<([A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*)>';
 
     public function getMatchDefinition(): InlineParserMatch
     {
         return InlineParserMatch::regex(self::EMAIL_REGEX . '|' . self::OTHER_LINK_REGEX);
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        $cursor = $inlineContext->getCursor();
-        if ($m = $cursor->match('/^' . self::EMAIL_REGEX . '/')) {
-            $email = \substr($m, 1, -1);
-            $inlineContext->getContainer()->appendChild(new Link('mailto:' . UrlEncoder::unescapeAndEncode($email), $email));
+        $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
+        $matches = $inlineContext->getMatches();
+
+        if ($matches[1] !== '') {
+            $inlineContext->getContainer()->appendChild(new Link('mailto:' . UrlEncoder::unescapeAndEncode($matches[1]), $matches[1]));
 
             return true;
         }
 
-        if ($m = $cursor->match('/^' . self::OTHER_LINK_REGEX . '/')) {
-            $dest = \substr($m, 1, -1);
-            $inlineContext->getContainer()->appendChild(new Link(UrlEncoder::unescapeAndEncode($dest), $dest));
+        if ($matches[2] !== '') {
+            $inlineContext->getContainer()->appendChild(new Link(UrlEncoder::unescapeAndEncode($matches[2]), $matches[2]));
 
             return true;
         }
 
-        return false;
+        return false; // This should never happen
     }
 }

--- a/src/Extension/CommonMark/Parser/Inline/BacktickParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/BacktickParser.php
@@ -29,11 +29,11 @@ final class BacktickParser implements InlineParserInterface
         return InlineParserMatch::regex('`+');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        $ticks  = $match;
+        $ticks  = $inlineContext->getFullMatch();
         $cursor = $inlineContext->getCursor();
-        $cursor->advanceBy(\mb_strlen($ticks));
+        $cursor->advanceBy($inlineContext->getFullMatchLength());
 
         $currentPosition = $cursor->getPosition();
         $previousState   = $cursor->saveState();

--- a/src/Extension/CommonMark/Parser/Inline/BangParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/BangParser.php
@@ -29,11 +29,11 @@ final class BangParser implements InlineParserInterface
         return InlineParserMatch::string('![');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
-
         $cursor->advanceBy(2);
+
         $node = new Text('![', ['delim' => true]);
         $inlineContext->getContainer()->appendChild($node);
 

--- a/src/Extension/CommonMark/Parser/Inline/CloseBracketParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/CloseBracketParser.php
@@ -46,7 +46,7 @@ final class CloseBracketParser implements InlineParserInterface, EnvironmentAwar
         return InlineParserMatch::string(']');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         // Look through stack of delimiters for a [ or !
         $opener = $inlineContext->getDelimiterStack()->searchByCharacter(['[', '!']);

--- a/src/Extension/CommonMark/Parser/Inline/EntityParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/EntityParser.php
@@ -30,10 +30,12 @@ final class EntityParser implements InlineParserInterface
         return InlineParserMatch::regex(RegexHelper::PARTIAL_ENTITY);
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        $inlineContext->getCursor()->advanceBy(\mb_strlen($match));
-        $inlineContext->getContainer()->appendChild(new Text(Html5EntityDecoder::decode($match)));
+        $entity = $inlineContext->getFullMatch();
+
+        $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
+        $inlineContext->getContainer()->appendChild(new Text(Html5EntityDecoder::decode($entity)));
 
         return true;
     }

--- a/src/Extension/CommonMark/Parser/Inline/EscapableParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/EscapableParser.php
@@ -30,7 +30,7 @@ final class EscapableParser implements InlineParserInterface
         return InlineParserMatch::string('\\');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor   = $inlineContext->getCursor();
         $nextChar = $cursor->peek();

--- a/src/Extension/CommonMark/Parser/Inline/HtmlInlineParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/HtmlInlineParser.php
@@ -29,10 +29,12 @@ final class HtmlInlineParser implements InlineParserInterface
         return InlineParserMatch::regex(RegexHelper::PARTIAL_HTMLTAG);
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        $inlineContext->getCursor()->advanceBy(\mb_strlen($match));
-        $inlineContext->getContainer()->appendChild(new HtmlInline($match));
+        $inline = $inlineContext->getFullMatch();
+
+        $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
+        $inlineContext->getContainer()->appendChild(new HtmlInline($inline));
 
         return true;
     }

--- a/src/Extension/CommonMark/Parser/Inline/OpenBracketParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/OpenBracketParser.php
@@ -29,7 +29,7 @@ final class OpenBracketParser implements InlineParserInterface
         return InlineParserMatch::string('[');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         $inlineContext->getCursor()->advanceBy(1);
         $node = new Text('[', ['delim' => true]);

--- a/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/AnonymousFootnoteRefParser.php
@@ -43,19 +43,16 @@ final class AnonymousFootnoteRefParser implements InlineParserInterface, Configu
 
     public function getMatchDefinition(): InlineParserMatch
     {
-        return InlineParserMatch::regex('\^\[[^\]]+\]');
+        return InlineParserMatch::regex('\^\[([^\]]+)\]');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        if (\preg_match('#\^\[([^\]]+)\]#', $match, $matches) <= 0) {
-            return false;
-        }
+        $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
 
-        $inlineContext->getCursor()->advanceBy(\mb_strlen($match));
-
-        $reference = $this->createReference($matches[1]);
-        $inlineContext->getContainer()->appendChild(new FootnoteRef($reference, $matches[1]));
+        [$label]   = $inlineContext->getSubMatches();
+        $reference = $this->createReference($label);
+        $inlineContext->getContainer()->appendChild(new FootnoteRef($reference, $label));
 
         return true;
     }

--- a/src/Extension/Footnote/Parser/FootnoteRefParser.php
+++ b/src/Extension/Footnote/Parser/FootnoteRefParser.php
@@ -32,14 +32,12 @@ final class FootnoteRefParser implements InlineParserInterface, ConfigurationAwa
         return InlineParserMatch::regex('\[\^([^\s\]]+)\]');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
-        if (\preg_match('#\[\^([^\s\]]+)\]#', $match, $matches) <= 0) {
-            return false;
-        }
+        $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
 
-        $inlineContext->getCursor()->advanceBy(\mb_strlen($match));
-        $inlineContext->getContainer()->appendChild(new FootnoteRef($this->createReference($matches[1])));
+        [$label] = $inlineContext->getSubMatches();
+        $inlineContext->getContainer()->appendChild(new FootnoteRef($this->createReference($label)));
 
         return true;
     }

--- a/src/Extension/Mention/Mention.php
+++ b/src/Extension/Mention/Mention.php
@@ -22,17 +22,17 @@ use League\CommonMark\Node\Inline\Text;
 class Mention extends Link
 {
     /** @var string */
-    private $symbol;
+    private $prefix;
 
     /** @var string */
     private $identifier;
 
-    public function __construct(string $symbol, string $identifier, ?string $label = null)
+    public function __construct(string $prefix, string $identifier, ?string $label = null)
     {
-        $this->symbol     = $symbol;
+        $this->prefix     = $prefix;
         $this->identifier = $identifier;
 
-        parent::__construct('', $label ?? \sprintf('%s%s', $symbol, $identifier));
+        parent::__construct('', $label ?? \sprintf('%s%s', $prefix, $identifier));
     }
 
     public function getLabel(): ?string
@@ -49,9 +49,9 @@ class Mention extends Link
         return $this->identifier;
     }
 
-    public function getSymbol(): string
+    public function getPrefix(): string
     {
-        return $this->symbol;
+        return $this->prefix;
     }
 
     public function hasUrl(): bool

--- a/src/Extension/Mention/MentionExtension.php
+++ b/src/Extension/Mention/MentionExtension.php
@@ -23,18 +23,18 @@ final class MentionExtension implements ExtensionInterface
     {
         $mentions = $environment->getConfig('mentions', []);
         foreach ($mentions as $name => $mention) {
-            foreach (['symbol', 'regex', 'generator'] as $key) {
+            foreach (['prefix', 'regex', 'generator'] as $key) {
                 if (! \array_key_exists($key, $mention)) {
                     throw new \RuntimeException(\sprintf('Missing "%s" from MentionParser configuration', $key));
                 }
             }
 
             if ($mention['generator'] instanceof MentionGeneratorInterface) {
-                $environment->addInlineParser(new MentionParser($mention['symbol'], $mention['regex'], $mention['generator']));
+                $environment->addInlineParser(new MentionParser($mention['prefix'], $mention['regex'], $mention['generator']));
             } elseif (\is_string($mention['generator'])) {
-                $environment->addInlineParser(MentionParser::createWithStringTemplate($mention['symbol'], $mention['regex'], $mention['generator']));
+                $environment->addInlineParser(MentionParser::createWithStringTemplate($mention['prefix'], $mention['regex'], $mention['generator']));
             } elseif (\is_callable($mention['generator'])) {
-                $environment->addInlineParser(MentionParser::createWithCallback($mention['symbol'], $mention['regex'], $mention['generator']));
+                $environment->addInlineParser(MentionParser::createWithCallback($mention['prefix'], $mention['regex'], $mention['generator']));
             } else {
                 throw new \RuntimeException(\sprintf('The "generator" provided for the MentionParser configuration must be a string template, callable, or an object that implements %s.', MentionGeneratorInterface::class));
             }

--- a/src/Extension/Mention/MentionParser.php
+++ b/src/Extension/Mention/MentionParser.php
@@ -70,7 +70,7 @@ final class MentionParser implements InlineParserInterface
         $previousState = $cursor->saveState();
 
         // Advance past the symbol to keep parsing simpler
-        $cursor->advance();
+        $cursor->advanceBy(\mb_strlen($this->symbol));
 
         // Parse the identifier
         $identifier = $cursor->match($this->mentionRegex);

--- a/src/Extension/SmartPunct/PunctuationParser.php
+++ b/src/Extension/SmartPunct/PunctuationParser.php
@@ -28,19 +28,20 @@ final class PunctuationParser implements InlineParserInterface
         return InlineParserMatch::oneOf('-', '.');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
+        $char   = $inlineContext->getFullMatch();
         $cursor = $inlineContext->getCursor();
 
         // Ellipses
-        if ($match === '.' && $matched = $cursor->match('/^\\.( ?\\.)\\1/')) {
+        if ($char === '.' && $matched = $cursor->match('/^\\.( ?\\.)\\1/')) {
             $inlineContext->getContainer()->appendChild(new Text('…'));
 
             return true;
         }
 
         // Em/En-dashes
-        if ($match === '-' && $matched = $cursor->match('/^(?<!-)(-{2,})/')) {
+        if ($char === '-' && $matched = $cursor->match('/^(?<!-)(-{2,})/')) {
             $count   = \strlen($matched);
             $enDash  = '–';
             $enCount = 0;

--- a/src/Extension/SmartPunct/QuoteParser.php
+++ b/src/Extension/SmartPunct/QuoteParser.php
@@ -35,11 +35,12 @@ final class QuoteParser implements InlineParserInterface
     /**
      * Normalizes any quote characters found and manually adds them to the delimiter stack
      */
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
+        $char   = $inlineContext->getFullMatch();
         $cursor = $inlineContext->getCursor();
 
-        $normalizedCharacter = $this->getNormalizedQuoteCharacter($match);
+        $normalizedCharacter = $this->getNormalizedQuoteCharacter($char);
 
         $charBefore = $cursor->peek(-1);
         if ($charBefore === null) {

--- a/src/Extension/TaskList/TaskListItemMarkerParser.php
+++ b/src/Extension/TaskList/TaskListItemMarkerParser.php
@@ -26,7 +26,7 @@ final class TaskListItemMarkerParser implements InlineParserInterface
         return InlineParserMatch::oneOf('[ ]', '[x]');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         $container = $inlineContext->getContainer();
 
@@ -46,7 +46,7 @@ final class TaskListItemMarkerParser implements InlineParserInterface
             return false;
         }
 
-        $isChecked = $match !== '[ ]';
+        $isChecked = $inlineContext->getFullMatch() !== '[ ]';
 
         $container->appendChild(new TaskListItemMarker($isChecked));
 

--- a/src/Parser/Inline/InlineParserInterface.php
+++ b/src/Parser/Inline/InlineParserInterface.php
@@ -19,5 +19,5 @@ interface InlineParserInterface
 {
     public function getMatchDefinition(): InlineParserMatch;
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool;
+    public function parse(InlineParserContext $inlineContext): bool;
 }

--- a/src/Parser/Inline/InlineParserMatch.php
+++ b/src/Parser/Inline/InlineParserMatch.php
@@ -28,7 +28,7 @@ final class InlineParserMatch
      */
     public function getRegex(): string
     {
-        return $this->regex;
+        return '/' . $this->regex . '/i';
     }
 
     /**
@@ -36,7 +36,7 @@ final class InlineParserMatch
      */
     public static function string(string $str): self
     {
-        return new self('/' . \preg_quote($str, '/') . '/i');
+        return new self(\preg_quote($str, '/'));
     }
 
     /**
@@ -44,9 +44,9 @@ final class InlineParserMatch
      */
     public static function oneOf(string ...$str): self
     {
-        return new self('/' . \implode('|', \array_map(static function (string $str): string {
+        return new self(\implode('|', \array_map(static function (string $str): string {
             return \preg_quote($str, '/');
-        }, $str)) . '/i');
+        }, $str)));
     }
 
     /**
@@ -54,6 +54,16 @@ final class InlineParserMatch
      */
     public static function regex(string $regex): self
     {
-        return new self('/' . $regex . '/i');
+        return new self($regex);
+    }
+
+    public static function join(self ...$definitions): self
+    {
+        $regex = '';
+        foreach ($definitions as $definition) {
+            $regex .= '(' . $definition->regex . ')';
+        }
+
+        return new self($regex);
     }
 }

--- a/src/Parser/Inline/NewlineParser.php
+++ b/src/Parser/Inline/NewlineParser.php
@@ -27,7 +27,7 @@ final class NewlineParser implements InlineParserInterface
         return InlineParserMatch::regex('\\n');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         $inlineContext->getCursor()->advanceBy(1);
 

--- a/src/Parser/InlineParserContext.php
+++ b/src/Parser/InlineParserContext.php
@@ -50,6 +50,14 @@ final class InlineParserContext
      */
     private $delimiterStack;
 
+    /**
+     * @var string[]
+     * @psalm-var non-empty-array<string>
+     *
+     * @psalm-readonly-allow-private-mutation
+     */
+    private $matches;
+
     public function __construct(Cursor $contents, AbstractBlock $container, ReferenceMapInterface $referenceMap)
     {
         $this->referenceMap   = $referenceMap;
@@ -76,5 +84,53 @@ final class InlineParserContext
     public function getDelimiterStack(): DelimiterStack
     {
         return $this->delimiterStack;
+    }
+
+    /**
+     * @return string The full text that matched the InlineParserMatch definition
+     */
+    public function getFullMatch(): string
+    {
+        return $this->matches[0];
+    }
+
+    /**
+     * @return int The length of the full match (in characters, not bytes)
+     */
+    public function getFullMatchLength(): int
+    {
+        return \mb_strlen($this->matches[0]);
+    }
+
+    /**
+     * @return string[] Similar to preg_match(), index 0 will contain the full match, and any other array elements will be captured sub-matches
+     *
+     * @psalm-return non-empty-array<string>
+     */
+    public function getMatches(): array
+    {
+        return $this->matches;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSubMatches(): array
+    {
+        return \array_slice($this->matches, 1);
+    }
+
+    /**
+     * @param string[] $matches
+     *
+     * @psalm-param non-empty-array<string> $matches
+     */
+    public function withMatches(array $matches): InlineParserContext
+    {
+        $ctx = clone $this;
+
+        $ctx->matches = $matches;
+
+        return $ctx;
     }
 }

--- a/tests/functional/Extension/Mention/MentionExtensionTest.php
+++ b/tests/functional/Extension/Mention/MentionExtensionTest.php
@@ -15,6 +15,7 @@ namespace League\CommonMark\Tests\Functional\Extension\Mention;
 
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidOptionException;
 use League\CommonMark\Extension\Mention\Generator\MentionGeneratorInterface;
 use League\CommonMark\Extension\Mention\Mention;
 use League\CommonMark\Extension\Mention\MentionExtension;
@@ -139,7 +140,7 @@ EOT;
 
     public function testConfigUnknownGenerator(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidOptionException::class);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addExtension(new MentionExtension());
@@ -160,7 +161,7 @@ EOT;
 
     public function testLegacySymbolOption(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidOptionException::class);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addExtension(new MentionExtension());
@@ -169,6 +170,27 @@ EOT;
                 'github_handle' => [
                     'symbol'    => '@',
                     'regex'     => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
+                    'generator' => 'https://github.com/%s',
+                ],
+            ],
+        ]);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $converter->convertToHtml('foo');
+    }
+
+    public function testWithFullRegexOption(): void
+    {
+        $this->expectException(InvalidOptionException::class);
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new MentionExtension());
+        $environment->setConfig([
+            'mentions' => [
+                'github_handle' => [
+                    'prefix'    => '@',
+                    'regex'     => '/[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/i',
                     'generator' => 'https://github.com/%s',
                 ],
             ],

--- a/tests/functional/Extension/Mention/MentionExtensionTest.php
+++ b/tests/functional/Extension/Mention/MentionExtensionTest.php
@@ -59,7 +59,7 @@ EOT;
             'mentions' => [
                 'github_handle' => [
                     'prefix'    => '@',
-                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'regex'     => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
                     'generator' => 'https://github.com/%s',
                 ],
             ],
@@ -87,7 +87,7 @@ EOT;
             'mentions' => [
                 'github_handle' => [
                     'prefix'    => '@',
-                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'regex'     => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
                     'generator' => static function (Mention $mention) {
                         $mention->setUrl(\sprintf('https://github.com/%s', $mention->getIdentifier()));
 
@@ -119,7 +119,7 @@ EOT;
             'mentions' => [
                 'github_handle' => [
                     'prefix'    => '@',
-                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'regex'     => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
                     'generator' => new class () implements MentionGeneratorInterface {
                         public function generateMention(Mention $mention): ?AbstractInline
                         {
@@ -147,7 +147,7 @@ EOT;
             'mentions' => [
                 'github_handle' => [
                     'prefix'    => '@',
-                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'regex'     => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
                     'generator' => new \stdClass(),
                 ],
             ],
@@ -168,7 +168,7 @@ EOT;
             'mentions' => [
                 'github_handle' => [
                     'symbol'    => '@',
-                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'regex'     => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
                     'generator' => 'https://github.com/%s',
                 ],
             ],

--- a/tests/functional/Extension/Mention/MentionExtensionTest.php
+++ b/tests/functional/Extension/Mention/MentionExtensionTest.php
@@ -58,7 +58,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => 'https://github.com/%s',
                 ],
@@ -86,7 +86,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => static function (Mention $mention) {
                         $mention->setUrl(\sprintf('https://github.com/%s', $mention->getIdentifier()));
@@ -118,7 +118,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => new class () implements MentionGeneratorInterface {
                         public function generateMention(Mention $mention): ?AbstractInline
@@ -146,7 +146,7 @@ EOT;
         $environment->setConfig([
             'mentions' => [
                 'github_handle' => [
-                    'symbol'    => '@',
+                    'prefix'    => '@',
                     'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                     'generator' => new \stdClass(),
                 ],
@@ -156,5 +156,26 @@ EOT;
         $converter = new CommonMarkConverter([], $environment);
 
         $converter->convertToHtml('');
+    }
+
+    public function testLegacySymbolOption(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new MentionExtension());
+        $environment->setConfig([
+            'mentions' => [
+                'github_handle' => [
+                    'symbol'    => '@',
+                    'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
+                    'generator' => 'https://github.com/%s',
+                ],
+            ],
+        ]);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $converter->convertToHtml('foo');
     }
 }

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -40,7 +40,7 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
-    public function testMentionParserWithMultiCharacterSymbol(): void
+    public function testMentionParserWithMultiCharacterPrefix(): void
     {
         $input    = 'Try asking u:colinodell about that.';
         $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
@@ -55,7 +55,7 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
-    public function testMentionParserWithMultiCharacterSymbolContainingSpecialRegexCharsThatShouldBeEscaped(): void
+    public function testMentionParserWithMultiCharacterPrefixContainingSpecialRegexCharsThatShouldBeEscaped(): void
     {
         $input    = 'I spend too much time on the /r/php subreddit.';
         $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
@@ -85,7 +85,7 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
-    public function testMentionParserWithNonMatchingSymbol(): void
+    public function testMentionParserWithNonMatchingPrefix(): void
     {
         $input    = 'See #123 for more information.';
         $expected = '<p>See #123 for more information.</p>';
@@ -137,7 +137,7 @@ final class MentionParserTest extends TestCase
     {
         $callable = static function (Mention $mention) {
             // Stuff the three params into the URL just to prove we received them all properly
-            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getSymbol()));
+            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getPrefix()));
             // Change the label
             $mention->setLabel('Replaced Label');
 

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -30,7 +30,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See #123 for more information.';
         $expected = '<p>See <a href="https://www.example.com/123">#123</a> for more information.</p>';
 
-        $mentionParser = new MentionParser('#', '/^\d+/', new StringTemplateLinkGenerator('https://www.example.com/%s'));
+        $mentionParser = new MentionParser('#', '\d+', new StringTemplateLinkGenerator('https://www.example.com/%s'));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -45,7 +45,7 @@ final class MentionParserTest extends TestCase
         $input    = 'Try asking u:colinodell about that.';
         $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
 
-        $mentionParser = new MentionParser('u:', '/^\w+/', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
+        $mentionParser = new MentionParser('u:', '\w+', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -60,7 +60,7 @@ final class MentionParserTest extends TestCase
         $input    = 'I spend too much time on the /r/php subreddit.';
         $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
 
-        $mentionParser = new MentionParser('/r/', '/^\w+/', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
+        $mentionParser = new MentionParser('/r/', '\w+', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -75,7 +75,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See#123 for more information.';
         $expected = '<p>See#123 for more information.</p>';
 
-        $mentionParser = new MentionParser('#', '/^\d+/', $this->createMock(MentionGeneratorInterface::class));
+        $mentionParser = new MentionParser('#', '\d+', $this->createMock(MentionGeneratorInterface::class));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -90,7 +90,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See #123 for more information.';
         $expected = '<p>See #123 for more information.</p>';
 
-        $mentionParser = new MentionParser('@', '/^\d+/', $this->createMock(MentionGeneratorInterface::class));
+        $mentionParser = new MentionParser('@', '\d+', $this->createMock(MentionGeneratorInterface::class));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -105,7 +105,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See #123 for more information.';
         $expected = '<p>See #123 for more information.</p>';
 
-        $mentionParser = new MentionParser('#', '/^[a-z]+/', $this->createMock(MentionGeneratorInterface::class));
+        $mentionParser = new MentionParser('#', '[a-z]+', $this->createMock(MentionGeneratorInterface::class));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -123,7 +123,7 @@ final class MentionParserTest extends TestCase
         $returnsNull = $this->createMock(MentionGeneratorInterface::class);
         $returnsNull->method('generateMention')->willReturn(null);
 
-        $mentionParser = new MentionParser('#', '/^\d+/', $returnsNull);
+        $mentionParser = new MentionParser('#', '\d+', $returnsNull);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -147,7 +147,7 @@ final class MentionParserTest extends TestCase
         $input    = 'This should parse #123.';
         $expected = '<p>This should parse <a href="https://www.example.com/123/#123/#">Replaced Label</a>.</p>';
 
-        $mentionParser = MentionParser::createWithCallback('#', '/^\d+/', $callable);
+        $mentionParser = MentionParser::createWithCallback('#', '\d+', $callable);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -170,7 +170,7 @@ final class MentionParserTest extends TestCase
         $input    = 'This should parse #123.';
         $expected = '<p>This should parse <em>[members only]</em>.</p>';
 
-        $mentionParser = MentionParser::createWithCallback('#', '/^\d+/', $callable);
+        $mentionParser = MentionParser::createWithCallback('#', '\d+', $callable);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -40,6 +40,36 @@ final class MentionParserTest extends TestCase
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
 
+    public function testMentionParserWithMultiCharacterSymbol(): void
+    {
+        $input    = 'Try asking u:colinodell about that.';
+        $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
+
+        $mentionParser = new MentionParser('u:', '/^\w+/', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
+    }
+
+    public function testMentionParserWithMultiCharacterSymbolContainingSpecialRegexCharsThatShouldBeEscaped(): void
+    {
+        $input    = 'I spend too much time on the /r/php subreddit.';
+        $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
+
+        $mentionParser = new MentionParser('/r/', '/^\w+/', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
+    }
+
     public function testMentionParserWithoutSpaceInFront(): void
     {
         $input    = 'See#123 for more information.';

--- a/tests/unit/Environment/FakeInjectableInlineParser.php
+++ b/tests/unit/Environment/FakeInjectableInlineParser.php
@@ -28,7 +28,7 @@ final class FakeInjectableInlineParser implements InlineParserInterface, Configu
         return InlineParserMatch::oneOf('');
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
         return false;
     }

--- a/tests/unit/Extension/CommonMark/Parser/Inline/BacktickParserTest.php
+++ b/tests/unit/Extension/CommonMark/Parser/Inline/BacktickParserTest.php
@@ -40,7 +40,7 @@ class BacktickParserTest extends TestCase
         $cursor->advanceBy($firstBacktickPos);
 
         $parser = new BacktickParser();
-        $this->assertTrue($parser->parse($cursor->getCharacter(), $inlineContext));
+        $this->assertTrue($parser->parse($inlineContext->withMatches([$cursor->getCharacter()])));
 
         $codeBlock = $paragraph->firstChild();
         \assert($codeBlock instanceof Code);

--- a/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
+++ b/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
@@ -25,7 +25,7 @@ final class CallbackGeneratorTest extends TestCase
     {
         $generator = new CallbackGenerator(static function (Mention $mention) {
             // Stuff the three params into the URL just to prove we received them all properly
-            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getSymbol()));
+            $mention->setUrl(\sprintf('https://www.example.com/%s/%s/%s', $mention->getIdentifier(), $mention->getLabel(), $mention->getPrefix()));
             // Change the label
             $mention->setLabel('New Label');
 

--- a/tests/unit/Extension/Mention/MentionTest.php
+++ b/tests/unit/Extension/Mention/MentionTest.php
@@ -23,7 +23,7 @@ final class MentionTest extends TestCase
     {
         $mention = new Mention('@', 'colinodell');
 
-        $this->assertSame('@', $mention->getSymbol());
+        $this->assertSame('@', $mention->getPrefix());
         $this->assertSame('colinodell', $mention->getIdentifier());
         $this->assertSame('@colinodell', $mention->getLabel());
         $this->assertSame('', $mention->getUrl());
@@ -38,7 +38,7 @@ final class MentionTest extends TestCase
     {
         $mention = new Mention('#', '123', 'Issue #123');
 
-        $this->assertSame('#', $mention->getSymbol());
+        $this->assertSame('#', $mention->getPrefix());
         $this->assertSame('123', $mention->getIdentifier());
         $this->assertSame('Issue #123', $mention->getLabel());
         $this->assertSame('', $mention->getUrl());

--- a/tests/unit/Parser/Inline/FakeInlineParser.php
+++ b/tests/unit/Parser/Inline/FakeInlineParser.php
@@ -36,8 +36,9 @@ final class FakeInlineParser implements InlineParserInterface
         return $this->start;
     }
 
-    public function parse(string $match, InlineParserContext $inlineContext): bool
+    public function parse(InlineParserContext $inlineContext): bool
     {
+        $match           = $inlineContext->getFullMatch();
         $this->matches[] = $match;
 
         $inlineContext->getCursor()->advanceBy(\mb_strlen($match));

--- a/tests/unit/Parser/Inline/InlineParserMatchTest.php
+++ b/tests/unit/Parser/Inline/InlineParserMatchTest.php
@@ -39,5 +39,13 @@ final class InlineParserMatchTest extends TestCase
         yield [InlineParserMatch::oneOf('foo', 'bar'), '/foo|bar/i'];
         yield [InlineParserMatch::oneOf('foo', '.', '[x]'), '/foo|\.|\[x\]/i'];
         yield [InlineParserMatch::regex('[\w-_]{3,}'), '/[\w-_]{3,}/i'];
+
+        $complexExample = InlineParserMatch::join(
+            InlineParserMatch::string('foo'),
+            InlineParserMatch::oneOf('bar', 'baz'),
+            InlineParserMatch::regex('\d+')
+        );
+
+        yield [$complexExample, '/(foo)(bar|baz)(\d+)/i'];
     }
 }


### PR DESCRIPTION
This takes the changes from #550 and #551 to the next level :wink: 

Based on @markcarver's feedback, we're removing the `string $match` parameter from `InlineParserInterface::parse()` and instead exposing the matches via the context.  This also now includes sub-matches from regex capturing groups.