### PR TITLE
Code block consistency - Legacy versions

### DIFF
--- a/docs/0.19/basic-usage.md
+++ b/docs/0.19/basic-usage.md
@@ -8,9 +8,7 @@ Basic Usage
 
 The `CommonMarkConverter` class provides a simple wrapper for converting CommonMark to HTML:
 
-~~~php
-<?php
-
+```php
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\CommonMarkConverter;
@@ -19,7 +17,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [security](/0.19/security/) section for important details on avoiding security misconfigurations.
@@ -32,9 +30,7 @@ The actual conversion process requires three steps:
 
 You can do this yourself if you wish:
 
-~~~php
-<?php
-
+```php
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\DocParser;
@@ -51,6 +47,6 @@ $document = $parser->parse($markdown);
 echo $htmlRenderer->renderBlock($document);
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 [Additional customization](/0.19/customization/overview/) is also possible.

--- a/docs/0.19/command-line.md
+++ b/docs/0.19/command-line.md
@@ -10,8 +10,10 @@ Markdown can be converted at the command line using the `./bin/commonmark` scrip
 
 ## Usage
 
-    ./bin/commonmark [OPTIONS] [FILE]
-    
+```bash
+./bin/commonmark [OPTIONS] [FILE]
+```
+
 * `-h`, `--help`: Shows help and usage information
 * `--enable-em`: Disable `<em>` parsing by setting to `0`; enable with `1` (default: `1`)
 * `--enable-strong`: Disable `<strong>` parsing by setting to `0`; enable with `1` (default: `1`)
@@ -26,16 +28,24 @@ Output will be written to STDOUT.
 
 ### Converting a file named document.md
 
-    ./bin/commonmark document.md
+```bash
+./bin/commonmark document.md
+```
 
 ### Converting a file and saving its output
 
-    ./bin/commonmark document.md > output.html
+```bash
+./bin/commonmark document.md > output.html
+```
 
 ### Converting from STDIN
 
-    echo -e '# Hello World!' | ./bin/commonmark
+```bash
+echo -e '# Hello World!' | ./bin/commonmark
+```
 
 ### Converting from STDIN and saving the output
 
-    echo -e '# Hello World!' | ./bin/commonmark > output.html
+```bash
+echo -e '# Hello World!' | ./bin/commonmark > output.html
+```

