### PR TITLE
Adding spekulatius/laravel-commonmark-blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See the [Extensions documentation](https://commonmark.thephpleague.com/customiza
 - [Symfony 4](https://github.com/avensome/commonmark-bundle)
 - [Twig Markdown extension](https://github.com/twigphp/markdown-extension)
 - [Twig filter and tag](https://github.com/aptoma/twig-markdown)
+- [Laravel CommonMark Blog](https://github.com/spekulatius/laravel-commonmark-blog)
 
 ### Included Extensions
 


### PR DESCRIPTION
Hey @colinodell,

I've build a static-generator to use within Laravel. It takes commonmark files with frontmatter and generates pages to publish in the `public` directory. Do you think it could be added to the "Integrations" section?

Happy New Year,
Peter