### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -3,6 +3,9 @@ name: "Backwards compatibility"
 on:
     pull_request:
 
+permissions:
+  contents: read
+
 jobs:
     bc-check:
         name: "Backwards compatibility check"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
     push: ~
     pull_request: ~
 
+permissions:
+  contents: read
+
 jobs:
     phpcs:
         name: PHPCS
@@ -103,6 +106,9 @@ jobs:
             - run: vendor/bin/psalm --no-progress --stats --threads=$(nproc) --output-format=github --shepherd
 
     docs-lint:
+        permissions:
+          contents: read  # for actions/checkout to fetch code
+          statuses: write  # for github/super-linter/slim to mark status of each linter run
         name: Markdownlint
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
