### PR TITLE
Resolve casing error in documentation of DisallowedRawHtmlExtension

### DIFF
--- a/docs/1.3/extensions/disallowed-raw-html.md
+++ b/docs/1.3/extensions/disallowed-raw-html.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: Disallowed Raw HTML Extension
-description: The DisallowedRawHTMLExtension automatically escapes certain HTML tags when rendering raw HTML
+description: The DisallowedRawHtmlExtension automatically escapes certain HTML tags when rendering raw HTML
 ---
 
 # Disallowed Raw HTML Extension
 
 _(Note: this extension is included by default within [the GFM extension](/1.3/extensions/github-flavored-markdown/))_
 
-The `DisallowedRawHTMLExtension` automatically filters certain HTML tags when rendering output, such as:
+The `DisallowedRawHtmlExtension` automatically filters certain HTML tags when rendering output, such as:
 
 - `<title>`
 - `<textarea>`
@@ -38,18 +38,18 @@ See the [installation](/1.3/installation/) section for more details.
 
 ## Usage
 
-Configure your `Environment` as usual and simply add the `DisallowedRawHTMLExtension` provided by this package:
+Configure your `Environment` as usual and simply add the `DisallowedRawHtmlExtension` provided by this package:
 
 ```php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
-use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
+use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHtmlExtension;
 
 // Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
 $environment = Environment::createCommonMarkEnvironment();
 
 // Add this extension
-$environment->addExtension(new DisallowedRawHTMLExtension());
+$environment->addExtension(new DisallowedRawHtmlExtension());
 
 // Instantiate the converter engine and start converting some Markdown!
 $converter = new CommonMarkConverter([], $environment);

--- a/docs/1.4/extensions/disallowed-raw-html.md
+++ b/docs/1.4/extensions/disallowed-raw-html.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: Disallowed Raw HTML Extension
-description: The DisallowedRawHTMLExtension automatically escapes certain HTML tags when rendering raw HTML
+description: The DisallowedRawHtmlExtension automatically escapes certain HTML tags when rendering raw HTML
 ---
 
 # Disallowed Raw HTML Extension
 
 _(Note: this extension is included by default within [the GFM extension](/1.4/extensions/github-flavored-markdown/))_
 
-The `DisallowedRawHTMLExtension` automatically filters certain HTML tags when rendering output, such as:
+The `DisallowedRawHtmlExtension` automatically filters certain HTML tags when rendering output, such as:
 
 - `<title>`
 - `<textarea>`
@@ -38,18 +38,18 @@ See the [installation](/1.4/installation/) section for more details.
 
 ## Usage
 
-Configure your `Environment` as usual and simply add the `DisallowedRawHTMLExtension` provided by this package:
+Configure your `Environment` as usual and simply add the `DisallowedRawHtmlExtension` provided by this package:
 
 ```php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
-use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
+use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHtmlExtension;
 
 // Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
 $environment = Environment::createCommonMarkEnvironment();
 
 // Add this extension
-$environment->addExtension(new DisallowedRawHTMLExtension());
+$environment->addExtension(new DisallowedRawHtmlExtension());
 
 // Instantiate the converter engine and start converting some Markdown!
 $converter = new CommonMarkConverter([], $environment);

--- a/docs/1.5/extensions/disallowed-raw-html.md
+++ b/docs/1.5/extensions/disallowed-raw-html.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Disallowed Raw HTML Extension
-description: The DisallowedRawHTMLExtension automatically escapes certain HTML tags when rendering raw HTML
+description: The DisallowedRawHtmlExtension automatically escapes certain HTML tags when rendering raw HTML
 redirect_from: /extensions/disallowed-raw-html/
 ---
 
@@ -9,7 +9,7 @@ redirect_from: /extensions/disallowed-raw-html/
 
 _(Note: this extension is included by default within [the GFM extension](/1.5/extensions/github-flavored-markdown/))_
 
-The `DisallowedRawHTMLExtension` automatically filters certain HTML tags when rendering output, such as:
+The `DisallowedRawHtmlExtension` automatically filters certain HTML tags when rendering output, such as:
 
 - `<title>`
 - `<textarea>`
@@ -39,18 +39,18 @@ See the [installation](/1.5/installation/) section for more details.
 
 ## Usage
 