--- a/docs/0.19/configuration.md
+++ b/docs/0.19/configuration.md
@@ -8,9 +8,7 @@ Configuration
 
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it::
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter([
@@ -27,13 +25,13 @@ $converter = new CommonMarkConverter([
     'allow_unsafe_links' => false,
     'max_nesting_level' => INF
 ]);
-~~~
+```
 
 Here's a list of currently-supported options:
 
 * `renderer` - Array of options for rendering HTML
   * `block_separator` - String to use for separating renderer block elements
-  * `inner_separator` - String to use for separating inner block contents 
+  * `inner_separator` - String to use for separating inner block contents
   * `soft_break` - String to use for rendering soft breaks
 * `enable_em` - Disable `<em>` parsing by setting to `false`; enable with `true` (default: `true`)
 * `enable_strong` - Disable `<strong>` parsing by setting to `false`; enable with `true` (default: `true`)

--- a/docs/0.19/customization/abstract-syntax-tree.md
+++ b/docs/0.19/customization/abstract-syntax-tree.md
@@ -23,14 +23,12 @@ The following methods can be used to traverse the AST:
 
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
-~~~php
-<?php
-
+```php
 $walker = $document->walker();
 while ($event = $walker->next()) {
     echo 'I am ' . ($event->isEntering() ? 'entering' : 'leaving') . ' a ' . get_class($event->getNode()) . ' node' . "\n";
 }
-~~~
+```
 
 This walker doesn't use recursion, so you won't blow the stack when working with deeply-nested nodes.
 

--- a/docs/0.19/customization/block-rendering.md
+++ b/docs/0.19/customization/block-rendering.md
@@ -32,28 +32,24 @@ You are responsible for handling any escaping that may be necessary.
 
 When registering your render, you must tell the `Environment` which block element class your renderer should handle. For example:
 
-~~~php
-<?php
-
+```php
 $environment = Environment::createCommonMarkEnvironment();
 
 // First param - the block class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addBlockRenderer(League\CommonMark\Block\Element\FencedCode::class, new MyCustomCodeRenderer());
-~~~
+```
 
 A single renderer could even be used for multiple block types:
 
-~~~php
-<?php
-
+```php
 $environment = Environment::createCommonMarkEnvironment();
 
 $myRenderer = new MyCustomCodeRenderer();
 
 $environment->addBlockRenderer(League\CommonMark\Block\Element\FencedCode::class, $myRenderer, 10);
 $environment->addBlockRenderer(League\CommonMark\Block\Element\IndentedCode::class, $myRenderer, 20);
-~~~
+```
 
 Multiple renderers can be added per element type - when this happens, we use the result from the highest-priority renderer that returns a non-`null` result.
 
@@ -61,9 +57,7 @@ Multiple renderers can be added per element type - when this happens, we use the
 
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
-~~~php
-<?php
-
+```php
 class TextDividerRenderer implements BlockRendererInterface
 {
     public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, $inTightList = false)
@@ -74,7 +68,7 @@ class TextDividerRenderer implements BlockRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addBlockRenderer('League\CommonMark\Block\Element\ThematicBreak', new TextDividerRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/0.19/customization/document-processing.md
+++ b/docs/0.19/customization/document-processing.md
@@ -8,24 +8,20 @@ Document Processing
 
 The best way to manipulate the [Abstract Syntax Tree](/0.19/customization/abstract-syntax-tree/) is by implementing a custom Document Processor.  These are executed once all other processing is done and the document is ready to be rendered. Simply create a class which implements the `DocumentProcessorInterface` which contains a single method:
 
-~~~php
-<?php
-
+```php
 /**
  * @param Document $document
  *
  * @return void
  */
 public function processDocument(Document $document);
-~~~
+```
 
 This method receives the root `Document` node which you could then walk across, modifying nodes as needed.
 
 Here's an example of a Document Processor which adds an `external-link` class to external URLs.
- 
-~~~php
-<?php
 
+```php
 class ExternalLinkProcessor implements DocumentProcessorInterface, ConfigurationAwareInterface
 {
     private $config;
@@ -78,13 +74,11 @@ class ExternalLinkProcessor implements DocumentProcessorInterface, Configuration
         return $host != $this->config->getConfig('host');
     }
 }
-~~~
+```
 
 And here's how you'd use it:
 
-~~~php
-<?php
-
+```php
 $env = Environment::createCommonMarkEnvironment();
 $env->addDocumentProcessor(new ExternalLinkProcessor());
 
@@ -93,15 +87,15 @@ $converter = new CommonMarkConverter(['host' => 'commonmark.thephpleague.com'], 
 $input = 'My two favorite sites are <https://google.com> and <https://commonmark.thephpleague.com>';
 
 echo $converter->convertToHtml($input);
-~~~
+```
 
 Output (formatted for readability):
 
-~~~html
+```html
 <p>
     My two favorite sites are
     <a class="external-link" href="https://google.com">https://google.com</a>
     and
     <a href="https://commonmark.thephpleague.com">https://commonmark.thephpleague.com</a>
 </p>
-~~~
+```

--- a/docs/0.19/customization/environment.md
+++ b/docs/0.19/customization/environment.md
@@ -10,13 +10,11 @@ All parsers, renderers, etc. must be registered with the `Environment` class so 
 
 A pre-configured `Environment` can be obtained like this:
 
-~~~php
-<?php
-
+```php
 use League\CommonMark;
 
 $environment = Environment::createCommonMarkEnvironment();
-~~~
+```
 
 All of the core renders, parsers, etc. will be pre-registered and ready to go.
 
@@ -25,11 +23,9 @@ You can customize this default `Environment` (or even a new, empty one) using an
 
 ## addBlockParser()
 
-~~~php
-<?php
-
+```php
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `BlockParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -37,11 +33,9 @@ See [Block Parsing](/0.19/customization/block-parsing/) for details.
 
 ## addBlockRenderer()
 
-~~~php
-<?php
-
+```php
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
-~~~
+```
 
 Registers a `BlockRendererInterface` to handle a specific type of block (`$blockClass`)  with the given priority (a higher number will be executed earlier).
 
@@ -49,11 +43,9 @@ See [Block Rendering](/0.19/customization/block-rendering/) for details.
 
 ## addInlineParser()
 
-~~~php
-<?php
-
+```php
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `InlineParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -61,11 +53,9 @@ See [Inline Parsing](/0.19/customization/inline-parsing/) for details.
 
 ## addInlineProcessor()
 
-~~~php
-<?php
-
+```php
 public function addInlineProcessor(InlineProcessorInterface $processor);
-~~~
+```
 
 Registers the given `InlineProcessorInterface` with the environment.
 
@@ -73,11 +63,9 @@ Registers the given `InlineProcessorInterface` with the environment.
 
 ## addInlineRenderer()
 
-~~~php
-<?php
-
+```php
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
-~~~
+```
 
 Registers an `InlineRendererInterface` to handle a specific type of inline (`$inlineClass`) with the given priority (a higher number will be executed earlier).
 A single renderer can handle multiple inline classes, but you must register it separately for each type. (The same renderer instance can be re-used if desired.)
@@ -86,11 +74,9 @@ See [Inline Rendering](/0.19/customization/inline-rendering/) for details.
 
 ## addDocumentProcessor()
 
-~~~php
-<?php
-
+```php
 public function addDocumentProcessor(DocumentProcessorInterface $processor, int $priority = 0);
-~~~
+```
 
 Adds a new Document Processor which will [manipulate the AST](/0.19/customization/abstract-syntax-tree/) after parsing the document but before rendering it.
 

--- a/docs/0.19/customization/inline-parsing.md
+++ b/docs/0.19/customization/inline-parsing.md
@@ -38,15 +38,14 @@ Returning `true` tells the engine that you've successfully parsed the character 
 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
-~~~php
-<?php
-
+```php
 class TwitterHandleParser extends AbstractInlineParser
 {
     public function getCharacters()
     {
         return ['@'];
     }
+
     public function parse(InlineParserContext $inlineContext)
     {
         $cursor = $inlineContext->getCursor();
@@ -75,15 +74,13 @@ class TwitterHandleParser extends AbstractInlineParser
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new TwitterHandleParser());
-~~~
+```
 
 ### Example 2 - Emoticons
 
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
-~~~php
-<?php
-
+```php
 class SmilieParser extends AbstractInlineParser
 {
     public function getCharacters()
@@ -104,7 +101,7 @@ class SmilieParser extends AbstractInlineParser
 
         // Advance the cursor past the 2 matched chars since we're able to parse them successfully
         $cursor->advanceBy(2);
-        
+
         // Add the corresponding image
         if ($nextChar === ')') {
             $inlineContext->getContainer()->appendChild(new Image('/img/happy.png'));
@@ -118,7 +115,7 @@ class SmilieParser extends AbstractInlineParser
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new SmilieParserParser());
-~~~
+```
 
 ## Tips
 

--- a/docs/0.19/customization/inline-rendering.md
+++ b/docs/0.19/customization/inline-rendering.md
@@ -33,23 +33,19 @@ Return `null` if your renderer cannot handle the given inline element - the next
 
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
-~~~php
-<?php
-
+```php
 $environment = Environment::createCommonMarkEnvironment();
 
 // First param - the inline class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyCustomLinkRenderer());
-~~~
+```
 
 ## Example
 
 Here's a custom renderer which puts a special class on links to external sites:
 
-~~~php
-<?php
-
+```php
 class MyCustomLinkRenderer implements InlineRendererInterface
 {
     private $host;
@@ -88,7 +84,7 @@ class MyCustomLinkRenderer implements InlineRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyCustomLinkRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/0.19/index.md
+++ b/docs/0.19/index.md
@@ -19,9 +19,9 @@ title: Overview
 
 This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark:^0.19
-~~~
+```
 
 See the [installation](/0.19/installation/) section for more details.
 
@@ -29,16 +29,14 @@ See the [installation](/0.19/installation/) section for more details.
 
 Simply instantiate the converter and start converting some Markdown to HTML!
 
-~~~php
-<?php
-
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [basic usage](/0.19/basic-usage/) and [security](/0.19/security/) sections for important details.

--- a/docs/0.19/installation.md
+++ b/docs/0.19/installation.md
@@ -9,9 +9,9 @@ The recommended installation method is via Composer.
 
 In your project root just run:
 
-~~~bash
+```bash
 composer require league/commonmark:^0.19
-~~~
+```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 

--- a/docs/0.19/security.md
+++ b/docs/0.19/security.md
@@ -14,24 +14,24 @@ If you're developing an application which renders user-provided Markdown from po
 
 ### Example - Escape all raw HTML input:
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'escape']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // &lt;script&gt;alert("Hello XSS!");&lt;/script&gt;
-~~~
+```
 
 ### Example - Strip all HTML from the input:
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'strip']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // (empty output)
-~~~
+```
 
 **Failing to set this option could make your site vulnerable to cross-site scripting (XSS) attacks!**
 
@@ -55,7 +55,7 @@ To prevent these from being parsed and rendered, you should set the `allow_unsaf
 If you need to parse untrusted input, consider setting a reasonable `max_nesting_level` (perhaps 10-50) depending on your needs.  Once this nesting level is hit, any subsequent Markdown will be rendered as plain text.
 
 ### Example - Prevent deep nesting
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
@@ -73,6 +73,6 @@ echo $converter->convertToHtml($markdown);
 //     </blockquote>
 //   </blockquote>
 // </blockquote>
-~~~
+```
 
 See the [configuration](/0.19/configuration/) section for more information.

--- a/docs/1.0/basic-usage.md
+++ b/docs/1.0/basic-usage.md
@@ -11,8 +11,6 @@ Basic Usage
 The `CommonMarkConverter` class provides a simple wrapper for converting CommonMark to HTML:
 
 ```php
-<?php
-
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\CommonMarkConverter;
@@ -35,8 +33,6 @@ The actual conversion process has three steps:
 `CommonMarkConverter` handles this for you, but you can execute that process yourself if you wish:
 
 ```php
-<?php
-
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\DocParser;

--- a/docs/1.0/basic-usage.md
+++ b/docs/1.0/basic-usage.md
@@ -10,7 +10,7 @@ Basic Usage
 
 The `CommonMarkConverter` class provides a simple wrapper for converting CommonMark to HTML:
 
-~~~php
+```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
@@ -21,7 +21,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [security](/1.0/security/) section for important details on avoiding security misconfigurations.
@@ -34,7 +34,7 @@ The actual conversion process has three steps:
 
 `CommonMarkConverter` handles this for you, but you can execute that process yourself if you wish:
 
-~~~php
+```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
@@ -53,7 +53,7 @@ $document = $parser->parse($markdown);
 echo $htmlRenderer->renderBlock($document);
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 [Additional customization](/1.0/customization/overview/) is also possible.
 

--- a/docs/1.0/command-line.md
+++ b/docs/1.0/command-line.md
@@ -11,8 +11,10 @@ Markdown can be converted at the command line using the `./bin/commonmark` scrip
 
 ## Usage
 
-    ./bin/commonmark [OPTIONS] [FILE]
-    
+```bash
+./bin/commonmark [OPTIONS] [FILE]
+```
+
 * `-h`, `--help`: Shows help and usage information
 * `--enable-em`: Disable `<em>` parsing by setting to `0`; enable with `1` (default: `1`)
 * `--enable-strong`: Disable `<strong>` parsing by setting to `0`; enable with `1` (default: `1`)
@@ -27,16 +29,24 @@ Output will be written to STDOUT.
 
 ### Converting a file named document.md
 
-    ./bin/commonmark document.md
+```bash
+./bin/commonmark document.md
+```
 
 ### Converting a file and saving its output
 
-    ./bin/commonmark document.md > output.html
+```bash
+./bin/commonmark document.md > output.html
+```
 
 ### Converting from STDIN
 
-    echo -e '# Hello World!' | ./bin/commonmark
+```bash
+echo -e '# Hello World!' | ./bin/commonmark
+```
 
 ### Converting from STDIN and saving the output
 
-    echo -e '# Hello World!' | ./bin/commonmark > output.html
+```bash
+echo -e '# Hello World!' | ./bin/commonmark > output.html
+```

--- a/docs/1.0/configuration.md
+++ b/docs/1.0/configuration.md
@@ -10,8 +10,6 @@ Configuration
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter([

--- a/docs/1.0/configuration.md
+++ b/docs/1.0/configuration.md
@@ -9,7 +9,7 @@ Configuration
 
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -29,7 +29,7 @@ $converter = new CommonMarkConverter([
     'allow_unsafe_links' => false,
     'max_nesting_level' => INF,
 ]);
-~~~
+```
 
 Here's a list of currently-supported options:
 

--- a/docs/1.0/customization/abstract-syntax-tree.md
+++ b/docs/1.0/customization/abstract-syntax-tree.md
@@ -26,8 +26,6 @@ The following methods can be used to traverse the AST:
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
 ```php
-<?php
-
 use League\CommonMark\Node\NodeWalker;
 
 /** @var NodeWalker $walker */

--- a/docs/1.0/customization/abstract-syntax-tree.md
+++ b/docs/1.0/customization/abstract-syntax-tree.md
@@ -25,7 +25,7 @@ The following methods can be used to traverse the AST:
 
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Node\NodeWalker;
@@ -35,7 +35,7 @@ $walker = $document->walker();
 while ($event = $walker->next()) {
     echo 'I am ' . ($event->isEntering() ? 'entering' : 'leaving') . ' a ' . get_class($event->getNode()) . ' node' . "\n";
 }
-~~~
+```
 
 This walker doesn't use recursion, so you won't blow the stack when working with deeply-nested nodes.
 

--- a/docs/1.0/customization/block-parsing.md
+++ b/docs/1.0/customization/block-parsing.md
@@ -12,11 +12,11 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 
 ## parse()
 
-~~~php
+```php
 <?php
 
 public function parse(ContextInterface $context, Cursor $cursor): bool;
-~~~
+```
 
 When parsing a new line, the `DocParser` iterates through all registered block parsers and calls their `parse()` method.  Each parser must determine whether it can handle the given line; if so, it should parse the given block and return `true`.
 

--- a/docs/1.0/customization/block-parsing.md
+++ b/docs/1.0/customization/block-parsing.md
@@ -13,8 +13,6 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 ## parse()
 
 ```php
-<?php
-
 public function parse(ContextInterface $context, Cursor $cursor): bool;
 ```
 

--- a/docs/1.0/customization/block-rendering.md
+++ b/docs/1.0/customization/block-rendering.md
@@ -15,8 +15,6 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 ## render()
 
 ```php
-<?php
-
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
 ```
 
@@ -41,8 +39,6 @@ If you choose to return an HTML `string` you are responsible for handling any es
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
 ```php
-<?php
-
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
@@ -54,8 +50,6 @@ $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Environment;
 
@@ -69,8 +63,6 @@ $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
 A single renderer could even be used for multiple block types:
 
 ```php
-<?php
-
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Block\Element\IndentedCode;
 use League\CommonMark\Environment;
@@ -90,8 +82,6 @@ Multiple renderers can be added per element type - when this happens, we use the
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Renderer\Block\BlockRendererInterface;

--- a/docs/1.0/customization/block-rendering.md
+++ b/docs/1.0/customization/block-rendering.md
@@ -14,11 +14,11 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 
 ## render()
 
-~~~php
+```php
 <?php
 
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
-~~~
+```
 
 The `HtmlRenderer` will call this method whenever a supported block element is encountered in the AST being rendered.
 
@@ -40,20 +40,20 @@ If you choose to return an HTML `string` you are responsible for handling any es
 
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
 $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
-~~~
+```
 
 ## Designating Block Renderers
 
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Block\Element\FencedCode;
@@ -64,11 +64,11 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the block class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
-~~~
+```
 
 A single renderer could even be used for multiple block types:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Block\Element\FencedCode;
@@ -81,7 +81,7 @@ $myRenderer = new MyCustomCodeRenderer();
 
 $environment->addBlockRenderer(FencedCode::class, $myRenderer, 10);
 $environment->addBlockRenderer(IndentedCode::class, $myRenderer, 20);
-~~~
+```
 
 Multiple renderers can be added per element type - when this happens, we use the result from the highest-priority renderer that returns a non-`null` result.
 
@@ -89,7 +89,7 @@ Multiple renderers can be added per element type - when this happens, we use the
 
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -108,7 +108,7 @@ class TextDividerRenderer implements BlockRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addBlockRenderer('League\CommonMark\Block\Element\ThematicBreak', new TextDividerRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.0/customization/delimiter-processing.md
+++ b/docs/1.0/customization/delimiter-processing.md
@@ -15,9 +15,9 @@ Delimiter runs are a special type of inline:
  - They are denoted by "wrapping" text with one or more characters before **and** after those inner contents
  - They can contain other delimiter runs or inlines inside of them
 
-~~~markdown
-This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after. 
-~~~
+```markdown
+This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
+```
 
 
 When implementing something with these characteristics you should consider leveraging delimiter runs; otherwise, a basic [inline parser](/1.0/inline-parsing/) should be sufficient.
@@ -30,9 +30,9 @@ Delimiter processors have a lower priority than inline parsers - if an [inline p
 
 Implement the `DelimiterProcessorInterface` and add it to your environment:
 
-~~~php
+```php
 $environment->addDelimiterProcessor(new MyCustomDelimiterProcessor());
-~~~
+```
 
 ### `getOpeningCharacter()` and `getClosingCharacter()`
 
@@ -44,21 +44,21 @@ This method tells the engine the minimum number of characters needed to match or
 
 ### `getDelimiterUse()`
 
-~~~php
+```php
 public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int;
-~~~
+```
 
 This method is used to tell the engine how many characters from the matching delimiters should be consumed.  For simple processors you'll likely return `1` (or whatever your minimum length is).  In more advanced cases, you can examine the opening and closing delimiters and perform additional logic to determine whether they should be fully or partially consumed.  You can also return `0` if you'd like.
 
 ### `process()`
 
-~~~php
+```php
 public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse);
-~~~
+```
 
 This is where the magic happens.  Once the engine determines it can use the delimiter it found (by looking at all the other methods above) it'll call this method.  Your job is to take everything between the `$opener` and `$closer` and wrap that in whatever custom inline element you'd like.  Here's a basic example of wrapping the inner contents inside a new `Emphasis` element:
 
-~~~php
+```php
 // Create the outer element
 $emphasis = new Emphasis();
 
@@ -72,7 +72,7 @@ while ($tmp !== null && $tmp !== $closer) {
 
 // Place the outer element into the AST
 $opener->insertAfter($emphasis);
-~~~
+```
 
 Note that `$opener` and `$closer` will be automatically removed for you after this function returns - no need to do that yourself.
 
@@ -84,7 +84,7 @@ Basic delimiter processors, as covered above, do not require any custom inline p
 
 As your identifies potential delimiter-based inlines, it should create a new `AbstractStringContainer` node (either `Text` or something custom) with the inner contents and also push a new `DelimiterInterface` onto the `DelimiterStack`:
 
-~~~php
+```php
 $node = new Text($cursor->getPreviousText(), [
     'delim' => true,
 ]);
@@ -93,7 +93,7 @@ $inlineContext->getContainer()->appendChild($node);
 // Add entry to stack to this opener
 $delimiter = new Delimiter($character, $numDelims, $node, $canOpen, $canClose);
 $inlineContext->getDelimiterStack()->push($delimiter);
-~~~
+```
 
 This basically tells the engine that text was found which _might_ be emphasis, but due to the delimiter run rules we can't make that determination just yet.  That final determination is later on by a "delimiter processor".
 

--- a/docs/1.0/customization/environment.md
+++ b/docs/1.0/customization/environment.md
@@ -13,8 +13,6 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 A pre-configured `Environment` can be obtained like this:
 
 ```php
-<?php
-
 use League\CommonMark;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -27,8 +25,6 @@ You can customize this default `Environment` (or even a new, empty one) using an
 ## mergeConfig()
 
 ```php
-<?php
-
 public function mergeConfig(array $config = []);
 ```
 
@@ -37,8 +33,6 @@ Merges the given [configuration](/1.0/configuration/) settings into any existing
 ## setConfig()
 
 ```php
-<?php
-
 public function setConfig(array $config = []);
 ```
 
@@ -47,8 +41,6 @@ Completely replaces the previous [configuration](/1.0/configuration/) settings w
 ## addExtension()
 
 ```php
-<?php
-
 public function addExtension(ExtensionInterface $extension);
 ```
 
@@ -57,8 +49,6 @@ Registers the given [extension](/1.0/customization/extensions/) with the environ
 ## addBlockParser()
 
 ```php
-<?php
-
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
 ```
 
@@ -69,8 +59,6 @@ See [Block Parsing](/1.0/customization/block-parsing/) for details.
 ## addBlockRenderer()
 
 ```php
-<?php
-
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
 ```
 
@@ -81,8 +69,6 @@ See [Block Rendering](/1.0/customization/block-rendering/) for details.
 ## addInlineParser()
 
 ```php
-<?php
-
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
 ```
 
@@ -93,8 +79,6 @@ See [Inline Parsing](/1.0/customization/inline-parsing/) for details.
 ## addInlineRenderer()
 
 ```php
-<?php
-
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
 ```
 
@@ -106,8 +90,6 @@ See [Inline Rendering](/1.0/customization/inline-rendering/) for details.
 ## addDelimiterProcessor()
 
 ```php
-<?php
-
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
 ```
 
@@ -118,8 +100,6 @@ See [Inline Parsing](/1.0/customization/delimiter-processing/) for details.
 ## addEventListener()
 
 ```php
-<?php
-
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
 ```
 

--- a/docs/1.0/customization/environment.md
+++ b/docs/1.0/customization/environment.md
@@ -12,13 +12,13 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 
 A pre-configured `Environment` can be obtained like this:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark;
 
 $environment = Environment::createCommonMarkEnvironment();
-~~~
+```
 
 All of the core renders, parsers, etc. needed to implement the CommonMark spec will be pre-registered and ready to go.
 
@@ -26,41 +26,41 @@ You can customize this default `Environment` (or even a new, empty one) using an
 
 ## mergeConfig()
 
-~~~php
+```php
 <?php
 
 public function mergeConfig(array $config = []);
-~~~
+```
 
 Merges the given [configuration](/1.0/configuration/) settings into any existing ones.
 
 ## setConfig()
 
-~~~php
+```php
 <?php
 
 public function setConfig(array $config = []);
-~~~
+```
 
 Completely replaces the previous [configuration](/1.0/configuration/) settings with the new `$config` you provide.
 
 ## addExtension()
 
-~~~php
+```php
 <?php
 
 public function addExtension(ExtensionInterface $extension);
-~~~
+```
 
 Registers the given [extension](/1.0/customization/extensions/) with the environment.  This is typically how you'd integrate third-party extensions with this library.
 
 ## addBlockParser()
 
-~~~php
+```php
 <?php
 
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `BlockParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -68,11 +68,11 @@ See [Block Parsing](/1.0/customization/block-parsing/) for details.
 
 ## addBlockRenderer()
 
-~~~php
+```php
 <?php
 
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
-~~~
+```
 
 Registers a `BlockRendererInterface` to handle a specific type of block (`$blockClass`)  with the given priority (a higher number will be executed earlier).
 
@@ -80,11 +80,11 @@ See [Block Rendering](/1.0/customization/block-rendering/) for details.
 
 ## addInlineParser()
 
-~~~php
+```php
 <?php
 
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `InlineParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -92,11 +92,11 @@ See [Inline Parsing](/1.0/customization/inline-parsing/) for details.
 
 ## addInlineRenderer()
 
-~~~php
+```php
 <?php
 
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
-~~~
+```
 
 Registers an `InlineRendererInterface` to handle a specific type of inline (`$inlineClass`) with the given priority (a higher number will be executed earlier).
 A single renderer can handle multiple inline classes, but you must register it separately for each type. (The same renderer instance can be re-used if desired.)
@@ -105,11 +105,11 @@ See [Inline Rendering](/1.0/customization/inline-rendering/) for details.
 
 ## addDelimiterProcessor()
 
-~~~php
+```php
 <?php
 
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
-~~~
+```
 
 Registers the given `DelimiterProcessorInterface` with the environment.
 
@@ -117,11 +117,11 @@ See [Inline Parsing](/1.0/customization/delimiter-processing/) for details.
 
 ## addEventListener()
 
-~~~php
+```php
 <?php
 
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
-~~~
+```
 
 Registers the given event listener with the environment.
 

--- a/docs/1.0/customization/event-dispatcher.md
+++ b/docs/1.0/customization/event-dispatcher.md
@@ -78,7 +78,7 @@ This event is dispatched once all other processing is done.  This offers extensi
 
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\EnvironmentInterface;
@@ -125,11 +125,11 @@ class ExternalLinkProcessor
         return $host != $this->environment->getConfig('host');
     }
 }
-~~~
+```
 
 And here's how you'd use it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -146,15 +146,15 @@ $converter = new CommonMarkConverter(['host' => 'commonmark.thephpleague.com'], 
 $input = 'My two favorite sites are <https://google.com> and <https://commonmark.thephpleague.com>';
 
 echo $converter->convertToHtml($input);
-~~~
+```
 
 Output (formatted for readability):
 
-~~~html
+```html
 <p>
     My two favorite sites are
     <a class="external-link" href="https://google.com">https://google.com</a>
     and
     <a href="https://commonmark.thephpleague.com">https://commonmark.thephpleague.com</a>
 </p>
-~~~
+```

--- a/docs/1.0/customization/event-dispatcher.md
+++ b/docs/1.0/customization/event-dispatcher.md
@@ -79,8 +79,6 @@ This event is dispatched once all other processing is done.  This offers extensi
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
 ```php
-<?php
-
 use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Inline\Element\Link;
@@ -130,8 +128,6 @@ class ExternalLinkProcessor
 And here's how you'd use it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;

--- a/docs/1.0/customization/inline-parsing.md
+++ b/docs/1.0/customization/inline-parsing.md
@@ -61,8 +61,6 @@ Returning `true` tells the engine that you've successfully parsed the character 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
@@ -74,6 +72,7 @@ class TwitterHandleParser implements InlineParserInterface
     {
         return ['@'];
     }
+
     public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
@@ -109,8 +108,6 @@ $environment->addInlineParser(new TwitterHandleParser());
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Image;
 use League\CommonMark\Inline\Parser\InlineParserInterface;

--- a/docs/1.0/customization/inline-parsing.md
+++ b/docs/1.0/customization/inline-parsing.md
@@ -20,11 +20,11 @@ The difference between normal inlines and delimiter-run-based inlines is subtle 
 
 An example of this would be emphasis:
 
-~~~markdown
-This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after. 
-~~~
+```markdown
+This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
+```
 
-If your syntax looks like that, consider using a [delimiter processor](/1.0/customization/delimiter-processing/) instead.  Otherwise, an inline parser is your best bet. 
+If your syntax looks like that, consider using a [delimiter processor](/1.0/customization/delimiter-processing/) instead.  Otherwise, an inline parser is your best bet.
 
 ## Implementing Inline Parsers
 
@@ -60,7 +60,7 @@ Returning `true` tells the engine that you've successfully parsed the character 
 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -102,13 +102,13 @@ class TwitterHandleParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new TwitterHandleParser());
-~~~
+```
 
 ### Example 2 - Emoticons
 
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -136,7 +136,7 @@ class SmilieParser implements InlineParserInterface
 
         // Advance the cursor past the 2 matched chars since we're able to parse them successfully
         $cursor->advanceBy(2);
-        
+
         // Add the corresponding image
         if ($nextChar === ')') {
             $inlineContext->getContainer()->appendChild(new Image('/img/happy.png'));
@@ -150,7 +150,7 @@ class SmilieParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new SmilieParserParser());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.0/customization/inline-rendering.md
+++ b/docs/1.0/customization/inline-rendering.md
@@ -36,8 +36,6 @@ Return `null` if your renderer cannot handle the given inline element - the next
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -52,8 +50,6 @@ $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyC
 Here's a custom renderer which puts a special class on links to external sites:
 
 ```php
-<?php
-
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;

--- a/docs/1.0/customization/inline-rendering.md
+++ b/docs/1.0/customization/inline-rendering.md
@@ -35,7 +35,7 @@ Return `null` if your renderer cannot handle the given inline element - the next
 
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -45,13 +45,13 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the inline class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyCustomLinkRenderer());
-~~~
+```
 
 ## Example
 
 Here's a custom renderer which puts a special class on links to external sites:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\ElementRendererInterface;
@@ -99,7 +99,7 @@ class MyCustomLinkRenderer implements InlineRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineRenderer(Link::class, new MyCustomLinkRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.0/index.md
+++ b/docs/1.0/index.md
@@ -22,9 +22,9 @@ redirect_from: /0.20/
 
 This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.0/installation/) section for more details.
 
@@ -32,7 +32,7 @@ See the [installation](/1.0/installation/) section for more details.
 
 Simply instantiate the converter and start converting some Markdown to HTML!
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -41,7 +41,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [basic usage](/1.0/basic-usage/) and [security](/1.0/security/) sections for important details.

--- a/docs/1.0/index.md
+++ b/docs/1.0/index.md
@@ -33,8 +33,6 @@ See the [installation](/1.0/installation/) section for more details.
 Simply instantiate the converter and start converting some Markdown to HTML!
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();

--- a/docs/1.0/installation.md
+++ b/docs/1.0/installation.md
@@ -11,9 +11,9 @@ The recommended installation method is via Composer.
 
 In your project root just run:
 
-~~~bash
+```bash
 composer require league/commonmark:^1.0
-~~~
+```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 

--- a/docs/1.0/security.md
+++ b/docs/1.0/security.md
@@ -24,24 +24,24 @@ If you're developing an application which renders user-provided Markdown from po
 
 ### Example - Escape all raw HTML input:
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'escape']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // &lt;script&gt;alert("Hello XSS!");&lt;/script&gt;
-~~~
+```
 
 ### Example - Strip all HTML from the input:
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'strip']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // (empty output)
-~~~
+```
 
 **Failing to set this option could make your site vulnerable to cross-site scripting (XSS) attacks!**
 
@@ -66,7 +66,7 @@ If you need to parse untrusted input, consider setting a reasonable `max_nesting
 
 ### Example - Prevent deep nesting
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
@@ -84,6 +84,6 @@ echo $converter->convertToHtml($markdown);
 //     </blockquote>
 //   </blockquote>
 // </blockquote>
-~~~
+```
 
 See the [configuration](/1.0/configuration/) section for more information.

--- a/docs/1.3/basic-usage.md
+++ b/docs/1.3/basic-usage.md
@@ -10,8 +10,6 @@ Basic Usage
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
 ```php
-<?php
-
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\CommonMarkConverter;
@@ -25,8 +23,6 @@ echo $converter->convertToHtml('# Hello World!');
 Or if you want Github-Flavored Markdown:
 
 ```php
-<?php
-
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 $converter = new GithubFlavoredMarkdownConverter();
@@ -47,8 +43,6 @@ The actual conversion process has three steps:
 `CommonMarkConverter` handles this for you, but you can execute that process yourself if you wish:
 
 ```php
-<?php
-
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\DocParser;

--- a/docs/1.3/basic-usage.md
+++ b/docs/1.3/basic-usage.md
@@ -9,7 +9,7 @@ Basic Usage
 
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
-~~~php
+```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
@@ -20,7 +20,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Or if you want Github-Flavored Markdown:
 
@@ -46,7 +46,7 @@ The actual conversion process has three steps:
 
 `CommonMarkConverter` handles this for you, but you can execute that process yourself if you wish:
 
-~~~php
+```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
@@ -65,7 +65,7 @@ $document = $parser->parse($markdown);
 echo $htmlRenderer->renderBlock($document);
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 [Additional customization](/1.3/customization/overview/) is also possible, and we have many handy [extensions](/1.3/extensions/overview/) to enable additional syntax and features.
 

--- a/docs/1.3/command-line.md
+++ b/docs/1.3/command-line.md
@@ -10,7 +10,9 @@ Markdown can be converted at the command line using the `./bin/commonmark` scrip
 
 ## Usage
 
-    ./bin/commonmark [OPTIONS] [FILE]
+```bash
+./bin/commonmark [OPTIONS] [FILE]
+```
 
 * `-h`, `--help`: Shows help and usage information
 * `--enable-em`: Disable `<em>` parsing by setting to `0`; enable with `1` (default: `1`)
@@ -26,16 +28,24 @@ Output will be written to STDOUT.
 
 ### Converting a file named document.md
 
-    ./bin/commonmark document.md
+```bash
+./bin/commonmark document.md
+```
 
 ### Converting a file and saving its output
 
-    ./bin/commonmark document.md > output.html
+```bash
+./bin/commonmark document.md > output.html
+```
 
 ### Converting from STDIN
 
-    echo -e '# Hello World!' | ./bin/commonmark
+```bash
+echo -e '# Hello World!' | ./bin/commonmark
+```
 
 ### Converting from STDIN and saving the output
 
-    echo -e '# Hello World!' | ./bin/commonmark > output.html
+```bash
+echo -e '# Hello World!' | ./bin/commonmark > output.html
+```

--- a/docs/1.3/configuration.md
+++ b/docs/1.3/configuration.md
@@ -9,8 +9,6 @@ Configuration
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter([

--- a/docs/1.3/configuration.md
+++ b/docs/1.3/configuration.md
@@ -8,7 +8,7 @@ Configuration
 
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -28,7 +28,7 @@ $converter = new CommonMarkConverter([
     'allow_unsafe_links' => false,
     'max_nesting_level' => INF,
 ]);
-~~~
+```
 
 Here's a list of currently-supported options:
 

--- a/docs/1.3/customization/abstract-syntax-tree.md
+++ b/docs/1.3/customization/abstract-syntax-tree.md
@@ -25,8 +25,6 @@ The following methods can be used to traverse the AST:
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
 ```php
-<?php
-
 use League\CommonMark\Node\NodeWalker;
 
 /** @var NodeWalker $walker */

--- a/docs/1.3/customization/abstract-syntax-tree.md
+++ b/docs/1.3/customization/abstract-syntax-tree.md
@@ -24,7 +24,7 @@ The following methods can be used to traverse the AST:
 
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Node\NodeWalker;
@@ -34,7 +34,7 @@ $walker = $document->walker();
 while ($event = $walker->next()) {
     echo 'I am ' . ($event->isEntering() ? 'entering' : 'leaving') . ' a ' . get_class($event->getNode()) . ' node' . "\n";
 }
-~~~
+```
 
 This walker doesn't use recursion, so you won't blow the stack when working with deeply-nested nodes.
 

--- a/docs/1.3/customization/block-parsing.md
+++ b/docs/1.3/customization/block-parsing.md
@@ -12,8 +12,6 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 ## parse()
 
 ```php
-<?php
-
 public function parse(ContextInterface $context, Cursor $cursor): bool;
 ```
 

--- a/docs/1.3/customization/block-parsing.md
+++ b/docs/1.3/customization/block-parsing.md
@@ -11,11 +11,11 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 
 ## parse()
 
-~~~php
+```php
 <?php
 
 public function parse(ContextInterface $context, Cursor $cursor): bool;
-~~~
+```
 
 When parsing a new line, the `DocParser` iterates through all registered block parsers and calls their `parse()` method.  Each parser must determine whether it can handle the given line; if so, it should parse the given block and return `true`.
 

--- a/docs/1.3/customization/block-rendering.md
+++ b/docs/1.3/customization/block-rendering.md
@@ -14,8 +14,6 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 ## render()
 
 ```php
-<?php
-
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
 ```
 
@@ -40,8 +38,6 @@ If you choose to return an HTML `string` you are responsible for handling any es
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
 ```php
-<?php
-
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
@@ -53,8 +49,6 @@ $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Environment;
 
@@ -68,8 +62,6 @@ $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
 A single renderer could even be used for multiple block types:
 
 ```php
-<?php
-
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Block\Element\IndentedCode;
 use League\CommonMark\Environment;
@@ -89,8 +81,6 @@ Multiple renderers can be added per element type - when this happens, we use the
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Renderer\Block\BlockRendererInterface;

--- a/docs/1.3/customization/block-rendering.md
+++ b/docs/1.3/customization/block-rendering.md
@@ -13,11 +13,11 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 
 ## render()
 
-~~~php
+```php
 <?php
 
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
-~~~
+```
 
 The `HtmlRenderer` will call this method whenever a supported block element is encountered in the AST being rendered.
 
@@ -39,20 +39,20 @@ If you choose to return an HTML `string` you are responsible for handling any es
 
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
 $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
-~~~
+```
 
 ## Designating Block Renderers
 
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Block\Element\FencedCode;
@@ -63,11 +63,11 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the block class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
-~~~
+```
 
 A single renderer could even be used for multiple block types:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Block\Element\FencedCode;
@@ -80,7 +80,7 @@ $myRenderer = new MyCustomCodeRenderer();
 
 $environment->addBlockRenderer(FencedCode::class, $myRenderer, 10);
 $environment->addBlockRenderer(IndentedCode::class, $myRenderer, 20);
-~~~
+```
 
 Multiple renderers can be added per element type - when this happens, we use the result from the highest-priority renderer that returns a non-`null` result.
 
@@ -88,7 +88,7 @@ Multiple renderers can be added per element type - when this happens, we use the
 
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -107,7 +107,7 @@ class TextDividerRenderer implements BlockRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addBlockRenderer('League\CommonMark\Block\Element\ThematicBreak', new TextDividerRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.3/customization/delimiter-processing.md
+++ b/docs/1.3/customization/delimiter-processing.md
@@ -14,9 +14,9 @@ Delimiter runs are a special type of inline:
  - They are denoted by "wrapping" text with one or more characters before **and** after those inner contents
  - They can contain other delimiter runs or inlines inside of them
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 
 When implementing something with these characteristics you should consider leveraging delimiter runs; otherwise, a basic [inline parser](/1.3/inline-parsing/) should be sufficient.
@@ -29,9 +29,9 @@ Delimiter processors have a lower priority than inline parsers - if an [inline p
 
 Implement the `DelimiterProcessorInterface` and add it to your environment:
 
-~~~php
+```php
 $environment->addDelimiterProcessor(new MyCustomDelimiterProcessor());
-~~~
+```
 
 ### `getOpeningCharacter()` and `getClosingCharacter()`
 
@@ -43,21 +43,21 @@ This method tells the engine the minimum number of characters needed to match or
 
 ### `getDelimiterUse()`
 
-~~~php
+```php
 public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int;
-~~~
+```
 
 This method is used to tell the engine how many characters from the matching delimiters should be consumed.  For simple processors you'll likely return `1` (or whatever your minimum length is).  In more advanced cases, you can examine the opening and closing delimiters and perform additional logic to determine whether they should be fully or partially consumed.  You can also return `0` if you'd like.
 
 ### `process()`
 
-~~~php
+```php
 public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse);
-~~~
+```
 
 This is where the magic happens.  Once the engine determines it can use the delimiter it found (by looking at all the other methods above) it'll call this method.  Your job is to take everything between the `$opener` and `$closer` and wrap that in whatever custom inline element you'd like.  Here's a basic example of wrapping the inner contents inside a new `Emphasis` element:
 
-~~~php
+```php
 // Create the outer element
 $emphasis = new Emphasis();
 
@@ -71,7 +71,7 @@ while ($tmp !== null && $tmp !== $closer) {
 
 // Place the outer element into the AST
 $opener->insertAfter($emphasis);
-~~~
+```
 
 Note that `$opener` and `$closer` will be automatically removed for you after this function returns - no need to do that yourself.
 
@@ -83,7 +83,7 @@ Basic delimiter processors, as covered above, do not require any custom inline p
 
 As your identifies potential delimiter-based inlines, it should create a new `AbstractStringContainer` node (either `Text` or something custom) with the inner contents and also push a new `DelimiterInterface` onto the `DelimiterStack`:
 
-~~~php
+```php
 $node = new Text($cursor->getPreviousText(), [
     'delim' => true,
 ]);
@@ -92,7 +92,7 @@ $inlineContext->getContainer()->appendChild($node);
 // Add entry to stack to this opener
 $delimiter = new Delimiter($character, $numDelims, $node, $canOpen, $canClose);
 $inlineContext->getDelimiterStack()->push($delimiter);
-~~~
+```
 
 This basically tells the engine that text was found which _might_ be emphasis, but due to the delimiter run rules we can't make that determination just yet.  That final determination is later on by a "delimiter processor".
 

--- a/docs/1.3/customization/environment.md
+++ b/docs/1.3/customization/environment.md
@@ -12,8 +12,6 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 A pre-configured `Environment` can be obtained like this:
 
 ```php
-<?php
-
 use League\CommonMark;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -26,8 +24,6 @@ You can customize this default `Environment` (or even a new, empty one) using an
 ## mergeConfig()
 
 ```php
-<?php
-
 public function mergeConfig(array $config = []);
 ```
 
@@ -36,8 +32,6 @@ Merges the given [configuration](/1.3/configuration/) settings into any existing
 ## setConfig()
 
 ```php
-<?php
-
 public function setConfig(array $config = []);
 ```
 
@@ -46,8 +40,6 @@ Completely replaces the previous [configuration](/1.3/configuration/) settings w
 ## addExtension()
 
 ```php
-<?php
-
 public function addExtension(ExtensionInterface $extension);
 ```
 
@@ -56,8 +48,6 @@ Registers the given [extension](/1.3/customization/extensions/) with the environ
 ## addBlockParser()
 
 ```php
-<?php
-
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
 ```
 
@@ -68,8 +58,6 @@ See [Block Parsing](/1.3/customization/block-parsing/) for details.
 ## addBlockRenderer()
 
 ```php
-<?php
-
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
 ```
 
@@ -80,8 +68,6 @@ See [Block Rendering](/1.3/customization/block-rendering/) for details.
 ## addInlineParser()
 
 ```php
-<?php
-
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
 ```
 
@@ -92,8 +78,6 @@ See [Inline Parsing](/1.3/customization/inline-parsing/) for details.
 ## addInlineRenderer()
 
 ```php
-<?php
-
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
 ```
 
@@ -105,8 +89,6 @@ See [Inline Rendering](/1.3/customization/inline-rendering/) for details.
 ## addDelimiterProcessor()
 
 ```php
-<?php
-
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
 ```
 
@@ -117,8 +99,6 @@ See [Inline Parsing](/1.3/customization/delimiter-processing/) for details.
 ## addEventListener()
 
 ```php
-<?php
-
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
 ```
 

--- a/docs/1.3/customization/environment.md
+++ b/docs/1.3/customization/environment.md
@@ -11,13 +11,13 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 
 A pre-configured `Environment` can be obtained like this:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark;
 
 $environment = Environment::createCommonMarkEnvironment();
-~~~
+```
 
 All of the core renders, parsers, etc. needed to implement the CommonMark spec will be pre-registered and ready to go.
 
@@ -25,41 +25,41 @@ You can customize this default `Environment` (or even a new, empty one) using an
 
 ## mergeConfig()
 
-~~~php
+```php
 <?php
 
 public function mergeConfig(array $config = []);
-~~~
+```
 
 Merges the given [configuration](/1.3/configuration/) settings into any existing ones.
 
 ## setConfig()
 
-~~~php
+```php
 <?php
 
 public function setConfig(array $config = []);
-~~~
+```
 
 Completely replaces the previous [configuration](/1.3/configuration/) settings with the new `$config` you provide.
 
 ## addExtension()
 
-~~~php
+```php
 <?php
 
 public function addExtension(ExtensionInterface $extension);
-~~~
+```
 
 Registers the given [extension](/1.3/customization/extensions/) with the environment.  This is typically how you'd integrate third-party extensions with this library.
 
 ## addBlockParser()
 
-~~~php
+```php
 <?php
 
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `BlockParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -67,11 +67,11 @@ See [Block Parsing](/1.3/customization/block-parsing/) for details.
 
 ## addBlockRenderer()
 
-~~~php
+```php
 <?php
 
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
-~~~
+```
 
 Registers a `BlockRendererInterface` to handle a specific type of block (`$blockClass`)  with the given priority (a higher number will be executed earlier).
 
@@ -79,11 +79,11 @@ See [Block Rendering](/1.3/customization/block-rendering/) for details.
 
 ## addInlineParser()
 
-~~~php
+```php
 <?php
 
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `InlineParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -91,11 +91,11 @@ See [Inline Parsing](/1.3/customization/inline-parsing/) for details.
 
 ## addInlineRenderer()
 
-~~~php
+```php
 <?php
 
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
-~~~
+```
 
 Registers an `InlineRendererInterface` to handle a specific type of inline (`$inlineClass`) with the given priority (a higher number will be executed earlier).
 A single renderer can handle multiple inline classes, but you must register it separately for each type. (The same renderer instance can be re-used if desired.)
@@ -104,11 +104,11 @@ See [Inline Rendering](/1.3/customization/inline-rendering/) for details.
 
 ## addDelimiterProcessor()
 
-~~~php
+```php
 <?php
 
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
-~~~
+```
 
 Registers the given `DelimiterProcessorInterface` with the environment.
 
@@ -116,11 +116,11 @@ See [Inline Parsing](/1.3/customization/delimiter-processing/) for details.
 
 ## addEventListener()
 
-~~~php
+```php
 <?php
 
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
-~~~
+```
 
 Registers the given event listener with the environment.
 

--- a/docs/1.3/customization/event-dispatcher.md
+++ b/docs/1.3/customization/event-dispatcher.md
@@ -78,8 +78,6 @@ This event is dispatched once all other processing is done.  This offers extensi
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
 ```php
-<?php
-
 use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Inline\Element\Link;
@@ -129,8 +127,6 @@ class ExternalLinkProcessor
 And here's how you'd use it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;

--- a/docs/1.3/customization/event-dispatcher.md
+++ b/docs/1.3/customization/event-dispatcher.md
@@ -77,7 +77,7 @@ This event is dispatched once all other processing is done.  This offers extensi
 
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\EnvironmentInterface;
@@ -124,11 +124,11 @@ class ExternalLinkProcessor
         return $host != $this->environment->getConfig('host');
     }
 }
-~~~
+```
 
 And here's how you'd use it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -145,15 +145,15 @@ $converter = new CommonMarkConverter(['host' => 'commonmark.thephpleague.com'], 
 $input = 'My two favorite sites are <https://google.com> and <https://commonmark.thephpleague.com>';
 
 echo $converter->convertToHtml($input);
-~~~
+```
 
 Output (formatted for readability):
 
-~~~html
+```html
 <p>
     My two favorite sites are
     <a class="external-link" href="https://google.com">https://google.com</a>
     and
     <a href="https://commonmark.thephpleague.com">https://commonmark.thephpleague.com</a>
 </p>
-~~~
+```

--- a/docs/1.3/customization/inline-parsing.md
+++ b/docs/1.3/customization/inline-parsing.md
@@ -19,9 +19,9 @@ The difference between normal inlines and delimiter-run-based inlines is subtle 
 
 An example of this would be emphasis:
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 If your syntax looks like that, consider using a [delimiter processor](/1.3/customization/delimiter-processing/) instead.  Otherwise, an inline parser is your best bet.
 
@@ -59,7 +59,7 @@ Returning `true` tells the engine that you've successfully parsed the character 
 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -101,13 +101,13 @@ class TwitterHandleParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new TwitterHandleParser());
