### PR TITLE
Fix ability to register block parsers that identify lines starting with letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 - Bumped minimum version of league/config to support PHP 8.1
 
+### Fixed
+
+- Fixed ability to register block parsers that identify lines starting with letters (#706)
+
 ## [2.0.1] - 2021-07-31
 
 ### Fixed

--- a/docs/2.0/customization/block-parsing.md
+++ b/docs/2.0/customization/block-parsing.md
@@ -44,6 +44,8 @@ return BlockStart::of(new MyCustomParser())->at($cursor);
 
 Unlike in 1.x, the `Cursor` state is no longer shared between parsers.  You must therefore explicitly provide the `BlockStart` object with a copy of your cursor at the correct, post-parsing position.
 
+**NOTE:** If your custom block starts with a [letter character](http://unicode.org/reports/tr18/#General_Category_Property) you'll need to [add your parser to the environment](/2.0/customization/environment/#addblockstartparser) with a priority of `250` or higher.  This is due to a performance optimization where such lines are usually skipped.
+
 ## `BlockContinueParserInterface`
 
 The previous interface only helps the engine identify where a block starts.  Additional information about the block, as well as the ability to parse additional lines of input, is all handled by the `BlockContinueParserInterface`.

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -30,6 +30,7 @@ use League\CommonMark\Normalizer\TextNormalizerInterface;
 use League\CommonMark\Normalizer\UniqueSlugNormalizer;
 use League\CommonMark\Normalizer\UniqueSlugNormalizerInterface;
 use League\CommonMark\Parser\Block\BlockStartParserInterface;
+use League\CommonMark\Parser\Block\SkipLinesStartingWithLettersParser;
 use League\CommonMark\Parser\Inline\InlineParserInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 use League\CommonMark\Util\HtmlFilter;
@@ -111,6 +112,10 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
         $this->inlineParsers       = new PrioritizedList();
         $this->listenerData        = new PrioritizedList();
         $this->delimiterProcessors = new DelimiterProcessorCollection();
+
+        // Performance optimization: always include a block "parser" that aborts parsing if a line starts with a letter
+        // and is therefore unlikely to match any lines as a block start.
+        $this->addBlockStartParser(new SkipLinesStartingWithLettersParser(), 249);
     }
 
     public function getConfiguration(): ConfigurationInterface

--- a/src/Parser/Block/BlockStart.php
+++ b/src/Parser/Block/BlockStart.php
@@ -34,6 +34,8 @@ final class BlockStart
     /** @psalm-readonly-allow-private-mutation */
     private bool $replaceActiveBlockParser = false;
 
+    private bool $isAborting = false;
+
     private function __construct(BlockContinueParserInterface ...$blockParsers)
     {
         $this->blockParsers = $blockParsers;
@@ -55,6 +57,14 @@ final class BlockStart
     public function isReplaceActiveBlockParser(): bool
     {
         return $this->replaceActiveBlockParser;
+    }
+
+    /**
+     * @internal
+     */
+    public function isAborting(): bool
+    {
+        return $this->isAborting;
     }
 
     /**
@@ -97,5 +107,18 @@ final class BlockStart
     public static function of(BlockContinueParserInterface ...$blockParsers): self
     {
         return new self(...$blockParsers);
+    }
+
+    /**
+     * Signal that the block parsing process should be aborted (no other block starts should be checked)
+     *
+     * @internal
+     */
+    public static function abort(): self
+    {
+        $ret             = new self();
+        $ret->isAborting = true;
+
+        return $ret;
     }
 }

--- a/src/Parser/Block/SkipLinesStartingWithLettersParser.php
+++ b/src/Parser/Block/SkipLinesStartingWithLettersParser.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Parser\Block;
+
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\MarkdownParserStateInterface;
+use League\CommonMark\Util\RegexHelper;
+
+/**
+ * @internal
+ *
+ * This "parser" is actually a performance optimization.
+ *
+ * Most lines in a typical Markdown document probably won't match a block start. This is especially true for lines starting
+ * with letters - nothing in the core CommonMark spec or our supported extensions will match those lines as blocks. Therefore,
+ * if we can identify those lines and skip block start parsing, we can optimize performance by ~10%.
+ *
+ * Previously this optimization was hard-coded in the MarkdownParser but did not allow users to override this behavior.
+ * By implementing this optimization as a block parser instead, users wanting custom blocks starting with letters
+ * can instead register their block parser with a higher priority to ensure their parser is always called first.
+ */
+final class SkipLinesStartingWithLettersParser implements BlockStartParserInterface
+{
+    public function tryStart(Cursor $cursor, MarkdownParserStateInterface $parserState): ?BlockStart
+    {
+        if (! $cursor->isIndented() && RegexHelper::isLetter($cursor->getNextNonSpaceCharacter())) {
+            $cursor->advanceToNextNonSpaceOrTab();
+
+            return BlockStart::abort();
+        }
+
+        return BlockStart::none();
+    }
+}

--- a/src/Parser/MarkdownParser.php
+++ b/src/Parser/MarkdownParser.php
@@ -33,7 +33,6 @@ use League\CommonMark\Parser\Block\DocumentBlockParser;
 use League\CommonMark\Parser\Block\ParagraphParser;
 use League\CommonMark\Reference\ReferenceInterface;
 use League\CommonMark\Reference\ReferenceMap;
-use League\CommonMark\Util\RegexHelper;
 
 final class MarkdownParser implements MarkdownParserInterface
 {
@@ -136,17 +135,12 @@ final class MarkdownParser implements MarkdownParserInterface
                 break;
             }
 
-            if (! $this->cursor->isIndented() && RegexHelper::isLetter($this->cursor->getNextNonSpaceCharacter())) {
-                $this->cursor->advanceToNextNonSpaceOrTab();
-                break;
-            }
-
             if ($blockParser->getBlock()->getDepth() >= $this->maxNestingLevel) {
                 break;
             }
 
             $blockStart = $this->findBlockStart($blockParser);
-            if ($blockStart === null) {
+            if ($blockStart === null || $blockStart->isAborting()) {
                 $this->cursor->advanceToNextNonSpaceOrTab();
                 break;
             }

--- a/tests/unit/Environment/EnvironmentTest.php
+++ b/tests/unit/Environment/EnvironmentTest.php
@@ -28,6 +28,7 @@ use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Normalizer\TextNormalizerInterface;
 use League\CommonMark\Parser\Block\BlockStartParserInterface;
+use League\CommonMark\Parser\Block\SkipLinesStartingWithLettersParser;
 use League\CommonMark\Parser\Inline\InlineParserInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 use League\CommonMark\Tests\Unit\Event\FakeEvent;
@@ -330,6 +331,16 @@ final class EnvironmentTest extends TestCase
         $this->assertNotNull($listener2->getConfiguration());
     }
 
+    public function testSkipLinesParserIncludedByDefault(): void
+    {
+        $environment = new Environment();
+
+        $parsers = \iterator_to_array($environment->getBlockStartParsers());
+
+        $this->assertCount(1, $parsers);
+        $this->assertInstanceOf(SkipLinesStartingWithLettersParser::class, $parsers[0]);
+    }
+
     public function testBlockParserPrioritization(): void
     {
         $environment = new Environment();
@@ -339,14 +350,15 @@ final class EnvironmentTest extends TestCase
         $parser3 = $this->createMock(BlockStartParserInterface::class);
 
         $environment->addBlockStartParser($parser1);
-        $environment->addBlockStartParser($parser2, 50);
+        $environment->addBlockStartParser($parser2, 500);
         $environment->addBlockStartParser($parser3);
 
         $parsers = \iterator_to_array($environment->getBlockStartParsers());
 
         $this->assertSame($parser2, $parsers[0]);
-        $this->assertSame($parser1, $parsers[1]);
-        $this->assertSame($parser3, $parsers[2]);
+        $this->assertInstanceOf(SkipLinesStartingWithLettersParser::class, $parsers[1]);
+        $this->assertSame($parser1, $parsers[2]);
+        $this->assertSame($parser3, $parsers[3]);
     }
 
     public function testGetInlineParsersWithPrioritization(): void


### PR DESCRIPTION
Fixes #706 by moving the optimization into a "parser" so that users have the opportunity to register their parsers with a higher priority than the optimization where needed.