### PR TITLE
Permalinks aria hidden

### DIFF
--- a/docs/2.0/extensions/heading-permalinks.md
+++ b/docs/2.0/extensions/heading-permalinks.md
@@ -44,6 +44,7 @@ $config = [
         'max_heading_level' => 6,
         'title' => 'Permalink',
         'symbol' => HeadingPermalinkRenderer::DEFAULT_SYMBOL,
+        'aria_hidden' => true
     ],
 ];
 
@@ -110,6 +111,12 @@ If you want to use a custom icon, then set this to an empty string `''` and chec
 ### `title`
 
 This option sets the `title` attribute on the `<a>` tag.  This defaults to `'Permalink'`.
+
+### `aria_hidden`
+
+This option sets the `aria-hidden` attribute on the `<a>` tag. This defaults to `aria-hidden=true`.
+
+Setting this option to false would render the `<a>` tag excluding the `aria-hidden` entirely.
 
 ## Example
 

--- a/docs/2.0/extensions/heading-permalinks.md
+++ b/docs/2.0/extensions/heading-permalinks.md
@@ -114,7 +114,7 @@ This option sets the `title` attribute on the `<a>` tag.  This defaults to `'Per
 
 ### `aria_hidden`
 
-This option sets the `aria-hidden` attribute on the `<a>` tag. This defaults to `aria-hidden=true`.
+This option sets the `aria-hidden` attribute on the `<a>` tag. This defaults to `aria-hidden="true"`.
 
 Setting this option to false would render the `<a>` tag excluding the `aria-hidden` entirely.
 

--- a/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
@@ -36,7 +36,6 @@ final class HeadingPermalinkExtension implements ConfigurableExtensionInterface
             'title' => Expect::string()->default('Permalink'),
             'symbol' => Expect::string()->default(HeadingPermalinkRenderer::DEFAULT_SYMBOL),
             'aria_hidden' => Expect::bool()->default(true),
-
         ]));
     }
 

--- a/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
@@ -36,6 +36,7 @@ final class HeadingPermalinkExtension implements ConfigurableExtensionInterface
             'title' => Expect::string()->default('Permalink'),
             'symbol' => Expect::string()->default(HeadingPermalinkRenderer::DEFAULT_SYMBOL),
             'aria_hidden' => Expect::bool()->default(true),
+
         ]));
     }
 

--- a/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
@@ -35,6 +35,7 @@ final class HeadingPermalinkExtension implements ConfigurableExtensionInterface
             'html_class' => Expect::string()->default('heading-permalink'),
             'title' => Expect::string()->default('Permalink'),
             'symbol' => Expect::string()->default(HeadingPermalinkRenderer::DEFAULT_SYMBOL),
+            'aria_hidden' => Expect::bool()->default(true)
         ]));
     }
 

--- a/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkExtension.php
@@ -35,7 +35,7 @@ final class HeadingPermalinkExtension implements ConfigurableExtensionInterface
             'html_class' => Expect::string()->default('heading-permalink'),
             'title' => Expect::string()->default('Permalink'),
             'symbol' => Expect::string()->default(HeadingPermalinkRenderer::DEFAULT_SYMBOL),
-            'aria_hidden' => Expect::bool()->default(true)
+            'aria_hidden' => Expect::bool()->default(true),
         ]));
     }
 

--- a/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
@@ -71,7 +71,6 @@ final class HeadingPermalinkRenderer implements NodeRendererInterface, XmlNodeRe
 
         $attrs->set('title', $this->config->get('heading_permalink/title'));
 
-
         $symbol = $this->config->get('heading_permalink/symbol');
         \assert(\is_string($symbol));
 

--- a/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
@@ -63,8 +63,14 @@ final class HeadingPermalinkRenderer implements NodeRendererInterface, XmlNodeRe
         $attrs->set('id', $idPrefix . $slug);
         $attrs->set('href', '#' . $fragmentPrefix . $slug);
         $attrs->append('class', $this->config->get('heading_permalink/html_class'));
-        $attrs->set('aria-hidden', 'true');
+
+        $hidden = $this->config->get('heading_permalink/aria_hidden');
+        if ($hidden) {
+            $attrs->set('aria-hidden', 'true');
+        }
+
         $attrs->set('title', $this->config->get('heading_permalink/title'));
+
 
         $symbol = $this->config->get('heading_permalink/symbol');
         \assert(\is_string($symbol));

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -61,6 +61,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
                 'symbol'          => '¶ 🦄️ <3 You',
                 'insert'          => 'after',
                 'title'           => 'Link',
+                'aria_hidden'     => false
             ],
         ]);
         $environment->addExtension(new CommonMarkCoreExtension());
@@ -73,9 +74,9 @@ final class HeadingPermalinkExtensionTest extends TestCase
 
     public function dataProviderForTestHeadingPermalinksWithCustomOptions(): \Generator
     {
-        yield ['# Hello World!', '<h1>Hello World!<a id="custom-id-prefix-hello-world" href="#custom-fragment-prefix-hello-world" class="custom-class" aria-hidden="true" title="Link">¶ 🦄️ &lt;3 You</a></h1>'];
-        yield ['# Hello *World*', '<h1>Hello <em>World</em><a id="custom-id-prefix-hello-world" href="#custom-fragment-prefix-hello-world" class="custom-class" aria-hidden="true" title="Link">¶ 🦄️ &lt;3 You</a></h1>'];
-        yield ["Test\n----", '<h2>Test<a id="custom-id-prefix-test" href="#custom-fragment-prefix-test" class="custom-class" aria-hidden="true" title="Link">¶ 🦄️ &lt;3 You</a></h2>'];
+        yield ['# Hello World!', '<h1>Hello World!<a id="custom-id-prefix-hello-world" href="#custom-fragment-prefix-hello-world" class="custom-class" title="Link">¶ 🦄️ &lt;3 You</a></h1>'];
+        yield ['# Hello *World*', '<h1>Hello <em>World</em><a id="custom-id-prefix-hello-world" href="#custom-fragment-prefix-hello-world" class="custom-class" title="Link">¶ 🦄️ &lt;3 You</a></h1>'];
+        yield ["Test\n----", '<h2>Test<a id="custom-id-prefix-test" href="#custom-fragment-prefix-test" class="custom-class" title="Link">¶ 🦄️ &lt;3 You</a></h2>'];
     }
 
     public function testHeadingPermalinksWithEmptyPrefixes(): void

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -61,7 +61,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
                 'symbol'          => '¶ 🦄️ <3 You',
                 'insert'          => 'after',
                 'title'           => 'Link',
-                'aria_hidden'     => false
+                'aria_hidden'     => false,
             ],
         ]);
         $environment->addExtension(new CommonMarkCoreExtension());


### PR DESCRIPTION
First time contributor.

Was running performance tests through various providers. [web.dev](https://web.dev/measure/) flagged one of the pages for accessibility due to `aria-hidden` being placed on a focusable element (see [discussion](https://github.com/thephpleague/commonmark/discussions/738)).

Personal goal of creating a good, accessible experience - not to be "technically accessible" (used by visually impaired accessibility expert I worked with once describing a website).

This seemed the lowest impact (a minor or patch release eligible) change.

1. [x] Created config option `aria_hidden` with a default of `true` to maintain backward compatibility.
2. [x] Verified current test suite passes using default config.
3. [x] Updated `testHeadingPermalinksWithCustomOptions` to use optional attribute.
4. [x] Updated documentation site, presuming the PR is approved (working on it).
5. [x] Learn which local scripts need to pass.
    - fixed the PHPCS errors listed in the failing build; however, fixing all of the ones found in my local would probably warrant a separate scouting PR.
6. [x] Not sure what else would be helpful...