-~~~
+```
 
 ### Example 2 - Emoticons
 
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -149,7 +149,7 @@ class SmilieParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new SmilieParserParser());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.3/customization/inline-parsing.md
+++ b/docs/1.3/customization/inline-parsing.md
@@ -60,8 +60,6 @@ Returning `true` tells the engine that you've successfully parsed the character 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
@@ -73,6 +71,7 @@ class TwitterHandleParser implements InlineParserInterface
     {
         return ['@'];
     }
+
     public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
@@ -108,8 +107,6 @@ $environment->addInlineParser(new TwitterHandleParser());
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Image;
 use League\CommonMark\Inline\Parser\InlineParserInterface;

--- a/docs/1.3/customization/inline-rendering.md
+++ b/docs/1.3/customization/inline-rendering.md
@@ -34,7 +34,7 @@ Return `null` if your renderer cannot handle the given inline element - the next
 
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -44,13 +44,13 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the inline class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyCustomLinkRenderer());
-~~~
+```
 
 ## Example
 
 Here's a custom renderer which puts a special class on links to external sites:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\ElementRendererInterface;
@@ -98,7 +98,7 @@ class MyCustomLinkRenderer implements InlineRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineRenderer(Link::class, new MyCustomLinkRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.3/customization/inline-rendering.md
+++ b/docs/1.3/customization/inline-rendering.md
@@ -35,8 +35,6 @@ Return `null` if your renderer cannot handle the given inline element - the next
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -51,8 +49,6 @@ $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyC
 Here's a custom renderer which puts a special class on links to external sites:
 
 ```php
-<?php
-
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;

--- a/docs/1.3/extensions/autolinks.md
+++ b/docs/1.3/extensions/autolinks.md
@@ -16,9 +16,9 @@ It also provides a parser to autolink `@mentions` to Twitter, Github, or any cus
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/commonmark.md
+++ b/docs/1.3/extensions/commonmark.md
@@ -12,9 +12,9 @@ The `CommonMarkCoreExtension` class contains all of the core Markdown syntax - t
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/disallowed-raw-html.md
+++ b/docs/1.3/extensions/disallowed-raw-html.md
@@ -30,9 +30,9 @@ All other HTML tags are left untouched by this extension.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/external-links.md
+++ b/docs/1.3/extensions/external-links.md
@@ -15,9 +15,9 @@ This extension can detect links to external sites and adjust the markup accordin
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/inlines-only.md
+++ b/docs/1.3/extensions/inlines-only.md
@@ -12,9 +12,9 @@ This extension configures the parser to only render inline elements - no paragra
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/smart-punctuation.md
+++ b/docs/1.3/extensions/smart-punctuation.md
@@ -24,9 +24,9 @@ Will result in this HTML:
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/strikethrough.md
+++ b/docs/1.3/extensions/strikethrough.md
@@ -14,9 +14,9 @@ This extension adds support for GFM-style strikethrough syntax.  It allows users
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/tables.md
+++ b/docs/1.3/extensions/tables.md
@@ -14,9 +14,9 @@ The `TableExtension` adds the ability to create tables in CommonMark documents.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/extensions/task-lists.md
+++ b/docs/1.3/extensions/task-lists.md
@@ -14,9 +14,9 @@ This extension adds support for [GFM-style task lists](https://github.github.com
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 

--- a/docs/1.3/index.md
+++ b/docs/1.3/index.md
@@ -21,9 +21,9 @@ title: Overview
 
 This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.3/installation/) section for more details.
 
@@ -31,7 +31,7 @@ See the [installation](/1.3/installation/) section for more details.
 
 Simply instantiate the converter and start converting some Markdown to HTML!
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -40,7 +40,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [basic usage](/1.3/basic-usage/) and [security](/1.3/security/) sections for important details.

--- a/docs/1.3/index.md
+++ b/docs/1.3/index.md
@@ -32,8 +32,6 @@ See the [installation](/1.3/installation/) section for more details.
 Simply instantiate the converter and start converting some Markdown to HTML!
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();

--- a/docs/1.3/installation.md
+++ b/docs/1.3/installation.md
@@ -10,9 +10,9 @@ The recommended installation method is via Composer.
 
 In your project root just run:
 
-~~~bash
+```bash
 composer require league/commonmark:^1.3
-~~~
+```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 

--- a/docs/1.3/security.md
+++ b/docs/1.3/security.md
@@ -23,24 +23,24 @@ If you're developing an application which renders user-provided Markdown from po
 
 ### Example - Escape all raw HTML input:
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'escape']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // &lt;script&gt;alert("Hello XSS!");&lt;/script&gt;
-~~~
+```
 
 ### Example - Strip all HTML from the input:
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'strip']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // (empty output)
-~~~
+```
 
 **Failing to set this option could make your site vulnerable to cross-site scripting (XSS) attacks!**
 
@@ -65,7 +65,7 @@ If you need to parse untrusted input, consider setting a reasonable `max_nesting
 
 ### Example - Prevent deep nesting
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
@@ -83,6 +83,6 @@ echo $converter->convertToHtml($markdown);
 //     </blockquote>
 //   </blockquote>
 // </blockquote>
