### PR TITLE
Fix mentions when they appear after a non-word character such as \n or ,

### DIFF
--- a/src/Extension/Mention/MentionParser.php
+++ b/src/Extension/Mention/MentionParser.php
@@ -72,7 +72,7 @@ final class MentionParser implements InlineParserInterface
 
         // The prefix must not have any other characters immediately prior
         $previousChar = $cursor->peek(-1);
-        if ($previousChar !== null && $previousChar !== ' ') {
+        if ($previousChar !== null && \preg_match('/\w/', $previousChar)) {
             // peek() doesn't modify the cursor, so no need to restore state first
             return false;
         }

--- a/tests/functional/Extension/Mention/MentionParserTest.php
+++ b/tests/functional/Extension/Mention/MentionParserTest.php
@@ -179,4 +179,24 @@ final class MentionParserTest extends TestCase
 
         $this->assertEquals($expected, \rtrim((string) $converter->convertToHtml($input)));
     }
+
+    public function testMentionParserWithNonWordCharacterBefore(): void
+    {
+        $input = "Test\n#123 for more information.";
+        $expected = "<p>Test\n<a href=\"https://www.example.com/123\">#123</a> for more information.</p>";
+
+        $mentionParser = new MentionParser(
+            'test',
+            '#',
+            '\d+',
+            new StringTemplateLinkGenerator('https://www.example.com/%s')
+        );
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addInlineParser($mentionParser);
+
+        $converter = new CommonMarkConverter([], $environment);
+
+        $this->assertEquals($expected, \rtrim((string)$converter->convertToHtml($input)));
+    }
 }


### PR DESCRIPTION
**Version(s) affected**: 1.5.6

**Description**  
If a mention immediately follows a new line or any other non-word character it doesn't get converted to a link.

**How to reproduce**  
```php
$environment = Environment::createGFMEnvironment();
$environment->addExtension(new MentionExtension());

$converter = new GithubFlavoredMarkdownConverter(
    [
        'mentions' => [
            'github_handle'  => [
                'symbol'    => '@',
                'regex'     => '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/',
                'generator' => 'https://github.com/%s',
            ]
        ],
    ],
    $environment
);

echo $converter->convertToHtml("@test\n@test");
```
Results in:
```html
<p><a href="https://github.com/test">@test</a>
@test</p>
```
instead of
```html
<p><a href="https://github.com/test">@test</a>
<a href="https://github.com/test">@test</a></p>
```
**Fix**
This PR replaces the test for a space with one for any non-word character.
This seems to be what GitHub does, as `test,@jean-gui` gets converted to `test<a href="...">@jean-gui</a>`.