### PR TITLE
Code block consistency - Upcoming version

### DIFF
--- a/docs/1.5/security.md
+++ b/docs/1.5/security.md
@@ -89,7 +89,6 @@ echo $converter->convertToHtml($markdown);
 
 See the [configuration](/1.5/configuration/) section for more information.
 
-
 ## Additional Filtering
 
 Although this library does offer these security features out-of-the-box, some users may opt to also run the HTML output through additional filtering layers (like HTMLPurifier).  If you do this, make sure you **thoroughly** test your additional post-processing steps and configure them to work properly with the types of HTML elements and attributes that converted Markdown might produce, otherwise, you may end up with weird behavior like missing images, broken links, mismatched HTML tags, etc.

--- a/docs/2.0/basic-usage.md
+++ b/docs/2.0/basic-usage.md
@@ -10,7 +10,6 @@ Basic Usage
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
 ```php
-<?php
 require __DIR__ . '/vendor/autoload.php';
 
 use League\CommonMark\CommonMarkConverter;
@@ -24,8 +23,6 @@ echo $converter->convertToHtml('# Hello World!');
 Or if you want Github-Flavored Markdown:
 
 ```php
-<?php
-
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 $converter = new GithubFlavoredMarkdownConverter();

--- a/docs/2.0/basic-usage.md
+++ b/docs/2.0/basic-usage.md
@@ -9,7 +9,7 @@ Basic Usage
 
 The `CommonMarkConverter` class provides a simple wrapper for converting Markdown to HTML:
 
-~~~php
+```php
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
@@ -19,7 +19,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Or if you want Github-Flavored Markdown:
 

--- a/docs/2.0/configuration.md
+++ b/docs/2.0/configuration.md
@@ -9,8 +9,6 @@ Configuration
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter([

--- a/docs/2.0/configuration.md
+++ b/docs/2.0/configuration.md
@@ -8,7 +8,7 @@ Configuration
 
 You can provide an array of configuration options to the `CommonMarkConverter` when creating it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -28,7 +28,7 @@ $converter = new CommonMarkConverter([
     'allow_unsafe_links' => false,
     'max_nesting_level' => INF,
 ]);
-~~~
+```
 
 Here's a list of currently-supported options:
 

--- a/docs/2.0/customization/abstract-syntax-tree.md
+++ b/docs/2.0/customization/abstract-syntax-tree.md
@@ -45,7 +45,7 @@ This is best suited for situations when you need to know information about those
 
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Node\NodeWalker;
@@ -55,7 +55,7 @@ $walker = $document->walker();
 while ($event = $walker->next()) {
     echo 'I am ' . ($event->isEntering() ? 'entering' : 'leaving') . ' a ' . get_class($event->getNode()) . ' node' . "\n";
 }
-~~~
+```
 
 This walker doesn't use recursion, so you won't blow the stack when working with deeply-nested nodes.  It's also very memory-efficient.
 
@@ -65,7 +65,7 @@ However, if you add/remove nodes while walking the tree, this can lead to the wa
 
 If you're trying to locate certain nodes to perform actions on them, querying the nodes from the AST might be easier to implement.  This can be done with the `Query` class:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
@@ -83,7 +83,7 @@ $matchingNodes = (new Query())
 foreach ($matchingNodes as $node) {
     // TODO: Do something with them
 }
-~~~
+```
 
 Each condition passed into `where()`, `orWhere()`, or `andWhere()` must be a callable "filter" that accepts a `Node` and returns `true` or `false`.  We provide several methods that can help create these filters for you:
 
@@ -97,7 +97,7 @@ Each condition passed into `where()`, `orWhere()`, or `andWhere()` must be a cal
 
 You can of course create your own custom filters/conditions using an anonymous function or by implementing `ExpressionInterface`:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Node\Node;
@@ -121,7 +121,7 @@ class ChildCountGreaterThan implements ExpressionInterface
 $query = (new Query())
     ->where(function (Node $node): bool { return $node->data->has('attributes/class'); })
     ->andWhere(new ChildCountGreaterThan(3));
-~~~
+```
 
 ## Modification
 

--- a/docs/2.0/customization/abstract-syntax-tree.md
+++ b/docs/2.0/customization/abstract-syntax-tree.md
@@ -46,8 +46,6 @@ This is best suited for situations when you need to know information about those
 If you'd like to iterate through all the nodes, use the `walker()` method to obtain an instance of `NodeWalker`.  This will walk through the entire tree, emitting `NodeWalkerEvent`s along the way.
 
 ```php
-<?php
-
 use League\CommonMark\Node\NodeWalker;
 
 /** @var NodeWalker $walker */
@@ -66,8 +64,6 @@ However, if you add/remove nodes while walking the tree, this can lead to the wa
 If you're trying to locate certain nodes to perform actions on them, querying the nodes from the AST might be easier to implement.  This can be done with the `Query` class:
 
 ```php
-<?php
-
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Node\Block\Paragraph;
@@ -98,8 +94,6 @@ Each condition passed into `where()`, `orWhere()`, or `andWhere()` must be a cal
 You can of course create your own custom filters/conditions using an anonymous function or by implementing `ExpressionInterface`:
 
 ```php