-~~~
+```
 
 See the [configuration](/1.3/configuration/) section for more information.

--- a/docs/1.4/basic-usage.md
+++ b/docs/1.4/basic-usage.md
@@ -10,8 +10,6 @@ Basic Usage
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
 ```php
-<?php
-
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\CommonMarkConverter;
@@ -25,8 +23,6 @@ echo $converter->convertToHtml('# Hello World!');
 Or if you want Github-Flavored Markdown:
 
 ```php
-<?php
-
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\GithubFlavoredMarkdownConverter;

--- a/docs/1.4/basic-usage.md
+++ b/docs/1.4/basic-usage.md
@@ -9,7 +9,7 @@ Basic Usage
 
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
-~~~php
+```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
@@ -20,7 +20,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Or if you want Github-Flavored Markdown:
 

--- a/docs/1.4/command-line.md
+++ b/docs/1.4/command-line.md
@@ -12,7 +12,9 @@ Markdown can be converted at the command line using the `./bin/commonmark` scrip
 
 ## Usage
 
-    ./bin/commonmark [OPTIONS] [FILE]
+```bash
+./bin/commonmark [OPTIONS] [FILE]
+```
 
 * `-h`, `--help`: Shows help and usage information
 * `--enable-em`: Disable `<em>` parsing by setting to `0`; enable with `1` (default: `1`)
