### PR TITLE
Image labels as attributes; avoid double-escaping

### DIFF
--- a/src/Extension/CommonMark/Node/Inline/Image.php
+++ b/src/Extension/CommonMark/Node/Inline/Image.php
@@ -20,17 +20,25 @@ use League\CommonMark\Node\Inline\Text;
 
 class Image extends AbstractWebResource
 {
+    protected string $label;
     protected ?string $title = null;
 
-    public function __construct(string $url, ?string $label = null, ?string $title = null)
+    public function __construct(string $url, ?string $label = '', ?string $title = null)
     {
         parent::__construct($url);
 
-        if ($label !== null && $label !== '') {
-            $this->appendChild(new Text($label));
-        }
-
+        $this->label = $label ?? '';
         $this->title = $title;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): void
+    {
+        $this->label = $label;
     }
 
     public function getTitle(): ?string

--- a/src/Extension/CommonMark/Node/Inline/Image.php
+++ b/src/Extension/CommonMark/Node/Inline/Image.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\CommonMark\Node\Inline;
 
-use League\CommonMark\Node\Inline\Text;
-
 class Image extends AbstractWebResource
 {
     protected string $label;

--- a/src/Extension/CommonMark/Parser/Inline/CloseBracketParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/CloseBracketParser.php
@@ -105,8 +105,7 @@ final class CloseBracketParser implements InlineParserInterface, EnvironmentAwar
                     $inline->setLabel($inline->getLabel() . $label->getTitle());
                 } elseif ($label instanceof Image) {
                     $inline->setLabel($inline->getLabel() . $label->getLabel());
-                }
-                else {
+                } else {
                     $literal = $label->getLiteral();
                     // Special handling for [ as "link syntax" is valid here.
                     // In particular see CommonMark example 519:
@@ -116,9 +115,9 @@ final class CloseBracketParser implements InlineParserInterface, EnvironmentAwar
                         $inline->setLabel($inline->getLabel() . $literal);
                     }
                 }
+
                 $label->detach();
-            }
-            else {
+            } else {
                 $inline->appendChild($label);
             }
         }

--- a/src/Extension/CommonMark/Renderer/Inline/ImageRenderer.php
+++ b/src/Extension/CommonMark/Renderer/Inline/ImageRenderer.php
@@ -51,9 +51,9 @@ final class ImageRenderer implements NodeRendererInterface, XmlNodeRendererInter
             $attrs['src'] = $node->getUrl();
         }
 
-        $alt          = $childRenderer->renderNodes($node->children());
-        $alt          = \preg_replace('/\<[^>]*alt="([^"]*)"[^>]*\>/', '$1', $alt);
-        $attrs['alt'] = \preg_replace('/\<[^>]*\>/', '', $alt ?? '');
+        if (($label = $node->getLabel()) !== null) {
+            $attrs['alt'] = $label;
+        }
 
         if (($title = $node->getTitle()) !== null) {
             $attrs['title'] = $title;
@@ -86,6 +86,7 @@ final class ImageRenderer implements NodeRendererInterface, XmlNodeRendererInter
         return [
             'destination' => $node->getUrl(),
             'title' => $node->getTitle() ?? '',
+            'label' => $node->getLabel() ?? '',
         ];
     }
 }

--- a/tests/functional/Extension/Attributes/data/image.html
+++ b/tests/functional/Extension/Attributes/data/image.html
@@ -1,1 +1,2 @@
 <p><img class="center" src="url-of-the-image.jpg" alt="some image title" /></p>
+<p><img src="url-of-the-image.jpg" alt="an &quot;image&quot; with &lt;escapable characters&gt; in the &amp; title" /></p>

--- a/tests/functional/Extension/Attributes/data/image.md
+++ b/tests/functional/Extension/Attributes/data/image.md
@@ -1,1 +1,3 @@
 ![some image title](url-of-the-image.jpg){.center}
+
+![an "image" with <escapable characters> in the & title](url-of-the-image.jpg)

--- a/tests/functional/Extension/CommonMark/xml/image-link.xml
+++ b/tests/functional/Extension/CommonMark/xml/image-link.xml
@@ -16,19 +16,15 @@
         </link>
     </paragraph>
     <paragraph>
-        <image destination="foo.jpg" title="" />
+        <image destination="foo.jpg" title="" label="" />
     </paragraph>
     <paragraph>
-        <image destination="foo.jpg" title="">
-            <text>alt text</text>
-        </image>
+        <image destination="foo.jpg" title="" label="alt text" />
     </paragraph>
     <paragraph>
-        <image destination="foo.jpg" title="title">
-            <text>alt text</text>
-        </image>
+        <image destination="foo.jpg" title="title" label="alt text" />
     </paragraph>
     <paragraph>
-        <image destination="foo.jpg" title="title" />
+        <image destination="foo.jpg" title="title" label="" />
     </paragraph>
 </document>

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/ImageRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/ImageRendererTest.php
@@ -48,7 +48,7 @@ final class ImageRendererTest extends TestCase
         $this->assertEquals('img', $result->getTagName());
         $this->assertStringContainsString('http://example.com/foo.jpg', $result->getAttribute('src'));
         $this->assertStringContainsString('foo.jpg', $result->getAttribute('src'));
-        $this->assertStringContainsString('::children::', $result->getAttribute('alt'));
+        $this->assertStringContainsString('::label::', $result->getAttribute('alt'));
         $this->assertStringContainsString('::title::', $result->getAttribute('title'));
         $this->assertStringContainsString('::id::', $result->getAttribute('id'));
     }
@@ -64,7 +64,7 @@ final class ImageRendererTest extends TestCase
         $this->assertEquals('img', $result->getTagName());
         $this->assertStringContainsString('http://example.com/foo.jpg', $result->getAttribute('src'));
         $this->assertStringContainsString('foo.jpg', $result->getAttribute('src'));
-        $this->assertStringContainsString('::children::', $result->getAttribute('alt'));
+        $this->assertStringContainsString('::label::', $result->getAttribute('alt'));
         $this->assertNull($result->getAttribute('title'));
     }
 


### PR DESCRIPTION
Fixes #806.

Image labels (alt text) were represented as child nodes on the Image node which are rendered, then the text stuffed into an attribute on an HtmlElement. This was resulting in special characters (particularly quotes, angle brackets, and ampersands) in the label to be double-escaped.

While it somewhat makes sense for labels to be children of Image since, according to spec, they are themselves inline elements, aside from the double-escaping issue, this is also a break from how other attributes are handled on nodes and had some hacky code to deal with it. This replacement code has its own weird quirks (see CloseBracketParser.php's diff) but achieves its goals.

A test case was altered to add code for an image with special characters in its labels and other cases were adjusted to deal with labels no longer being children of images.

Note that the message on commit eb69572 is incorrect; we're changing behavior of image labels, not image titles. (Hopefully I can be forgiven for mixing the two up frequently.)

If you like video games, it may be of interest that [Gamer Guides](https://gamerguides.com) sponsored my development of this fix.