-<?php
-
 use League\CommonMark\Node\Node;
 use League\CommonMark\Node\Query;
 use League\CommonMark\Node\Query\ExpressionInterface;

--- a/docs/2.0/customization/block-parsing.md
+++ b/docs/2.0/customization/block-parsing.md
@@ -119,8 +119,6 @@ Here are some additional tips to consider when writing your own custom parsers:
 Although parsing requires two classes, you can use the anonymous class feature of PHP to combine both into a single file!  Here's an example:
 
 ```php
-<?php
-
 use League\CommonMark\Parser\Block\AbstractBlockContinueParser;
 use League\CommonMark\Parser\Block\BlockStartParserInterface;
 

--- a/docs/2.0/customization/block-parsing.md
+++ b/docs/2.0/customization/block-parsing.md
@@ -52,61 +52,61 @@ This interface has several methods, so it's usually easier to extend from `Abstr
 
 ### `getBlock()`
 
-~~~php
+```php
 public function getBlock(): AbstractBlock;
-~~~
+```
 
 Each instance of a `BlockContinueParserInterface` is associated with a new block that is being parsed.  This method here returns that block.
 
 ### `isContainer()`
 
-~~~php
+```php
 public function isContainer(): bool;
-~~~
+```
 
 This method returns whether or not the block is a "container" capable of containing other blocks as children.
 
 ### `canContain()`
 
-~~~
+```php
 public function canContain(AbstractBlock $childBlock): bool;
-~~~
+```
 
 This method returns whether the current block being parsed can contain the given child block.
 
 ### `canHaveLazyContinuationLines()`
 
-~~~php
+```php
 public function canHaveLazyContinuationLines(): bool;
-~~~
+```
 
 This method returns whether or not this parser should also receive subsequent lines of Markdown input.  This is primarily used when a block can span multiple lines, like code blocks do.
 
 ### `addLine()`
 
-~~~php
+```php
 public function addLine(string $line): void;
-~~~
+```
 
 If `canHaveLazyContinuationLines()` returned `true`, this method will be called with the additional lines of content.
 
 ### `tryContinue()`
 
-~~~php
+```php
 public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue;
-~~~
+```
 
 This method allows you to try and parse an additional line of Markdown.
 
-~~~php
+```php
 public function closeBlock(): void;
-~~~
+```
 
 This method is called when the block is done being parsed.  Any final adjustments to the block should be made at this time.
 
-~~~php
+```php
 public function parseInlines(InlineParserEngineInterface $inlineParser): void;
-~~~
+```
 
 This method is called when the engine is ready to parse any inline child elements.
 
@@ -118,7 +118,7 @@ Here are some additional tips to consider when writing your own custom parsers:
 
 Although parsing requires two classes, you can use the anonymous class feature of PHP to combine both into a single file!  Here's an example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Parser\Block\AbstractBlockContinueParser;
@@ -137,7 +137,7 @@ final class MyCustomBlockParser extends AbstractBlockContinueParser
     }
 }
 
-~~~
+```
 
 ### Performance
 

--- a/docs/2.0/customization/delimiter-processing.md
+++ b/docs/2.0/customization/delimiter-processing.md
@@ -14,9 +14,9 @@ Delimiter runs are a special type of inline:
  - They are denoted by "wrapping" text with one or more characters before **and** after those inner contents
  - They can contain other delimiter runs or inlines inside of them
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 
 When implementing something with these characteristics you should consider leveraging delimiter runs; otherwise, a basic [inline parser](/2.0/inline-parsing/) should be sufficient.
@@ -29,9 +29,9 @@ Delimiter processors have a lower priority than inline parsers - if an [inline p
 
 Implement the `DelimiterProcessorInterface` and add it to your environment:
 
-~~~php
+```php
 $environment->addDelimiterProcessor(new MyCustomDelimiterProcessor());
-~~~
+```
 
 ### `getOpeningCharacter()` and `getClosingCharacter()`
 
@@ -43,21 +43,21 @@ This method tells the engine the minimum number of characters needed to match or
 
 ### `getDelimiterUse()`
 
-~~~php
+```php
 public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int;
-~~~
+```
 
 This method is used to tell the engine how many characters from the matching delimiters should be consumed.  For simple processors you'll likely return `1` (or whatever your minimum length is).  In more advanced cases, you can examine the opening and closing delimiters and perform additional logic to determine whether they should be fully or partially consumed.  You can also return `0` if you'd like.
 
 ### `process()`
 
-~~~php
+```php
 public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse): void;
