### PR TITLE
Add object return type to Environment::dispatch()

### DIFF
--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -332,7 +332,7 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
     /**
      * {@inheritDoc}
      */
-    public function dispatch(object $event)
+    public function dispatch(object $event): object
     {
         if (! $this->extensionsInitialized) {
             $this->initializeExtensions();

--- a/tests/unit/Environment/EnvironmentTest.php
+++ b/tests/unit/Environment/EnvironmentTest.php
@@ -466,9 +466,11 @@ final class EnvironmentTest extends TestCase
                 $this->dispatchersCalled = $dispatchersCalled;
             }
 
-            public function dispatch(object $event): void
+            public function dispatch(object $event): object
             {
                 $this->dispatchersCalled[] = 'external';
+
+                return $event;
             }
         });
 


### PR DESCRIPTION
Minor thing to remove deprecation warnings when using Symfony 5.4/6.0.

Refs:
1. https://symfony.com/blog/preparing-your-apps-and-bundles-for-symfony-6
2. https://wouterj.nl/2021/09/symfony-6-native-typing
3. https://github.com/twigphp/Twig/runs/4684887490?check_suite_focus=true#step:12:17
