### PR TITLE
Use `github/super-linter/slim`

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: github/super-linter@v4.8.1
+      - uses: github/super-linter/slim@v4.8.1
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
While reading SuperLinter's latest README, they now have a [slim image available](https://github.com/github/super-linter#slim-image) that can reduce build times. The linters they drop have no impact on markdownlint.

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