-~~~
+```
 
 This is where the magic happens.  Once the engine determines it can use the delimiter it found (by looking at all the other methods above) it'll call this method.  Your job is to take everything between the `$opener` and `$closer` and wrap that in whatever custom inline element you'd like.  Here's a basic example of wrapping the inner contents inside a new `Emphasis` element:
 
-~~~php
+```php
 // Create the outer element
 $emphasis = new Emphasis();
 
@@ -71,7 +71,7 @@ while ($tmp !== null && $tmp !== $closer) {
 
 // Place the outer element into the AST
 $opener->insertAfter($emphasis);
-~~~
+```
 
 Note that `$opener` and `$closer` will be automatically removed for you after this function returns - no need to do that yourself.
 
@@ -83,7 +83,7 @@ Basic delimiter processors, as covered above, do not require any custom inline p
 
 As your identifies potential delimiter-based inlines, it should create a new `AbstractStringContainer` node (either `Text` or something custom) with the inner contents and also push a new `DelimiterInterface` onto the `DelimiterStack`:
 
-~~~php
+```php
 $node = new Text($cursor->getPreviousText(), [
     'delim' => true,
 ]);
@@ -92,7 +92,7 @@ $inlineContext->getContainer()->appendChild($node);
 // Add entry to stack to this opener
 $delimiter = new Delimiter($character, $numDelims, $node, $canOpen, $canClose);
 $inlineContext->getDelimiterStack()->push($delimiter);
-~~~
+```
 
 This basically tells the engine that text was found which _might_ be emphasis, but due to the delimiter run rules we can't make that determination just yet.  That final determination is later on by a "delimiter processor".
 

--- a/docs/2.0/customization/environment.md
+++ b/docs/2.0/customization/environment.md
@@ -11,13 +11,13 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 
 A pre-configured `Environment` can be obtained like this:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
-~~~
+```
 
 All of the core renders, parsers, etc. needed to implement the CommonMark spec will be pre-registered and ready to go.
 
@@ -25,41 +25,41 @@ You can customize this default `Environment` (or even a new, empty one) using an
 
 ## mergeConfig()
 
-~~~php
+```php
 <?php
 
 public function mergeConfig(array $config = []);
-~~~
+```
 
 Merges the given [configuration](/2.0/configuration/) settings into any existing ones.
 
 ## setConfig()
 
-~~~php
+```php
 <?php
 
 public function setConfig(array $config = []);
-~~~
+```
 
 Completely replaces the previous [configuration](/2.0/configuration/) settings with the new `$config` you provide.
 
 ## addExtension()
 
-~~~php
+```php
 <?php
 
 public function addExtension(ExtensionInterface $extension);
-~~~
+```
 
 Registers the given [extension](/2.0/customization/extensions/) with the environment.  This is typically how you'd integrate third-party extensions with this library.
 
 ## addBlockParser()
 
-~~~php
+```php
 <?php
 
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `BlockParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -67,11 +67,11 @@ See [Block Parsing](/2.0/customization/block-parsing/) for details.
 
 ## addInlineParser()
 
-~~~php
+```php
 <?php
 
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
-~~~
+```
 
 Registers the given `InlineParserInterface` with the environment with the given priority (a higher number will be executed earlier).
 
@@ -79,11 +79,11 @@ See [Inline Parsing](/2.0/customization/inline-parsing/) for details.
 
 ## addDelimiterProcessor()
 
-~~~php
+```php
 <?php
 
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
-~~~
+```
 
 Registers the given `DelimiterProcessorInterface` with the environment.
 
@@ -91,11 +91,11 @@ See [Inline Parsing](/2.0/customization/delimiter-processing/) for details.
 
 ## addRenderer()
 
-~~~php
+```php
 <?php
 
 public function addRenderer(string $blockOrInlineClass, NodeRendererInterface $blockRenderer, int $priority = 0);
-~~~
+```
 
 Registers a `NodeRendererInterface` to handle a specific type of AST node (`$blockOrInlineClass`)  with the given priority (a higher number will be executed earlier).
 
@@ -103,11 +103,11 @@ See [Rendering](/2.0/customization/rendering/) for details.
 
 ## addEventListener()
 
-~~~php
+```php
 <?php
 
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
-~~~
+```
 
 Registers the given event listener with the environment.
 

--- a/docs/2.0/customization/environment.md
+++ b/docs/2.0/customization/environment.md
@@ -12,8 +12,6 @@ The `Environment` contains all of the parsers, renderers, configurations, etc. t
 A pre-configured `Environment` can be obtained like this:
 
 ```php
-<?php
-
 use League\CommonMark\Environment\Environment;
 
 $environment = Environment::createCommonMarkEnvironment();
@@ -26,8 +24,6 @@ You can customize this default `Environment` (or even a new, empty one) using an
 ## mergeConfig()
 
 ```php
-<?php
-
 public function mergeConfig(array $config = []);
 ```
 
@@ -36,8 +32,6 @@ Merges the given [configuration](/2.0/configuration/) settings into any existing
 ## setConfig()
 
 ```php
-<?php
-
 public function setConfig(array $config = []);
 ```
 
@@ -46,8 +40,6 @@ Completely replaces the previous [configuration](/2.0/configuration/) settings w
 ## addExtension()
 
 ```php
-<?php
-
 public function addExtension(ExtensionInterface $extension);
 ```
 
@@ -56,8 +48,6 @@ Registers the given [extension](/2.0/customization/extensions/) with the environ
 ## addBlockParser()
 
 ```php
-<?php
-
 public function addBlockParser(BlockParserInterface $parser, int $priority = 0);
 ```
 
@@ -68,8 +58,6 @@ See [Block Parsing](/2.0/customization/block-parsing/) for details.
 ## addInlineParser()
 
 ```php
-<?php
-
 public function addInlineParser(InlineParserInterface $parser, int $priority = 0);
 ```
 
@@ -80,8 +68,6 @@ See [Inline Parsing](/2.0/customization/inline-parsing/) for details.
 ## addDelimiterProcessor()
 
 ```php
-<?php
-
 public function addDelimiterProcessor(DelimiterProcessorInterface $processor);
 ```
 
@@ -92,8 +78,6 @@ See [Inline Parsing](/2.0/customization/delimiter-processing/) for details.
 ## addRenderer()
 
 ```php
-<?php
-
 public function addRenderer(string $blockOrInlineClass, NodeRendererInterface $blockRenderer, int $priority = 0);
 ```
 
@@ -104,8 +88,6 @@ See [Rendering](/2.0/customization/rendering/) for details.
 ## addEventListener()
 
 ```php
-<?php
-
 public function addEventListener(string $eventClass, callable $listener, int $priority = 0);
 ```
 

--- a/docs/2.0/customization/event-dispatcher.md
+++ b/docs/2.0/customization/event-dispatcher.md
@@ -98,8 +98,6 @@ Because the `Environment` implements PSR-14's `ListenerProviderInterface` you'll
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
 ```php
-<?php
-
 use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
@@ -149,8 +147,6 @@ class ExternalLinkProcessor
 And here's how you'd use it:
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;

--- a/docs/2.0/customization/event-dispatcher.md
+++ b/docs/2.0/customization/event-dispatcher.md
@@ -97,7 +97,7 @@ Because the `Environment` implements PSR-14's `ListenerProviderInterface` you'll
 
 Here's an example of a listener which uses the `DocumentParsedEvent` to add an `external-link` class to external URLs:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\EnvironmentInterface;
@@ -144,11 +144,11 @@ class ExternalLinkProcessor
         return $host != $this->environment->getConfig('host');
     }
 }
