### PR TITLE
Add “name” property to mentions so implementers can identify which mention is which

### DIFF
--- a/src/Extension/Mention/Mention.php
+++ b/src/Extension/Mention/Mention.php
@@ -22,13 +22,17 @@ use League\CommonMark\Node\Inline\Text;
 class Mention extends Link
 {
     /** @var string */
+    private $name;
+
+    /** @var string */
     private $prefix;
 
     /** @var string */
     private $identifier;
 
-    public function __construct(string $prefix, string $identifier, ?string $label = null)
+    public function __construct(string $name, string $prefix, string $identifier, ?string $label = null)
     {
+        $this->name       = $name;
         $this->prefix     = $prefix;
         $this->identifier = $identifier;
 
@@ -47,6 +51,11 @@ class Mention extends Link
     public function getIdentifier(): string
     {
         return $this->identifier;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
     }
 
     public function getPrefix(): string

--- a/src/Extension/Mention/MentionExtension.php
+++ b/src/Extension/Mention/MentionExtension.php
@@ -35,11 +35,11 @@ final class MentionExtension implements ExtensionInterface
             }
 
             if ($mention['generator'] instanceof MentionGeneratorInterface) {
-                $environment->addInlineParser(new MentionParser($mention['prefix'], $mention['pattern'], $mention['generator']));
+                $environment->addInlineParser(new MentionParser($name, $mention['prefix'], $mention['pattern'], $mention['generator']));
             } elseif (\is_string($mention['generator'])) {
-                $environment->addInlineParser(MentionParser::createWithStringTemplate($mention['prefix'], $mention['pattern'], $mention['generator']));
+                $environment->addInlineParser(MentionParser::createWithStringTemplate($name, $mention['prefix'], $mention['pattern'], $mention['generator']));
             } elseif (\is_callable($mention['generator'])) {
-                $environment->addInlineParser(MentionParser::createWithCallback($mention['prefix'], $mention['pattern'], $mention['generator']));
+                $environment->addInlineParser(MentionParser::createWithCallback($name, $mention['prefix'], $mention['pattern'], $mention['generator']));
             } else {
                 throw new InvalidOptionException(\sprintf('The "generator" provided for the "%s" MentionParser configuration must be a string template, callable, or an object that implements %s.', $name, MentionGeneratorInterface::class));
             }

--- a/src/Extension/Mention/MentionParser.php
+++ b/src/Extension/Mention/MentionParser.php
@@ -27,6 +27,13 @@ final class MentionParser implements InlineParserInterface
      *
      * @psalm-readonly
      */
+    private $name;
+
+    /**
+     * @var string
+     *
+     * @psalm-readonly
+     */
     private $prefix;
 
     /**
@@ -43,8 +50,9 @@ final class MentionParser implements InlineParserInterface
      */
     private $mentionGenerator;
 
-    public function __construct(string $prefix, string $identifierPattern, MentionGeneratorInterface $mentionGenerator)
+    public function __construct(string $name, string $prefix, string $identifierPattern, MentionGeneratorInterface $mentionGenerator)
     {
+        $this->name              = $name;
         $this->prefix            = $prefix;
         $this->identifierPattern = $identifierPattern;
         $this->mentionGenerator  = $mentionGenerator;
@@ -71,7 +79,7 @@ final class MentionParser implements InlineParserInterface
 
         [$prefix, $identifier] = $inlineContext->getSubMatches();
 
-        $mention = $this->mentionGenerator->generateMention(new Mention($prefix, $identifier));
+        $mention = $this->mentionGenerator->generateMention(new Mention($this->name, $prefix, $identifier));
 
         if ($mention === null) {
             return false;
@@ -83,13 +91,13 @@ final class MentionParser implements InlineParserInterface
         return true;
     }
 
-    public static function createWithStringTemplate(string $prefix, string $mentionRegex, string $urlTemplate): MentionParser
+    public static function createWithStringTemplate(string $name, string $prefix, string $mentionRegex, string $urlTemplate): MentionParser
     {
-        return new self($prefix, $mentionRegex, new StringTemplateLinkGenerator($urlTemplate));
+        return new self($name, $prefix, $mentionRegex, new StringTemplateLinkGenerator($urlTemplate));
     }
 
-    public static function createWithCallback(string $prefix, string $mentionRegex, callable $callback): MentionParser
+    public static function createWithCallback(string $name, string $prefix, string $mentionRegex, callable $callback): MentionParser
     {
-        return new self($prefix, $mentionRegex, new CallbackGenerator($callback));
+        return new self($name, $prefix, $mentionRegex, new CallbackGenerator($callback));
     }
 }

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -30,7 +30,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See #123 for more information.';
         $expected = '<p>See <a href="https://www.example.com/123">#123</a> for more information.</p>';
 
-        $mentionParser = new MentionParser('#', '\d+', new StringTemplateLinkGenerator('https://www.example.com/%s'));
+        $mentionParser = new MentionParser('test', '#', '\d+', new StringTemplateLinkGenerator('https://www.example.com/%s'));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -45,7 +45,7 @@ final class MentionParserTest extends TestCase
         $input    = 'Try asking u:colinodell about that.';
         $expected = '<p>Try asking <a href="https://www.example.com/users/colinodell">u:colinodell</a> about that.</p>';
 
-        $mentionParser = new MentionParser('u:', '\w+', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
+        $mentionParser = new MentionParser('test', 'u:', '\w+', new StringTemplateLinkGenerator('https://www.example.com/users/%s'));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -60,7 +60,7 @@ final class MentionParserTest extends TestCase
         $input    = 'I spend too much time on the /r/php subreddit.';
         $expected = '<p>I spend too much time on the <a href="https://www.reddit.com/r/php">/r/php</a> subreddit.</p>';
 
-        $mentionParser = new MentionParser('/r/', '\w+', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
+        $mentionParser = new MentionParser('test', '/r/', '\w+', new StringTemplateLinkGenerator('https://www.reddit.com/r/%s'));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -75,7 +75,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See#123 for more information.';
         $expected = '<p>See#123 for more information.</p>';
 
-        $mentionParser = new MentionParser('#', '\d+', $this->createMock(MentionGeneratorInterface::class));
+        $mentionParser = new MentionParser('test', '#', '\d+', $this->createMock(MentionGeneratorInterface::class));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -90,7 +90,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See #123 for more information.';
         $expected = '<p>See #123 for more information.</p>';
 
-        $mentionParser = new MentionParser('@', '\d+', $this->createMock(MentionGeneratorInterface::class));
+        $mentionParser = new MentionParser('test', '@', '\d+', $this->createMock(MentionGeneratorInterface::class));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -105,7 +105,7 @@ final class MentionParserTest extends TestCase
         $input    = 'See #123 for more information.';
         $expected = '<p>See #123 for more information.</p>';
 
-        $mentionParser = new MentionParser('#', '[a-z]+', $this->createMock(MentionGeneratorInterface::class));
+        $mentionParser = new MentionParser('test', '#', '[a-z]+', $this->createMock(MentionGeneratorInterface::class));
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -123,7 +123,7 @@ final class MentionParserTest extends TestCase
         $returnsNull = $this->createMock(MentionGeneratorInterface::class);
         $returnsNull->method('generateMention')->willReturn(null);
 
-        $mentionParser = new MentionParser('#', '\d+', $returnsNull);
+        $mentionParser = new MentionParser('test', '#', '\d+', $returnsNull);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -147,7 +147,7 @@ final class MentionParserTest extends TestCase
         $input    = 'This should parse #123.';
         $expected = '<p>This should parse <a href="https://www.example.com/123/#123/#">Replaced Label</a>.</p>';
 
-        $mentionParser = MentionParser::createWithCallback('#', '\d+', $callable);
+        $mentionParser = MentionParser::createWithCallback('test', '#', '\d+', $callable);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);
@@ -170,7 +170,7 @@ final class MentionParserTest extends TestCase
         $input    = 'This should parse #123.';
         $expected = '<p>This should parse <em>[members only]</em>.</p>';
 
-        $mentionParser = MentionParser::createWithCallback('#', '\d+', $callable);
+        $mentionParser = MentionParser::createWithCallback('test', '#', '\d+', $callable);
 
         $environment = Environment::createCommonMarkEnvironment();
         $environment->addInlineParser($mentionParser);

--- a/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
+++ b/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
@@ -32,7 +32,7 @@ final class CallbackGeneratorTest extends TestCase
             return $mention;
         });
 