@@ -28,16 +30,24 @@ Output will be written to STDOUT.
 
 ### Converting a file named document.md
 
-    ./bin/commonmark document.md
+```bash
+./bin/commonmark document.md
+```
 
 ### Converting a file and saving its output
 
-    ./bin/commonmark document.md > output.html
+```bash
+./bin/commonmark document.md > output.html
+```
 
 ### Converting from STDIN
 
-    echo -e '# Hello World!' | ./bin/commonmark
+```bash
+echo -e '# Hello World!' | ./bin/commonmark
+```
 
 ### Converting from STDIN and saving the output
 
-    echo -e '# Hello World!' | ./bin/commonmark > output.html
+```bash
+echo -e '# Hello World!' | ./bin/commonmark > output.html
+```

--- a/docs/1.4/configuration.md
+++ b/docs/1.4/configuration.md
@@ -9,8 +9,6 @@ Configuration
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter([

--- a/docs/1.4/configuration.md
+++ b/docs/1.4/configuration.md
@@ -8,7 +8,7 @@ Configuration
 
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -28,7 +28,7 @@ $converter = new CommonMarkConverter([
     'allow_unsafe_links' => false,
     'max_nesting_level' => INF,
 ]);
-~~~
+```
 
 Here's a list of currently-supported options:
 

--- a/docs/1.4/customization/abstract-syntax-tree.md
+++ b/docs/1.4/customization/abstract-syntax-tree.md
@@ -31,7 +31,7 @@ The following methods can be used to traverse the AST:
 
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Node\NodeWalker;
@@ -41,7 +41,7 @@ $walker = $document->walker();
 while ($event = $walker->next()) {
     echo 'I am ' . ($event->isEntering() ? 'entering' : 'leaving') . ' a ' . get_class($event->getNode()) . ' node' . "\n";
 }
-~~~
+```
 
 This walker doesn't use recursion, so you won't blow the stack when working with deeply-nested nodes.
 

--- a/docs/1.4/customization/abstract-syntax-tree.md
+++ b/docs/1.4/customization/abstract-syntax-tree.md
@@ -32,8 +32,6 @@ The following methods can be used to traverse the AST:
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
 ```php
-<?php
-
 use League\CommonMark\Node\NodeWalker;
 
 /** @var NodeWalker $walker */

--- a/docs/1.4/customization/block-parsing.md
+++ b/docs/1.4/customization/block-parsing.md
@@ -12,8 +12,6 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 ## parse()
 
 ```php
-<?php
-
 public function parse(ContextInterface $context, Cursor $cursor): bool;
 ```
 

--- a/docs/1.4/customization/block-parsing.md
+++ b/docs/1.4/customization/block-parsing.md
@@ -11,11 +11,11 @@ Block parsers should implement `BlockParserInterface` and implement the followin
 
 ## parse()
 
-~~~php
+```php
 <?php
 
 public function parse(ContextInterface $context, Cursor $cursor): bool;
-~~~
+```
 
 When parsing a new line, the `DocParser` iterates through all registered block parsers and calls their `parse()` method.  Each parser must determine whether it can handle the given line; if so, it should parse the given block and return `true`.
 

--- a/docs/1.4/customization/block-rendering.md
+++ b/docs/1.4/customization/block-rendering.md
@@ -14,8 +14,6 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 ## render()
 
 ```php
-<?php
-
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
 ```
 
@@ -40,8 +38,6 @@ If you choose to return an HTML `string` you are responsible for handling any es
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
 ```php
-<?php
-
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
@@ -53,8 +49,6 @@ $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Environment;
 
@@ -68,8 +62,6 @@ $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
 A single renderer could even be used for multiple block types:
 
 ```php
-<?php
-
 use League\CommonMark\Block\Element\FencedCode;
 use League\CommonMark\Block\Element\IndentedCode;
 use League\CommonMark\Environment;
@@ -89,8 +81,6 @@ Multiple renderers can be added per element type - when this happens, we use the
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Renderer\Block\BlockRendererInterface;

--- a/docs/1.4/customization/block-rendering.md
+++ b/docs/1.4/customization/block-rendering.md
@@ -13,11 +13,11 @@ All block renderers should implement `BlockRendererInterface` and its `render()`
 
 ## render()
 
-~~~php
+```php
 <?php
 
 public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false);
-~~~
+```
 
 The `HtmlRenderer` will call this method whenever a supported block element is encountered in the AST being rendered.
 
@@ -39,20 +39,20 @@ If you choose to return an HTML `string` you are responsible for handling any es
 
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
 $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
-~~~
+```
 
 ## Designating Block Renderers
 
 When registering your renderer, you must tell the `Environment` which block element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Block\Element\FencedCode;
@@ -63,11 +63,11 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the block class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addBlockRenderer(FencedCode::class, new MyCustomCodeRenderer());
-~~~
+```
 
 A single renderer could even be used for multiple block types:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Block\Element\FencedCode;
@@ -80,7 +80,7 @@ $myRenderer = new MyCustomCodeRenderer();
 
 $environment->addBlockRenderer(FencedCode::class, $myRenderer, 10);
 $environment->addBlockRenderer(IndentedCode::class, $myRenderer, 20);
-~~~
+```
 
 Multiple renderers can be added per element type - when this happens, we use the result from the highest-priority renderer that returns a non-`null` result.
 
@@ -88,7 +88,7 @@ Multiple renderers can be added per element type - when this happens, we use the
 
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -107,7 +107,7 @@ class TextDividerRenderer implements BlockRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addBlockRenderer('League\CommonMark\Block\Element\ThematicBreak', new TextDividerRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.4/customization/delimiter-processing.md
+++ b/docs/1.4/customization/delimiter-processing.md
@@ -14,9 +14,9 @@ Delimiter runs are a special type of inline:
  - They are denoted by "wrapping" text with one or more characters before **and** after those inner contents
  - They can contain other delimiter runs or inlines inside of them
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 
 When implementing something with these characteristics you should consider leveraging delimiter runs; otherwise, a basic [inline parser](/1.4/inline-parsing/) should be sufficient.
@@ -29,9 +29,9 @@ Delimiter processors have a lower priority than inline parsers - if an [inline p
 
 Implement the `DelimiterProcessorInterface` and add it to your environment:
 
-~~~php
+```php
 $environment->addDelimiterProcessor(new MyCustomDelimiterProcessor());
-~~~
+```
 
 ### `getOpeningCharacter()` and `getClosingCharacter()`
 
@@ -43,21 +43,21 @@ This method tells the engine the minimum number of characters needed to match or
 
 ### `getDelimiterUse()`
 
-~~~php
+```php
 public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int;
-~~~
+```
 
 This method is used to tell the engine how many characters from the matching delimiters should be consumed.  For simple processors you'll likely return `1` (or whatever your minimum length is).  In more advanced cases, you can examine the opening and closing delimiters and perform additional logic to determine whether they should be fully or partially consumed.  You can also return `0` if you'd like.
 
 ### `process()`
 
-~~~php
+```php
 public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse);
-~~~
+```
 
 This is where the magic happens.  Once the engine determines it can use the delimiter it found (by looking at all the other methods above) it'll call this method.  Your job is to take everything between the `$opener` and `$closer` and wrap that in whatever custom inline element you'd like.  Here's a basic example of wrapping the inner contents inside a new `Emphasis` element:
 
-~~~php
+```php
 // Create the outer element
 $emphasis = new Emphasis();
 
@@ -71,7 +71,7 @@ while ($tmp !== null && $tmp !== $closer) {
 
 // Place the outer element into the AST
 $opener->insertAfter($emphasis);
-~~~
+```
 
 Note that `$opener` and `$closer` will be automatically removed for you after this function returns - no need to do that yourself.
 
@@ -83,7 +83,7 @@ Basic delimiter processors, as covered above, do not require any custom inline p
 
 As your identifies potential delimiter-based inlines, it should create a new `AbstractStringContainer` node (either `Text` or something custom) with the inner contents and also push a new `DelimiterInterface` onto the `DelimiterStack`:
 
-~~~php
+```php
 $node = new Text($cursor->getPreviousText(), [
     'delim' => true,
 ]);
@@ -92,7 +92,7 @@ $inlineContext->getContainer()->appendChild($node);
 // Add entry to stack to this opener
 $delimiter = new Delimiter($character, $numDelims, $node, $canOpen, $canClose);
 $inlineContext->getDelimiterStack()->push($delimiter);
-~~~
+```
 
 This basically tells the engine that text was found which _might_ be emphasis, but due to the delimiter run rules we can't make that determination just yet.  That final determination is later on by a "delimiter processor".
 

--- a/docs/1.4/customization/environment.md
+++ b/docs/1.4/customization/environment.md
@@ -12,8 +12,6 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 A pre-configured `Environment` can be obtained like this:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -26,8 +24,6 @@ You can customize this default `Environment` (or even a new, empty one) using an
 ## mergeConfig()
 
 ```php
-<?php
-
 public function mergeConfig(array $config = []);
 ```
 
@@ -36,8 +32,6 @@ Merges the given [configuration](/1.4/configuration/) settings into any existing
 ## setConfig()
 
 ```php
-<?php
-
 public function setConfig(array $config = []);
 ```
 
@@ -46,8 +40,6 @@ Completely replaces the previous [configuration](/1.4/configuration/) settings w
 ## addExtension()
 
 ```php
-<?php
-
 public function addExtension(ExtensionInterface $extension);
 ```
 
@@ -56,8 +48,6 @@ Registers the given [extension](/1.4/customization/extensions/) with the environ
 ## addBlockParser()
 
 ```php
-<?php
-
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
 ```
 
@@ -68,8 +58,6 @@ See [Block Parsing](/1.4/customization/block-parsing/) for details.
 ## addBlockRenderer()
 
 ```php
-<?php
-
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
 ```
 
@@ -80,8 +68,6 @@ See [Block Rendering](/1.4/customization/block-rendering/) for details.
 ## addInlineParser()
 
 ```php
-<?php
-
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
 ```
 
@@ -92,8 +78,6 @@ See [Inline Parsing](/1.4/customization/inline-parsing/) for details.
 ## addInlineRenderer()
 
 ```php
-<?php
-
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
 ```
 
@@ -105,8 +89,6 @@ See [Inline Rendering](/1.4/customization/inline-rendering/) for details.
 ## addDelimiterProcessor()
 
 ```php
-<?php
-
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
 ```
 
@@ -117,8 +99,6 @@ See [Inline Parsing](/1.4/customization/delimiter-processing/) for details.
 ## addEventListener()
 
 ```php
-<?php
-
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
 ```
 

--- a/docs/1.4/customization/environment.md
+++ b/docs/1.4/customization/environment.md
@@ -11,13 +11,13 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 
 A pre-configured `Environment` can be obtained like this:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
-~~~
+```
 
 All of the core renders, parsers, etc. needed to implement the CommonMark spec will be pre-registered and ready to go.
 
@@ -25,41 +25,41 @@ You can customize this default `Environment` (or even a new, empty one) using an
 
 ## mergeConfig()
 
-~~~php
+```php
 <?php
 
 public function mergeConfig(array $config = []);
-~~~
+```
 
 Merges the given [configuration](/1.4/configuration/) settings into any existing ones.
 
 ## setConfig()
 
-~~~php
+```php
 <?php
 
 public function setConfig(array $config = []);
-~~~
+```
 
 Completely replaces the previous [configuration](/1.4/configuration/) settings with the new `$config` you provide.
 
 ## addExtension()
 
-~~~php
+```php
 <?php
 
 public function addExtension(ExtensionInterface $extension);
-~~~
+```
 
 Registers the given [extension](/1.4/customization/extensions/) with the environment.  This is typically how you'd integrate third-party extensions with this library.
 
 ## addBlockParser()
 
-~~~php
+```php
 <?php
 
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `BlockParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -67,11 +67,11 @@ See [Block Parsing](/1.4/customization/block-parsing/) for details.
 
 ## addBlockRenderer()
 
-~~~php
+```php
 <?php
 
 public function addBlockRenderer(string $blockClass, BlockRendererInterface $blockRenderer, int $priority = 0);
-~~~
+```
 
 Registers a `BlockRendererInterface` to handle a specific type of block (`$blockClass`)  with the given priority (a higher number will be executed earlier).
 
@@ -79,11 +79,11 @@ See [Block Rendering](/1.4/customization/block-rendering/) for details.
 
 ## addInlineParser()
 
-~~~php
+```php
 <?php
 
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `InlineParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -91,11 +91,11 @@ See [Inline Parsing](/1.4/customization/inline-parsing/) for details.
 
 ## addInlineRenderer()
 
-~~~php
+```php
 <?php
 
 public function addInlineRenderer(string $inlineClass, InlineRendererInterface $renderer, int $priority = 0);
-~~~
+```
 
 Registers an `InlineRendererInterface` to handle a specific type of inline (`$inlineClass`) with the given priority (a higher number will be executed earlier).
 A single renderer can handle multiple inline classes, but you must register it separately for each type. (The same renderer instance can be re-used if desired.)
@@ -104,11 +104,11 @@ See [Inline Rendering](/1.4/customization/inline-rendering/) for details.
 
 ## addDelimiterProcessor()
 
-~~~php
+```php
 <?php
 
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
-~~~
+```
 
 Registers the given `DelimiterProcessorInterface` with the environment.
 
@@ -116,11 +116,11 @@ See [Inline Parsing](/1.4/customization/delimiter-processing/) for details.
 
 ## addEventListener()
 
-~~~php
+```php
 <?php
 
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
-~~~
+```
 
 Registers the given event listener with the environment.
 

--- a/docs/1.4/customization/event-dispatcher.md
+++ b/docs/1.4/customization/event-dispatcher.md
@@ -82,8 +82,6 @@ This event is dispatched once all other processing is done.  This offers extensi
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
 ```php
-<?php
-
 use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Inline\Element\Link;
@@ -133,8 +131,6 @@ class ExternalLinkProcessor
 And here's how you'd use it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;

--- a/docs/1.4/customization/event-dispatcher.md
+++ b/docs/1.4/customization/event-dispatcher.md
@@ -81,7 +81,7 @@ This event is dispatched once all other processing is done.  This offers extensi
 
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\EnvironmentInterface;
@@ -128,11 +128,11 @@ class ExternalLinkProcessor
         return $host != $this->environment->getConfig('host');
     }
 }
-~~~
+```
 
 And here's how you'd use it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -149,15 +149,15 @@ $converter = new CommonMarkConverter(['host' => 'commonmark.thephpleague.com'], 
 $input = 'My two favorite sites are <https://google.com> and <https://commonmark.thephpleague.com>';
 
 echo $converter->convertToHtml($input);
-~~~
+```
 
 Output (formatted for readability):
 
-~~~html
+```html
 <p>
     My two favorite sites are
     <a class="external-link" href="https://google.com">https://google.com</a>
     and
     <a href="https://commonmark.thephpleague.com">https://commonmark.thephpleague.com</a>
 </p>
-~~~
+```

--- a/docs/1.4/customization/inline-parsing.md
+++ b/docs/1.4/customization/inline-parsing.md
@@ -60,8 +60,6 @@ Returning `true` tells the engine that you've successfully parsed the character 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Parser\InlineParserInterface;
@@ -73,6 +71,7 @@ class TwitterHandleParser implements InlineParserInterface
     {
         return ['@'];
     }
+
     public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
@@ -108,8 +107,6 @@ $environment->addInlineParser(new TwitterHandleParser());
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Image;
 use League\CommonMark\Inline\Parser\InlineParserInterface;

--- a/docs/1.4/customization/inline-parsing.md
+++ b/docs/1.4/customization/inline-parsing.md
@@ -19,9 +19,9 @@ The difference between normal inlines and delimiter-run-based inlines is subtle 
 
 An example of this would be emphasis:
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 If your syntax looks like that, consider using a [delimiter processor](/1.4/customization/delimiter-processing/) instead.  Otherwise, an inline parser is your best bet.
 
@@ -59,7 +59,7 @@ Returning `true` tells the engine that you've successfully parsed the character 
 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -101,13 +101,13 @@ class TwitterHandleParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new TwitterHandleParser());