-~~~
+```
 
 And here's how you'd use it:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -165,15 +165,15 @@ $converter = new CommonMarkConverter(['host' => 'commonmark.thephpleague.com'], 
 $input = 'My two favorite sites are <https://google.com> and <https://commonmark.thephpleague.com>';
 
 echo $converter->convertToHtml($input);
-~~~
+```
 
 Output (formatted for readability):
 
-~~~html
+```html
 <p>
     My two favorite sites are
     <a class="external-link" href="https://google.com">https://google.com</a>
     and
     <a href="https://commonmark.thephpleague.com">https://commonmark.thephpleague.com</a>
 </p>
-~~~
+```

--- a/docs/2.0/customization/extensions.md
+++ b/docs/2.0/customization/extensions.md
@@ -34,7 +34,6 @@ To hook up your new extension to the `Environment`, simply do this:
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 
-
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addExtension(new EmojiExtension());
 

--- a/docs/2.0/customization/inline-parsing.md
+++ b/docs/2.0/customization/inline-parsing.md
@@ -19,9 +19,9 @@ The difference between normal inlines and delimiter-run-based inlines is subtle 
 
 An example of this would be emphasis:
 
-~~~markdown
+```markdown
 This is an example of **emphasis**. Note how the text is *wrapped* with the same character(s) before and after.
-~~~
+```
 
 If your syntax looks like that, consider using a [delimiter processor](/2.0/customization/delimiter-processing/) instead.  Otherwise, an inline parser is your best bet.
 
@@ -86,7 +86,7 @@ Returning `true` tells the engine that you've successfully parsed the character 
 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\Environment;
@@ -125,13 +125,13 @@ class TwitterHandleParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new TwitterHandleParser());
-~~~
+```
 
 ### Example 2 - Emoticons
 
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\Environment;
@@ -167,7 +167,7 @@ class SmilieParser implements InlineParserInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addInlineParser(new SmilieParserParser());
-~~~
+```
 
 ## Tips
 

