### PR TITLE
ci: fix code coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
 
             - uses: shivammathur/setup-php@v2
               with:


### PR DESCRIPTION
Code coverage is failing in CI but the job still passes due to `continue-on-error: true`

```
In RepositoryIntrospector.php line 39:
                                                                               
  Failed to retrieve commit parents. If you use a shallow git checkout, pleas  
  e checkout at least a depth of one.                                          
                                                                               

code-coverage:upload [--api-url API-URL] [--repository REPOSITORY] [--revision REVISION] [--format FORMAT] [--parent PARENT] [--] <coverage-file>
```