-~~~
+```
 
 ### Example 2 - Emoticons
 
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -149,7 +149,7 @@ class SmilieParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new SmilieParserParser());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.4/customization/inline-rendering.md
+++ b/docs/1.4/customization/inline-rendering.md
@@ -34,7 +34,7 @@ Return `null` if your renderer cannot handle the given inline element - the next
 
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment;
@@ -44,13 +44,13 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the inline class type that should use our renderer
 // Second param - instance of the block renderer
 $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyCustomLinkRenderer());
-~~~
+```
 
 ## Example
 
 Here's a custom renderer which puts a special class on links to external sites:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\ElementRendererInterface;
@@ -98,7 +98,7 @@ class MyCustomLinkRenderer implements InlineRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineRenderer(Link::class, new MyCustomLinkRenderer());
-~~~
+```
 
 ## Tips
 

--- a/docs/1.4/customization/inline-rendering.md
+++ b/docs/1.4/customization/inline-rendering.md
@@ -35,8 +35,6 @@ Return `null` if your renderer cannot handle the given inline element - the next
 When registering your render, you must tell the `Environment` which inline element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -51,8 +49,6 @@ $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link', new MyC
 Here's a custom renderer which puts a special class on links to external sites:
 
 ```php
-<?php
-
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\Environment;
 use League\CommonMark\Inline\Element\Link;