--- a/docs/2.0/customization/inline-parsing.md
+++ b/docs/2.0/customization/inline-parsing.md
@@ -87,8 +87,6 @@ Returning `true` tells the engine that you've successfully parsed the character 
 Let's say you wanted to autolink Twitter handles without using the link syntax.  This could be accomplished by registering a new inline parser to handle the `@` character:
 
 ```php
-<?php
-
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Parser\Inline\InlineParserInterface;
@@ -101,6 +99,7 @@ class TwitterHandleParser implements InlineParserInterface
     {
         return InlineParserMatch::regex('@([A-Za-z0-9_]{1,15}(?!\w))');
     }
+
     public function parse(InlineParserContext $inlineContext): bool
     {
         $cursor = $inlineContext->getCursor();
@@ -132,8 +131,6 @@ $environment->addInlineParser(new TwitterHandleParser());
 Let's say you want to automatically convert smilies (or "frownies") to emoticon images.  This is incredibly easy with an inline parser:
 
 ```php
-<?php
-
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Parser\Inline\InlineParserInterface;

--- a/docs/2.0/customization/overview.md
+++ b/docs/2.0/customization/overview.md
@@ -22,8 +22,6 @@ The actual process of converting Markdown to HTML has several steps:
 `CommonMarkConverter` handles all of this for you, but you can execute that process yourself if you wish:
 
 ```php
-<?php
-
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Renderer\HtmlRenderer;

--- a/docs/2.0/customization/overview.md
+++ b/docs/2.0/customization/overview.md
@@ -21,7 +21,7 @@ The actual process of converting Markdown to HTML has several steps:
 
 `CommonMarkConverter` handles all of this for you, but you can execute that process yourself if you wish:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Parser\MarkdownParser;
@@ -42,7 +42,7 @@ $document = $parser->parse($markdown);
 echo $htmlRenderer->renderDocument($document);
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 Feel free to swap out different components or add your own steps in between.  However, the best way to customize this library is to [create your own extensions](/2.0/customization/extensions/) which hook into the parsing and rendering steps - continue reading to see which kinds of extension points are available to you.
 

--- a/docs/2.0/customization/rendering.md
+++ b/docs/2.0/customization/rendering.md
@@ -14,11 +14,11 @@ block renderers and inline renderers share the same interface and method:
 
 ## render()
 
-~~~php
+```php
 <?php
 
 public function render(Node $node, ChildNodeRendererInterface $childRenderer);
-~~~
+```
 
 The `HtmlRenderer` will call this method during the rendering process whenever a supported element is encountered.
 
@@ -39,20 +39,20 @@ If you choose to return an HTML `string` you are responsible for handling any es
 
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Util\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
 $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
-~~~
+```
 
 ## Designating Renderers
 
 When registering your renderer, you must tell the `Environment` which node element class your renderer should handle. For example:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\Environment;
@@ -63,11 +63,11 @@ $environment = Environment::createCommonMarkEnvironment();
 // First param - the node class type that should use our renderer
 // Second param - instance of the renderer
 $environment->addRenderer(FencedCode::class, new MyCustomCodeRenderer());
-~~~
+```
 
 A single renderer could even be used for multiple types:
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\Environment;
@@ -80,7 +80,7 @@ $myRenderer = new MyCustomCodeRenderer();
 
 $environment->addRenderer(FencedCode::class, $myRenderer, 10);
 $environment->addRenderer(IndentedCode::class, $myRenderer, 20);
-~~~
+```
 
 Multiple renderers can be added per element type - when this happens, we use the result from the highest-priority renderer that returns a non-`null` result.
 
@@ -88,7 +88,7 @@ Multiple renderers can be added per element type - when this happens, we use the
 
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\Environment\Environment;
@@ -108,7 +108,7 @@ class TextDividerRenderer implements NodeRendererInterface
 
 $environment = Environment::createCommonMarkEnvironment();
 $environment->addRenderer(ThematicBreak::class, new TextDividerRenderer());
-~~~
+```
 
 Note that thematic breaks should not contain children, which is why the `$childRenderer` is unused in this example.  Otherwise we'd have to call code like this and return the result as part of the rendered HTML we're generating here: `$innerHtml = $childRenderer->renderNodes($node->children());`
 

--- a/docs/2.0/customization/rendering.md
+++ b/docs/2.0/customization/rendering.md
@@ -15,8 +15,6 @@ block renderers and inline renderers share the same interface and method:
 ## render()
 
 ```php
-<?php
-
 public function render(Node $node, ChildNodeRendererInterface $childRenderer);
 ```
 
@@ -40,8 +38,6 @@ If you choose to return an HTML `string` you are responsible for handling any es
 Instead of manually building the HTML output yourself, you can leverage the `HtmlElement` to generate that for you.  For example:
 
 ```php
-<?php
-
 use League\CommonMark\Util\HtmlElement;
 
 $link = new HtmlElement('a', ['href' => 'https://github.com'], 'GitHub');
@@ -53,8 +49,6 @@ $img = new HtmlElement('img', ['src' => 'logo.jpg'], '', true);
 When registering your renderer, you must tell the `Environment` which node element class your renderer should handle. For example:
 
 ```php
-<?php
-
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 
@@ -68,8 +62,6 @@ $environment->addRenderer(FencedCode::class, new MyCustomCodeRenderer());
 A single renderer could even be used for multiple types:
 
 ```php