-Configure your `Environment` as usual and simply add the `DisallowedRawHTMLExtension` provided by this package:
+Configure your `Environment` as usual and simply add the `DisallowedRawHtmlExtension` provided by this package:
 
 ```php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
-use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
+use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHtmlExtension;
 
 // Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
 $environment = Environment::createCommonMarkEnvironment();
 
 // Add this extension
-$environment->addExtension(new DisallowedRawHTMLExtension());
+$environment->addExtension(new DisallowedRawHtmlExtension());
 
 // Instantiate the converter engine and start converting some Markdown!
 $converter = new CommonMarkConverter([], $environment);

--- a/docs/1.6/extensions/disallowed-raw-html.md
+++ b/docs/1.6/extensions/disallowed-raw-html.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: Disallowed Raw HTML Extension
-description: The DisallowedRawHTMLExtension automatically escapes certain HTML tags when rendering raw HTML
+description: The DisallowedRawHtmlExtension automatically escapes certain HTML tags when rendering raw HTML
 ---
 
 # Disallowed Raw HTML Extension
 
 _(Note: this extension is included by default within [the GFM extension](/1.6/extensions/github-flavored-markdown/))_
 
-The `DisallowedRawHTMLExtension` automatically filters certain HTML tags when rendering output, such as:
+The `DisallowedRawHtmlExtension` automatically filters certain HTML tags when rendering output, such as:
 
 - `<title>`
 - `<textarea>`
@@ -38,18 +38,18 @@ See the [installation](/1.6/installation/) section for more details.
 
 ## Usage
 
-Configure your `Environment` as usual and simply add the `DisallowedRawHTMLExtension` provided by this package:
+Configure your `Environment` as usual and simply add the `DisallowedRawHtmlExtension` provided by this package:
 
 ```php
 use League\CommonMark\Environment;
-use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
+use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHtmlExtension;
 use League\CommonMark\MarkdownConverter;
 
 // Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
 $environment = Environment::createCommonMarkEnvironment();
 
 // Add this extension
-$environment->addExtension(new DisallowedRawHTMLExtension());
+$environment->addExtension(new DisallowedRawHtmlExtension());
 
 // Set your configuration if needed
 $environment->mergeConfig([

--- a/docs/2.0/extensions/disallowed-raw-html.md
+++ b/docs/2.0/extensions/disallowed-raw-html.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: Disallowed Raw HTML Extension
-description: The DisallowedRawHTMLExtension automatically escapes certain HTML tags when rendering raw HTML
+description: The DisallowedRawHtmlExtension automatically escapes certain HTML tags when rendering raw HTML
 ---
 
 # Disallowed Raw HTML Extension
 
 _(Note: this extension is included by default within [the GFM extension](/2.0/extensions/github-flavored-markdown/))_
 
-The `DisallowedRawHTMLExtension` automatically escapes certain HTML tags when rendering raw HTML, such as:
+The `DisallowedRawHtmlExtension` automatically escapes certain HTML tags when rendering raw HTML, such as:
 
 - `<title>`
 - `<textarea>`
@@ -38,12 +38,12 @@ See the [installation](/2.0/installation/) section for more details.
 
 ## Usage
 
-Configure your `Environment` as usual and simply add the `DisallowedRawHTMLExtension` provided by this package:
+Configure your `Environment` as usual and simply add the `DisallowedRawHtmlExtension` provided by this package:
 
 ```php
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
-use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHTMLExtension;
+use League\CommonMark\Extension\DisallowedRawHTML\DisallowedRawHtmlExtension;
 use League\CommonMark\MarkdownConverter;
 
 // Customize the extension's configuration if needed
@@ -60,7 +60,7 @@ $environment = new Environment($config);
 $environment->addExtension(new CommonMarkCoreExtension());
 
 // Add this extension
-$environment->addExtension(new DisallowedRawHTMLExtension());
+$environment->addExtension(new DisallowedRawHtmlExtension());
 
 // Instantiate the converter engine and start converting some Markdown!
 $converter = new MarkdownConverter($environment);


### PR DESCRIPTION
Replace DisallowedRawHTMLExtension with DisallowedRawHtmlExtension (Html instead of HTML) in documentation

fixes #599