### PR TITLE
Fixed link to custom extensions overview

### DIFF
--- a/docs/2.0/xml.md
+++ b/docs/2.0/xml.md
@@ -7,7 +7,7 @@ redirect_from: /xml/
 
 # XML Rendering
 
-Version 2.0 introduced the ability to render Markdown `Document` objects in XML. This is particularly useful for debugging [custom extensions](/2.0/customization/).
+Version 2.0 introduced the ability to render Markdown `Document` objects in XML. This is particularly useful for debugging [custom extensions](/2.0/customization/overview/).
 
 To convert Markdown to XML, you would instantiate an [`Environment`](/2.0/customization/environment/), parse the Markdown into an [AST](/2.0/customization/abstract-syntax-tree/), and render it using the new `XmlRenderer`:
 


### PR DESCRIPTION
On the ["XML Rendering"](https://commonmark.thephpleague.com/2.0/xml/) page, the "custom extensions" link currently goes to `/customization/` which results in [a 404 on the live website](https://commonmark.thephpleague.com/2.0/customization/).

This commit changes it to `/customization/overview/` for the relevant version.