### PR TITLE
Add minor style tweaks for smaller mobile screens

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -3,7 +3,10 @@ html {
 }
 
 body {
-    min-width: 460px;
+    /* ADDED - Add Flexbox for responsiveness */
+    min-width: 320px;
+    display: flex;
+    flex-flow: column;
 }
 
 blockquote {
@@ -291,9 +294,29 @@ table th > * {
     background: #1672ce;
 }
 
+/* ADDED - Responsive table size for mobile */
+@media screen and (max-width: 420px) {
+    table {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        font-size: 0.9rem;
+    }
+}
+
+/* ADDED - Responsive table size for mobile */
+@media screen and (max-width: 375px) {
+    main article table td {
+        padding: 2px 5px 2px 2px;
+    }
+    thead tr {
+        font-size: 0.8rem;
+    }
+}
 
 header .logo .name {
-    font-size: 2rem;
+    /* ADDED - Add smaller font-size for mobile */
+    font-size: 1.6rem;
     line-height: 100%;
     margin: 0 !important;
 }
@@ -317,7 +340,8 @@ header .logo em {
 
 @media screen and (max-width: 549px) {
     header {
-        padding: 20px 0 25px 10px;
+        /* ADDED - Adjust padding for mobile */
+        padding: 25px 0 20px 10px;
     }
 
     menu {

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -3,7 +3,6 @@ html {
 }
 
 body {
-    /* ADDED - Add Flexbox for responsiveness */
     min-width: 320px;
     display: flex;
     flex-flow: column;
@@ -294,7 +293,6 @@ table th > * {
     background: #1672ce;
 }
 
-/* ADDED - Responsive table size for mobile */
 @media screen and (max-width: 420px) {
     table {
         display: flex;
@@ -304,7 +302,6 @@ table th > * {
     }
 }
 
-/* ADDED - Responsive table size for mobile */
 @media screen and (max-width: 375px) {
     main article table td {
         padding: 2px 5px 2px 2px;
@@ -315,7 +312,6 @@ table th > * {
 }
 
 header .logo .name {
-    /* ADDED - Add smaller font-size for mobile */
     font-size: 1.6rem;
     line-height: 100%;
     margin: 0 !important;
@@ -340,7 +336,6 @@ header .logo em {
 
 @media screen and (max-width: 549px) {
     header {
-        /* ADDED - Adjust padding for mobile */
         padding: 25px 0 20px 10px;
     }
 


### PR DESCRIPTION
Hey there! I added a few style tweaks to the CSS to accommodate for smaller mobile screens, including preventing the header logo from being cutoff, and adding Flexbox in a couple places to help keep the layout responsive.