--- a/docs/1.4/customization/overview.md
+++ b/docs/1.4/customization/overview.md
@@ -22,8 +22,6 @@ The actual process of converting Markdown to HTML has several steps:
 `CommonMarkConverter` handles all of this for you, but you can execute that process yourself if you wish:
 
 ```php
-<?php
-
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
 use League\CommonMark\HtmlRenderer;

--- a/docs/1.4/customization/overview.md
+++ b/docs/1.4/customization/overview.md
@@ -21,7 +21,7 @@ The actual process of converting Markdown to HTML has several steps:
 
 `CommonMarkConverter` handles all of this for you, but you can execute that process yourself if you wish:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\DocParser;
@@ -42,7 +42,7 @@ $document = $parser->parse($markdown);
 echo $htmlRenderer->renderBlock($document);
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Feel free to swap out different components or add your own steps in between.  However, the best way to customize this library is to [create your own extensions](/1.4/customization/extensions/) which hook into the parsing and rendering steps - continue reading to see which kinds of extension points are available to you.
 

--- a/docs/1.4/extensions/autolinks.md
+++ b/docs/1.4/extensions/autolinks.md
@@ -16,9 +16,9 @@ It also provides a parser to autolink `@mentions` to Twitter, Github, or any cus
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/commonmark.md
+++ b/docs/1.4/extensions/commonmark.md
@@ -12,9 +12,9 @@ The `CommonMarkCoreExtension` class contains all of the core Markdown syntax - t
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/disallowed-raw-html.md
+++ b/docs/1.4/extensions/disallowed-raw-html.md
@@ -30,9 +30,9 @@ All other HTML tags are left untouched by this extension.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/external-links.md
+++ b/docs/1.4/extensions/external-links.md
@@ -15,9 +15,9 @@ This extension can detect links to external sites and adjust the markup accordin
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/heading-permalinks.md
+++ b/docs/1.4/extensions/heading-permalinks.md
@@ -14,9 +14,9 @@ This extension makes all of your heading elements (`<h1>`, `<h2>`, etc) linkable
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/inlines-only.md
+++ b/docs/1.4/extensions/inlines-only.md
@@ -12,9 +12,9 @@ This extension configures the parser to only render inline elements - no paragra
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/smart-punctuation.md
+++ b/docs/1.4/extensions/smart-punctuation.md
@@ -24,9 +24,9 @@ Will result in this HTML:
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/strikethrough.md
+++ b/docs/1.4/extensions/strikethrough.md
@@ -14,9 +14,9 @@ This extension adds support for GFM-style strikethrough syntax.  It allows users
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/table-of-contents.md
+++ b/docs/1.4/extensions/table-of-contents.md
@@ -14,9 +14,9 @@ The [Heading Permalink](/1.4/extensions/heading-permalinks/) extension must also
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/tables.md
+++ b/docs/1.4/extensions/tables.md
@@ -14,9 +14,9 @@ The `TableExtension` adds the ability to create tables in CommonMark documents.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/extensions/task-lists.md
+++ b/docs/1.4/extensions/task-lists.md
@@ -14,9 +14,9 @@ This extension adds support for [GFM-style task lists](https://github.github.com
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 

--- a/docs/1.4/index.md
+++ b/docs/1.4/index.md
@@ -32,8 +32,6 @@ See the [installation](/1.4/installation/) section for more details.
 Simply instantiate the converter and start converting some Markdown to HTML!
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();

--- a/docs/1.4/index.md
+++ b/docs/1.4/index.md
@@ -21,9 +21,9 @@ title: Overview
 
 This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/1.4/installation/) section for more details.
 
@@ -31,7 +31,7 @@ See the [installation](/1.4/installation/) section for more details.
 
 Simply instantiate the converter and start converting some Markdown to HTML!
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -40,7 +40,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [basic usage](/1.4/basic-usage/) and [security](/1.4/security/) sections for important details.

--- a/docs/1.4/installation.md
+++ b/docs/1.4/installation.md
@@ -10,9 +10,9 @@ The recommended installation method is via Composer.
 
 In your project root just run:
 
-~~~bash
+```bash
 composer require league/commonmark:^1.4