-        $mention = $generator->generateMention(new Mention('@', 'colinodell'));
+        $mention = $generator->generateMention(new Mention('test', '@', 'colinodell'));
 
         $this->assertSame('https://www.example.com/colinodell/@colinodell/@', $mention->getUrl());
 
@@ -47,7 +47,7 @@ final class CallbackGeneratorTest extends TestCase
             return null;
         });
 
-        $mention = $generator->generateMention(new Mention('@', 'colinodell'));
+        $mention = $generator->generateMention(new Mention('test', '@', 'colinodell'));
 
         $this->assertNull($mention);
     }
@@ -62,7 +62,7 @@ final class CallbackGeneratorTest extends TestCase
             return $emphasis;
         });
 
-        $mention = $generator->generateMention(new Mention('@', 'colinodell'));
+        $mention = $generator->generateMention(new Mention('test', '@', 'colinodell'));
 
         $this->assertSame($emphasis, $mention);
 
@@ -82,7 +82,7 @@ final class CallbackGeneratorTest extends TestCase
             return $mention;
         });
 
-        $generator->generateMention(new Mention('@', 'colinodell'));
+        $generator->generateMention(new Mention('test', '@', 'colinodell'));
     }
 
     public function testWithNewMentionButNoUrlReturn(): void
@@ -91,10 +91,10 @@ final class CallbackGeneratorTest extends TestCase
 
         $generator = new CallbackGenerator(static function (Mention $mention) {
             // Test what happens when returning a new mention without a URL
-            return new Mention('@', 'foo');
+            return new Mention('test', '@', 'foo');
         });
 
