### PR TITLE
Fix position of description of tryContinue

### DIFF
--- a/docs/2.0/customization/block-parsing.md
+++ b/docs/2.0/customization/block-parsing.md
@@ -97,9 +97,9 @@ If `canHaveLazyContinuationLines()` returned `true`, this method will be called 
 public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue;
 ```
 
-### `closeBlock()`
-
 This method allows you to try and parse an additional line of Markdown.
+
+### `closeBlock()`
 
 ```php
 public function closeBlock(): void;

--- a/docs/2.1/customization/block-parsing.md
+++ b/docs/2.1/customization/block-parsing.md
@@ -98,9 +98,9 @@ If `canHaveLazyContinuationLines()` returned `true`, this method will be called 
 public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue;
 ```
 
-### `closeBlock()`
-
 This method allows you to try and parse an additional line of Markdown.
+
+### `closeBlock()`
 
 ```php
 public function closeBlock(): void;

--- a/docs/2.2/customization/block-parsing.md
+++ b/docs/2.2/customization/block-parsing.md
@@ -97,9 +97,9 @@ If `canHaveLazyContinuationLines()` returned `true`, this method will be called 
 public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue;
 ```
 
-### `closeBlock()`
-
 This method allows you to try and parse an additional line of Markdown.
+
+### `closeBlock()`
 
 ```php
 public function closeBlock(): void;


### PR DESCRIPTION
Moved the description of `tryContinue()` from under the heading for `closeBlock()`.