### PR TITLE
Add instructions on how to install dev version

### DIFF
--- a/docs/2.0/installation.md
+++ b/docs/2.0/installation.md
@@ -34,7 +34,7 @@ Put the following code in it and save:
 
 When the file is set up, run the following command and you are done.
 
-```sh
+```bash
 composer install
 ```
 

--- a/docs/2.0/installation.md
+++ b/docs/2.0/installation.md
@@ -8,10 +8,34 @@ description: Instructions on how to install the league/commonmark library
 
 The recommended installation method is via Composer.
 
-In your project root just run:
-
 ```bash
-composer require league/commonmark:^2.0
+composer require "league/commonmark:^2.0"
+```
+
+Since this version is still a work in progress, you will need to include packages of dev stability. If you see an error like this you need to change your stability requirements.
+
+> Your requirements could not be resolved to an installable set of packages.
+>  
+> Problem 1
+> - The requested package league/commonmark ^2.0 is satisfiable by league/commonmark[2.0.x-dev] but these conflict with your requirements or minimum-stability.
+
+The easiest way to do this, is to create a file in your project root, called `composer.json`
+
+Put the following code in it and save:
+
+```json
+{
+	"require-dev": {
+		"league/commonmark": "^2.0@dev",
+		"dflydev/dot-access-data": "^3.0@dev"
+	}
+}
+```
+
+When the file is set up, run the following command and you are done.
+
+```sh
+composer install
 ```
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).


### PR DESCRIPTION
When version 2.0 goes stable, it will be as easy as is currently
documented:

```bash
composer require "league/commonmark:^2.0"
```

Right now however, there's a good chance people have their composer
settings set to have a minimum stability of "stable".[1]
This will probably result in errors when trying to run this command.

I wasn't sure what the best way forward is for here: leave in the old,
but make a note of it? Make temporary instructions for dev?

For now I went with a combination: leave the current way (with just
`composer require`), but add some instructions for the current dev
version.

When this version goes stable the extra instructions can easily be
deleted from the document.

[1] This is the issue I ran into myself when I tried to play around with 
the 2.0 version. This PR is my way of paying it forward or something. 😉