-~~~
+```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 

--- a/docs/1.4/security.md
+++ b/docs/1.4/security.md
@@ -23,24 +23,24 @@ If you're developing an application which renders user-provided Markdown from po
 
 ### Example - Escape all raw HTML input:
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'escape']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // &lt;script&gt;alert("Hello XSS!");&lt;/script&gt;
-~~~
+```
 
 ### Example - Strip all HTML from the input:
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'strip']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // (empty output)
-~~~
+```
 
 **Failing to set this option could make your site vulnerable to cross-site scripting (XSS) attacks!**
 
@@ -65,7 +65,7 @@ If you need to parse untrusted input, consider setting a reasonable `max_nesting
 
 ### Example - Prevent deep nesting
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
@@ -83,7 +83,7 @@ echo $converter->convertToHtml($markdown);
 //     </blockquote>
 //   </blockquote>
 // </blockquote>
-~~~
+```
 
 See the [configuration](/1.4/configuration/) section for more information.
 


### PR DESCRIPTION
Follow up to https://github.com/thephpleague/commonmark/pull/554#pullrequestreview-501455569. This follows the same decisions in that PR and applies it backward to previous version's docs. I separated this out as I used more automated processes for the edits and this PR is less likely to have conflicts than the `2.0` docs which are under active development.

RE: #553