### PR TITLE
PHP 8.1 deprecated warning

### DIFF
--- a/src/Util/ArrayCollection.php
+++ b/src/Util/ArrayCollection.php
@@ -93,6 +93,7 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      *
      * @phpstan-param int $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return \array_key_exists($offset, $this->elements);
@@ -107,6 +108,7 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      *
      * @phpstan-return T|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->elements[$offset] ?? null;
@@ -120,6 +122,7 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      * @phpstan-param int|null $offset
      * @phpstan-param T        $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
@@ -136,6 +139,7 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      *
      * @phpstan-param int $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         if (! \array_key_exists($offset, $this->elements)) {

--- a/src/Util/ArrayCollection.php
+++ b/src/Util/ArrayCollection.php
@@ -93,7 +93,6 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      *
      * @phpstan-param int $offset
      */
-    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return \array_key_exists($offset, $this->elements);
@@ -122,7 +121,6 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      * @phpstan-param int|null $offset
      * @phpstan-param T        $value
      */
-    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
@@ -139,7 +137,6 @@ final class ArrayCollection implements \IteratorAggregate, \Countable, \ArrayAcc
      *
      * @phpstan-param int $offset
      */
-    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         if (! \array_key_exists($offset, $this->elements)) {


### PR DESCRIPTION
Prevent deprecated warning on ArrayAccess with PHP 8.1