-<?php
-
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
@@ -89,8 +81,6 @@ Multiple renderers can be added per element type - when this happens, we use the
 Here's a custom renderer which renders thematic breaks as text (instead of `<hr>`):
 
 ```php
-<?php
-
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\Node\Node;

--- a/docs/2.0/extensions/attributes.md
+++ b/docs/2.0/extensions/attributes.md
@@ -34,9 +34,9 @@ This is *red*{style="color: red"}.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/attributes.md
+++ b/docs/2.0/extensions/attributes.md
@@ -45,7 +45,6 @@ See the [installation](/2.0/installation/) section for more details.
 Configure your `Environment` as usual and simply add the `AttributesExtension`:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Extension\Attributes\AttributesExtension;

--- a/docs/2.0/extensions/autolinks.md
+++ b/docs/2.0/extensions/autolinks.md
@@ -14,9 +14,9 @@ The `AutolinkExtension` adds [GFM-style autolinking][link-gfm-spec-autolinking].
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/commonmark.md
+++ b/docs/2.0/extensions/commonmark.md
@@ -12,9 +12,9 @@ The `CommonMarkCoreExtension` class contains all of the core Markdown syntax - t
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/disallowed-raw-html.md
+++ b/docs/2.0/extensions/disallowed-raw-html.md
@@ -30,9 +30,9 @@ All other HTML tags are left untouched by this extension.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/external-links.md
+++ b/docs/2.0/extensions/external-links.md
@@ -16,9 +16,9 @@ This extension can detect links to external sites and adjust the markup accordin
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/footnotes.md
+++ b/docs/2.0/extensions/footnotes.md
@@ -54,7 +54,6 @@ Result:
 Configure your `Environment` as usual and simply add the `FootnoteExtension`:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Footnote\FootnoteExtension;

--- a/docs/2.0/extensions/footnotes.md
+++ b/docs/2.0/extensions/footnotes.md
@@ -12,9 +12,9 @@ The `FootnoteExtension` adds the ability to create footnotes in Markdown documen
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 
@@ -22,7 +22,7 @@ See the [installation](/2.0/installation/) section for more details.
 
 Sample Markdown input:
 
-```md
+```markdown
 Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi[^note1] leo risus, porta ac consectetur ac.
 
@@ -31,7 +31,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi[^note1] leo risus
 
 Result:
 
-```md
+```html
 <p>
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/docs/2.0/extensions/front-matter.md
+++ b/docs/2.0/extensions/front-matter.md
@@ -13,17 +13,17 @@ The `FrontMatterExtension` adds the ability to parse YAML front matter from the 
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 
 You will also need to install `symfony/yaml` to use this extension:
 
-~~~bash
+```bash
 composer require symfony/yaml
-~~~
+```
 
 (You can use any version of `symfony/yaml` 2.3 or higher, though we recommend using 4.0 or higher.)
 
@@ -31,7 +31,7 @@ composer require symfony/yaml
 
 This extension follows the [Jekyll Front Matter syntax](https://jekyllrb.com/docs/front-matter/). The front matter must be the first thing in the file and must take the form of valid YAML set between triple-dashed lines. Here is a basic example:
 
-```md
+```markdown
 ---
 layout: post
 title: I Love Markdown

--- a/docs/2.0/extensions/front-matter.md
+++ b/docs/2.0/extensions/front-matter.md
@@ -67,7 +67,6 @@ And the HTML output will only contain the one heading:
 Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;

--- a/docs/2.0/extensions/heading-permalinks.md
+++ b/docs/2.0/extensions/heading-permalinks.md
@@ -14,9 +14,9 @@ This extension makes all of your heading elements (`<h1>`, `<h2>`, etc) linkable
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/heading-permalinks.md
+++ b/docs/2.0/extensions/heading-permalinks.md
@@ -100,8 +100,6 @@ You can change the string that is used as the "slug" by setting the `slug_normal
 For example, if you'd like each slug to be an MD5 hash, you could create a class like this:
 
 ```php
-<?php
-
 use League\CommonMark\Normalizer\TextNormalizerInterface;
 
 final class MD5Normalizer implements TextNormalizerInterface

--- a/docs/2.0/extensions/inlines-only.md
+++ b/docs/2.0/extensions/inlines-only.md
@@ -12,9 +12,9 @@ This extension configures the parser to only render inline elements - no paragra
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/mentions.md
+++ b/docs/2.0/extensions/mentions.md
@@ -17,7 +17,6 @@ define the starting prefix, a regular expression to match against, and any custo
 generate the URL.
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Mention\MentionExtension;
@@ -212,7 +211,6 @@ You can then hook this class up to a mention definition in the configuration to 
 mentions:
 
 ```php
-<?php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Mention\MentionExtension;

--- a/docs/2.0/extensions/smart-punctuation.md
+++ b/docs/2.0/extensions/smart-punctuation.md
@@ -10,7 +10,7 @@ The `SmartPunctExtension` Intelligently converts ASCII quotes, dashes, and ellip
 
 For example, this Markdown...
 
