### PR TITLE
Add missing import for available classes

### DIFF
--- a/docs/2.0/extensions/mentions.md
+++ b/docs/2.0/extensions/mentions.md
@@ -174,6 +174,10 @@ want to parse `@username` into custom user profile links for your application, b
 create a class like the following which integrates with the framework your application is built on:
 
 ```php
+use League\CommonMark\Extension\Mention\Generator\MentionGeneratorInterface;
+use League\CommonMark\Extension\Mention\Mention;
+use League\CommonMark\Inline\Element\AbstractInline;
+
 class UserMentionGenerator implements MentionGeneratorInterface
 {
     private $currentUser;


### PR DESCRIPTION
this PR adds import class for `MentionGeneratorInterface`, `Mention` and `AbstractInline` which can be imported from `commonmark` package.