### PR TITLE
DocumentRendererInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ### Added
 
- - Added new `EmbedExtension` (#805)
+- Added new `EmbedExtension` (#805)
+- Added `DocumentRendererInterface` as a replacement for the now-deprecated `MarkdownRendererInterface`
+
+### Deprecated
+
+- Deprecated `MarkdownRendererInterface`; use `DocumentRendererInterface` instead
 
 ## [2.2.3] - 2022-02-26
 

--- a/src/Renderer/DocumentRendererInterface.php
+++ b/src/Renderer/DocumentRendererInterface.php
@@ -18,10 +18,8 @@ use League\CommonMark\Output\RenderedContentInterface;
 
 /**
  * Renders a parsed Document AST
- *
- * @deprecated since 2.3; use {@link DocumentRendererInterface} instead
  */
-interface MarkdownRendererInterface
+interface DocumentRendererInterface extends MarkdownRendererInterface
 {
     /**
      * Render the given Document node (and all of its children)

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -25,7 +25,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Output\RenderedContent;
 use League\CommonMark\Output\RenderedContentInterface;
 
-final class HtmlRenderer implements MarkdownRendererInterface, ChildNodeRendererInterface
+final class HtmlRenderer implements DocumentRendererInterface, ChildNodeRendererInterface
 {
     /** @psalm-readonly */
     private EnvironmentInterface $environment;

--- a/src/Xml/MarkdownToXmlConverter.php
+++ b/src/Xml/MarkdownToXmlConverter.php
@@ -18,7 +18,7 @@ use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Parser\MarkdownParserInterface;
-use League\CommonMark\Renderer\MarkdownRendererInterface;
+use League\CommonMark\Renderer\DocumentRendererInterface;
 
 final class MarkdownToXmlConverter implements ConverterInterface
 {
@@ -26,7 +26,7 @@ final class MarkdownToXmlConverter implements ConverterInterface
     private MarkdownParserInterface $parser;
 
     /** @psalm-readonly */
-    private MarkdownRendererInterface $renderer;
+    private DocumentRendererInterface $renderer;
 
     public function __construct(EnvironmentInterface $environment)
     {

--- a/src/Xml/XmlRenderer.php
+++ b/src/Xml/XmlRenderer.php
@@ -11,10 +11,10 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Node\StringContainerInterface;
 use League\CommonMark\Output\RenderedContent;
 use League\CommonMark\Output\RenderedContentInterface;
-use League\CommonMark\Renderer\MarkdownRendererInterface;
+use League\CommonMark\Renderer\DocumentRendererInterface;
 use League\CommonMark\Util\Xml;
 
-final class XmlRenderer implements MarkdownRendererInterface
+final class XmlRenderer implements DocumentRendererInterface
 {
     private const INDENTATION = '    ';
 


### PR DESCRIPTION
`MarkdownRendererInterface` is poorly named, so deprecate it in favor of a new `DocumentRendererInterface`

This new interface will be needed for #419 and #719