-```md
+```markdown
 "CommonMark is the PHP League's Markdown parser," she said.  "It's super-configurable... you can even use additional extensions to expand its capabilities -- just like this one!"
 ```
 
@@ -24,9 +24,9 @@ Will result in this HTML:
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 
@@ -34,7 +34,7 @@ See the [installation](/2.0/installation/) section for more details.
 
 Extensions can be added to any new `Environment`:
 
-``` php
+```php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;

--- a/docs/2.0/extensions/strikethrough.md
+++ b/docs/2.0/extensions/strikethrough.md
@@ -14,9 +14,9 @@ This extension adds support for GFM-style strikethrough syntax.  It allows users
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/table-of-contents.md
+++ b/docs/2.0/extensions/table-of-contents.md
@@ -14,9 +14,9 @@ The [Heading Permalink](/2.0/extensions/heading-permalinks/) extension must also
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 
@@ -104,7 +104,7 @@ These two settings control which headings should appear in the list.  By default
 
 Consider this sample Markdown input:
 
-```md
+```markdown
 ## Level 2 Heading
 
 This is a sample document that starts with a level 2 heading

--- a/docs/2.0/extensions/tables.md
+++ b/docs/2.0/extensions/tables.md
@@ -14,9 +14,9 @@ The `TableExtension` adds the ability to create tables in CommonMark documents.
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/extensions/task-lists.md
+++ b/docs/2.0/extensions/task-lists.md
@@ -14,9 +14,9 @@ This extension adds support for [GFM-style task lists](https://github.github.com
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 

--- a/docs/2.0/index.md
+++ b/docs/2.0/index.md
@@ -21,9 +21,9 @@ title: Overview
 
 This library can be installed via Composer:
 
-~~~bash
+```bash
 composer require league/commonmark
-~~~
+```
 
 See the [installation](/2.0/installation/) section for more details.
 
@@ -31,7 +31,7 @@ See the [installation](/2.0/installation/) section for more details.
 
 Simply instantiate the converter and start converting some Markdown to HTML!
 
-~~~php
+```php
 <?php
 
 use League\CommonMark\CommonMarkConverter;
@@ -40,7 +40,7 @@ $converter = new CommonMarkConverter();
 echo $converter->convertToHtml('# Hello World!');
 
 // <h1>Hello World!</h1>
-~~~
+```
 
 <i class="fa fa-exclamation-triangle"></i>
 **Important:** See the [basic usage](/2.0/basic-usage/) and [security](/2.0/security/) sections for important details.

--- a/docs/2.0/index.md
+++ b/docs/2.0/index.md
@@ -32,8 +32,6 @@ See the [installation](/2.0/installation/) section for more details.
 Simply instantiate the converter and start converting some Markdown to HTML!
 
 ```php
-<?php
-
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();

--- a/docs/2.0/installation.md
+++ b/docs/2.0/installation.md
@@ -10,9 +10,9 @@ The recommended installation method is via Composer.
 
 In your project root just run:
 
-~~~bash
+```bash
 composer require league/commonmark:^2.0
-~~~
+```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 

--- a/docs/2.0/security.md
+++ b/docs/2.0/security.md
@@ -23,24 +23,24 @@ If you're developing an application which renders user-provided Markdown from po
 
 ### Example - Escape all raw HTML input:
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'escape']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // &lt;script&gt;alert("Hello XSS!");&lt;/script&gt;
-~~~
+```
 
 ### Example - Strip all HTML from the input:
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter(['html_input' => 'strip']);
 echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 
 // (empty output)
-~~~
+```
 
 **Failing to set this option could make your site vulnerable to cross-site scripting (XSS) attacks!**
 
@@ -65,7 +65,7 @@ If you need to parse untrusted input, consider setting a reasonable `max_nesting
 
 ### Example - Prevent deep nesting
 
-~~~php
+```php
 use League\CommonMark\CommonMarkConverter;
 
 $markdown = str_repeat('> ', 10000) . ' Foo';
@@ -83,7 +83,7 @@ echo $converter->convertToHtml($markdown);
 //     </blockquote>
 //   </blockquote>
 // </blockquote>
-~~~
+```
 
 See the [configuration](/2.0/configuration/) section for more information.
 

--- a/docs/2.0/security.md
+++ b/docs/2.0/security.md
@@ -33,6 +33,7 @@ echo $converter->convertToHtml('<script>alert("Hello XSS!");</script>');
 ```
 
 ### Example - Strip all HTML from the input:
+
 ```php
 use League\CommonMark\CommonMarkConverter;
 

--- a/docs/2.0/upgrading/consumers.md
+++ b/docs/2.0/upgrading/consumers.md
@@ -13,7 +13,6 @@ The minimum supported PHP version was increased from 7.1 to 7.2.
 In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast it to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
 
 ```diff
