### PR TITLE
Docs: Improve readabillity on large screens

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -184,6 +184,10 @@ h4 {
     font-size:1em;
 }
 
+main article p {
+    max-width: 840px;
+}
+
 main article p code,
 main article li code,
 main article div > code {


### PR DESCRIPTION
This PR adds a `max-width` on paragraphs, to limit the line length and improve the readabillity on larger screens.