-        $generator->generateMention(new Mention('@', 'colinodell'));
+        $generator->generateMention(new Mention('test', '@', 'colinodell'));
     }
 
     public function testWithInvalidReturn(): void
@@ -105,6 +105,6 @@ final class CallbackGeneratorTest extends TestCase
             return new \stdClass(); // something that is not a string or null
         });
 
-        $generator->generateMention(new Mention('@', 'colinodell'));
+        $generator->generateMention(new Mention('test', '@', 'colinodell'));
     }
 }

--- a/tests/unit/Extension/Mention/Generator/StringTemplateLinkGeneratorTest.php
+++ b/tests/unit/Extension/Mention/Generator/StringTemplateLinkGeneratorTest.php
@@ -24,7 +24,7 @@ final class StringTemplateLinkGeneratorTest extends TestCase
     {
         $generator = new StringTemplateLinkGenerator('https://www.twitter.com/%s');
 
-        $mention = $generator->generateMention(new Mention('@', 'colinodell'));
+        $mention = $generator->generateMention(new Mention('test', '@', 'colinodell'));
         \assert($mention instanceof Mention);
 
         $this->assertSame('https://www.twitter.com/colinodell', $mention->getUrl());

--- a/tests/unit/Extension/Mention/MentionTest.php
+++ b/tests/unit/Extension/Mention/MentionTest.php
@@ -21,8 +21,9 @@ final class MentionTest extends TestCase
 {
     public function testConstructorAndGetters(): void
     {
-        $mention = new Mention('@', 'colinodell');
+        $mention = new Mention('test', '@', 'colinodell');
 
+        $this->assertSame('test', $mention->getName());
         $this->assertSame('@', $mention->getPrefix());
         $this->assertSame('colinodell', $mention->getIdentifier());
         $this->assertSame('@colinodell', $mention->getLabel());
@@ -36,7 +37,7 @@ final class MentionTest extends TestCase
 
     public function testConstructorAndGettersWithCustomLabel(): void
     {
-        $mention = new Mention('#', '123', 'Issue #123');
+        $mention = new Mention('test', '#', '123', 'Issue #123');
 
         $this->assertSame('#', $mention->getPrefix());
         $this->assertSame('123', $mention->getIdentifier());
@@ -51,7 +52,7 @@ final class MentionTest extends TestCase
 
     public function testSetUrl(): void
     {
-        $mention = new Mention('@', 'colinodell');
+        $mention = new Mention('test', '@', 'colinodell');
         $mention->setUrl('https://www.twitter.com/colinodell');
 
         $this->assertSame('https://www.twitter.com/colinodell', $mention->getUrl());
@@ -59,7 +60,7 @@ final class MentionTest extends TestCase
 
     public function testSetLabel(): void
     {
-        $mention = new Mention('@', 'colinodell');
+        $mention = new Mention('test', '@', 'colinodell');
 
         $this->assertSame('@colinodell', $mention->getLabel());
 
@@ -82,7 +83,7 @@ final class MentionTest extends TestCase
 
     public function testLabelFunctionsWhenLabelDetached(): void
     {
-        $mention = new Mention('@', 'colinodell');
+        $mention = new Mention('test', '@', 'colinodell');
 
         $this->assertSame('@colinodell', $mention->getLabel());
 


### PR DESCRIPTION
While working on https://www.drupal.org/project/markdown/issues/3160927, I suddenly realized that there's no "easy" way to determine which mention is being used by the generator callback we're using, thus I cannot load that specific mention's configuration (has much more than the normal mention due to CMS integrations).

Since the changes to these classes are mostly internal, I figured it wouldn't hurt to add a new parameter that names the mention (which is automatically pulled from the mention configuration as the array key).