- <?php
  use League\CommonMark\CommonMarkConverter;
 
  $converter = new CommonMarkConverter();

--- a/docs/2.0/upgrading/consumers.md
+++ b/docs/2.0/upgrading/consumers.md
@@ -12,7 +12,7 @@ The minimum supported PHP version was increased from 7.1 to 7.2.
 
 In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast it to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
 
-~~~diff
+```diff
  <?php
  use League\CommonMark\CommonMarkConverter;
 
@@ -21,7 +21,7 @@ In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed t
 +echo $converter->convertToHtml('# Hello World!')->getContent();
 +// or
 +echo (string) $converter->convertToHtml('# Hello World!');
-~~~
+```
 
 ## Classes/Namespaces Renamed
 

--- a/docs/2.0/upgrading/developers.md
+++ b/docs/2.0/upgrading/developers.md
@@ -13,7 +13,6 @@ The minimum supported PHP version was increased from 7.1 to 7.2.
 In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast the return value to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
 
 ```diff
- <?php
  use League\CommonMark\CommonMarkConverter;
 
  $converter = new CommonMarkConverter();

--- a/docs/2.0/upgrading/developers.md
+++ b/docs/2.0/upgrading/developers.md
@@ -12,7 +12,7 @@ The minimum supported PHP version was increased from 7.1 to 7.2.
 
 In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast the return value to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
 
-~~~diff
+```diff
  <?php
  use League\CommonMark\CommonMarkConverter;
 
@@ -21,7 +21,7 @@ In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed t
 +echo $converter->convertToHtml('# Hello World!')->getContent();
 +// or
 +echo (string) $converter->convertToHtml('# Hello World!');
-~~~
+```
 
 ## Method Return Types
 
@@ -171,7 +171,7 @@ This library no longer differentiates between block renderers and inline rendere
 Renderers now implement the unified `NodeRendererInterface` which has a similar (but slightly different) signature from
 the old `BlockRendererInterface` and `InlineRendererInterface` interfaces:
 
-~~~php
+```php
 /**
  * @param Node                       $node
  * @param ChildNodeRendererInterface $childRenderer
@@ -179,7 +179,7 @@ the old `BlockRendererInterface` and `InlineRendererInterface` interfaces:
  * @return HtmlElement|string|null
  */
 public function render(Node $node, ChildNodeRendererInterface $childRenderer);
-~~~
+```
 
 The element being rendered is still passed in the first argument, and the object that helps you render children is still
 passed in the second argument.  Note that blocks are no longer told whether they're being rendered in a tight list - if you

--- a/docs/2.0/upgrading/integrators.md
+++ b/docs/2.0/upgrading/integrators.md
@@ -12,7 +12,7 @@ The minimum supported PHP version was increased from 7.1 to 7.2.
 
 In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast the return value to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
 
-~~~diff
+```diff
  <?php
  use League\CommonMark\CommonMarkConverter;
 
@@ -21,7 +21,7 @@ In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed t
 +echo $converter->convertToHtml('# Hello World!')->getContent();
 +// or
 +echo (string) $converter->convertToHtml('# Hello World!');
-~~~
+```
 
 ## Method Return Types
 
@@ -142,7 +142,7 @@ This library no longer differentiates between block renderers and inline rendere
 Renderers now implement the unified `NodeRendererInterface` which has a similar (but slightly different) signature from
 the old `BlockRendererInterface` and `InlineRendererInterface` interfaces:
 
-~~~php
+```php
 /**
  * @param Node                       $node
  * @param ChildNodeRendererInterface $childRenderer
@@ -150,7 +150,7 @@ the old `BlockRendererInterface` and `InlineRendererInterface` interfaces:
  * @return HtmlElement|string|null
  */
 public function render(Node $node, ChildNodeRendererInterface $childRenderer);
-~~~
+```
 
 The element being rendered is still passed in the first argument, and the object that helps you render children is still
 passed in the second argument.  Note that blocks are no longer told whether they're being rendered in a tight list - if you

--- a/docs/2.0/upgrading/integrators.md
+++ b/docs/2.0/upgrading/integrators.md
@@ -13,7 +13,6 @@ The minimum supported PHP version was increased from 7.1 to 7.2.
 In 1.x, calling `convertToHtml()` would return a `string`. In 2.x this changed to return a `RenderedContentInterface`.  To get the resulting HTML, either cast the return value to a `string` or call `->getContent()`.  (This new interface extends from `Stringable` so you can type hint against that instead, if needed.)
 
 ```diff
- <?php
  use League\CommonMark\CommonMarkConverter;
 
  $converter = new CommonMarkConverter();


### PR DESCRIPTION
Follow up to https://github.com/thephpleague/commonmark/pull/554#pullrequestreview-501455569. This follows the same decisions in that PR and applies it to the `2.0/` documents. I separated this out as it is more likely to contain conflicts as 2.0 is under active development. Furthermore, these changes were applied in a more hands on manner and manually checked throughout the rendered site.

RE: #553 