### PR TITLE
Fix styles in table headings

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -285,7 +285,8 @@ table {
     box-shadow:0 6px 6px 0 rgba(80, 88, 94, .24);
 }
 
-table th {
+table th,
+table th > * {
     color:#fff;
     background: #1672ce;
 }


### PR DESCRIPTION
This PR adds inheritance to all possible direct children of a table header in the docs.

Currently, the `th` styles are bypassed by the styles of the child element. 
E.g. https://commonmark.thephpleague.com/1.5/upgrading/