### PR TITLE
Improve exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Added generic `CommonMarkExceptionInterface` marker interface.
+
 ## [2.3.4] - 2022-07-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 ### Added
 
 - Added generic `CommonMarkExceptionInterface` marker interface.
+- Added several new specific exception types:
+    - `AlreadyInitializedException`
+    - `InvalidArgumentException`
+    - `IOException`
+    - `LogicException`
+    - `MissingDependencyException`
+    - `NoMatchingRendererException`
+    - `ParserLogicException`
+
+### Changed
+
+- Change several thrown exceptions from `RuntimeException` to `LogicException` (or something extending it), including:
+    - `CallbackGenerator`s that fail to set a URL or return an expected value
+    - `MarkdownParser` when deactivating the last block parser or attempting to get an active block parser when they've all been closed
+    - Adding items to an already-initialized `Environment`
+    - Rendering a `Node` when no renderer has been registered for it
+- `HeadingPermalinkProcessor` now throws `InvalidConfigurationException` instead of `RuntimeException` when invalid config values are given.
+
+### Fixed
+
+- Fixed inaccurate `@throws` docblocks throughout the codebase, including `ConverterInterface`, `MarkdownConverter`, and `MarkdownConverterInterface`.
+    - These previously suggested that only `\RuntimeException`s were thrown, which was inaccurate as `\LogicException`s were also possible.
 
 ## [2.3.4] - 2022-07-17
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,20 @@ parameters:
      message: '#Parameter .+ of class .+Reference constructor expects string, string\|null given#'
    - path: src/Util/RegexHelper.php
      message: '#Method .+RegexHelper::unescape\(\) should return string but returns string\|null#'
+  exceptions:
+    uncheckedExceptionClasses:
+      # Exceptions caused by bad developer logic that should always bubble up:
+      - 'League\CommonMark\Exception\AlreadyInitializedException'
+      - 'League\CommonMark\Exception\InvalidArgumentException'
+      - 'League\CommonMark\Exception\MissingDependencyException'
+      - 'League\CommonMark\Exception\UnexpectedEncodingException'
+      - 'League\CommonMark\Parser\ParserLogicException'
+      - 'League\CommonMark\Renderer\NoMatchingRendererException'
+      - 'League\Config\Exception\InvalidConfigurationException'
+      - 'League\Config\Exception\UnknownOptionException'
+      - 'League\Config\Exception\ValidationException'
+      # Should never be thrown by our code:
+      - 'Dflydev\DotAccessData\Exception\DataException'
+      - 'Dflydev\DotAccessData\Exception\InvalidPathException'
+    check:
+      missingCheckedExceptionInThrows: true

--- a/src/ConverterInterface.php
+++ b/src/ConverterInterface.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace League\CommonMark;
 
+use League\CommonMark\Exception\CommonMarkExceptionInterface;
 use League\CommonMark\Output\RenderedContentInterface;
+use League\Config\Exception\ConfigurationExceptionInterface;
 
 /**
  * Interface for a service which converts content from one format (like Markdown) to another (like HTML).
@@ -21,7 +23,8 @@ use League\CommonMark\Output\RenderedContentInterface;
 interface ConverterInterface
 {
     /**
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
+     * @throws ConfigurationExceptionInterface
      */
     public function convert(string $input): RenderedContentInterface;
 }

--- a/src/Delimiter/DelimiterParser.php
+++ b/src/Delimiter/DelimiterParser.php
@@ -38,9 +38,7 @@ final class DelimiterParser implements InlineParserInterface
         $cursor    = $inlineContext->getCursor();
         $processor = $this->collection->getDelimiterProcessor($character);
 
-        if ($processor === null) {
-            throw new \LogicException('Delimiter processor should never be null here');
-        }
+        \assert($processor !== null); // Delimiter processor should never be null here
 
         $charBefore = $cursor->peek(-1);
         if ($charBefore === null) {

--- a/src/Delimiter/Processor/DelimiterProcessorCollection.php
+++ b/src/Delimiter/Processor/DelimiterProcessorCollection.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Delimiter\Processor;
 
+use League\CommonMark\Exception\InvalidArgumentException;
+
 final class DelimiterProcessorCollection implements DelimiterProcessorCollectionInterface
 {
     /**
@@ -62,7 +64,7 @@ final class DelimiterProcessorCollection implements DelimiterProcessorCollection
     private function addDelimiterProcessorForChar(string $delimiterChar, DelimiterProcessorInterface $processor): void
     {
         if (isset($this->processorsByChar[$delimiterChar])) {
-            throw new \InvalidArgumentException(\sprintf('Delim processor for character "%s" already exists', $processor->getOpeningCharacter()));
+            throw new InvalidArgumentException(\sprintf('Delim processor for character "%s" already exists', $processor->getOpeningCharacter()));
         }
 
         $this->processorsByChar[$delimiterChar] = $processor;

--- a/src/Delimiter/Processor/DelimiterProcessorCollectionInterface.php
+++ b/src/Delimiter/Processor/DelimiterProcessorCollectionInterface.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Delimiter\Processor;
 
+use League\CommonMark\Exception\InvalidArgumentException;
+
 interface DelimiterProcessorCollectionInterface extends \Countable
 {
     /**
@@ -26,7 +28,7 @@ interface DelimiterProcessorCollectionInterface extends \Countable
      *
      * @param DelimiterProcessorInterface $processor The delim processor to add
      *
-     * @throws \InvalidArgumentException Exception will be thrown if attempting to add multiple processors for the same character
+     * @throws InvalidArgumentException Exception will be thrown if attempting to add multiple processors for the same character
      */
     public function add(DelimiterProcessorInterface $processor): void;
 

--- a/src/Delimiter/Processor/StaggeredDelimiterProcessor.php
+++ b/src/Delimiter/Processor/StaggeredDelimiterProcessor.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Delimiter\Processor;
 
 use League\CommonMark\Delimiter\DelimiterInterface;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Inline\AbstractStringContainer;
 
 /**
@@ -71,7 +72,7 @@ final class StaggeredDelimiterProcessor implements DelimiterProcessorInterface
         $len = $processor->getMinLength();
 
         if (isset($this->processors[$len])) {
-            throw new \InvalidArgumentException(\sprintf('Cannot add two delimiter processors for char "%s" and minimum length %d', $this->delimiterChar, $len));
+            throw new InvalidArgumentException(\sprintf('Cannot add two delimiter processors for char "%s" and minimum length %d', $this->delimiterChar, $len));
         }
 
         $this->processors[$len] = $processor;

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -21,6 +21,7 @@ use League\CommonMark\Delimiter\Processor\DelimiterProcessorCollection;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Event\ListenerData;
+use League\CommonMark\Exception\AlreadyInitializedException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use League\CommonMark\Extension\ExtensionInterface;
@@ -416,12 +417,12 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
     }
 
     /**
-     * @throws \RuntimeException
+     * @throws AlreadyInitializedException
      */
     private function assertUninitialized(string $message): void
     {
         if ($this->extensionsInitialized) {
-            throw new \RuntimeException($message . ' Extensions have already been initialized.');
+            throw new AlreadyInitializedException($message . ' Extensions have already been initialized.');
         }
     }
 

--- a/src/Environment/EnvironmentBuilderInterface.php
+++ b/src/Environment/EnvironmentBuilderInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Environment;
 
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Exception\AlreadyInitializedException;
 use League\CommonMark\Extension\ExtensionInterface;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Parser\Block\BlockStartParserInterface;
@@ -28,6 +29,8 @@ interface EnvironmentBuilderInterface extends ConfigurationProviderInterface
 {
     /**
      * Registers the given extension with the Environment
+     *
+     * @throws AlreadyInitializedException if the Environment has already been initialized
      */
     public function addExtension(ExtensionInterface $extension): EnvironmentBuilderInterface;
 
@@ -38,6 +41,8 @@ interface EnvironmentBuilderInterface extends ConfigurationProviderInterface
      * @param int                       $priority Priority (a higher number will be executed earlier)
      *
      * @return $this
+     *
+     * @throws AlreadyInitializedException if the Environment has already been initialized
      */
     public function addBlockStartParser(BlockStartParserInterface $parser, int $priority = 0): EnvironmentBuilderInterface;
 
@@ -48,6 +53,8 @@ interface EnvironmentBuilderInterface extends ConfigurationProviderInterface
      * @param int                   $priority Priority (a higher number will be executed earlier)
      *
      * @return $this
+     *
+     * @throws AlreadyInitializedException if the Environment has already been initialized
      */
     public function addInlineParser(InlineParserInterface $parser, int $priority = 0): EnvironmentBuilderInterface;
 
@@ -55,6 +62,8 @@ interface EnvironmentBuilderInterface extends ConfigurationProviderInterface
      * Registers the given delimiter processor with the Environment
      *
      * @param DelimiterProcessorInterface $processor Delimiter processors instance
+     *
+     * @throws AlreadyInitializedException if the Environment has already been initialized
      */
     public function addDelimiterProcessor(DelimiterProcessorInterface $processor): EnvironmentBuilderInterface;
 
@@ -68,6 +77,8 @@ interface EnvironmentBuilderInterface extends ConfigurationProviderInterface
      * @psalm-param class-string<Node> $nodeClass
      *
      * @return $this
+     *
+     * @throws AlreadyInitializedException if the Environment has already been initialized
      */
     public function addRenderer(string $nodeClass, NodeRendererInterface $renderer, int $priority = 0): EnvironmentBuilderInterface;
 
@@ -79,6 +90,8 @@ interface EnvironmentBuilderInterface extends ConfigurationProviderInterface
      * @param int          $priority   Priority (a higher number will be executed earlier)
      *
      * @return $this
+     *
+     * @throws AlreadyInitializedException if the Environment has already been initialized
      */
     public function addEventListener(string $eventClass, callable $listener, int $priority = 0): EnvironmentBuilderInterface;
 }

--- a/src/Exception/AlreadyInitializedException.php
+++ b/src/Exception/AlreadyInitializedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Exception;
+
+class AlreadyInitializedException extends LogicException implements CommonMarkExceptionInterface
+{
+}

--- a/src/Exception/CommonMarkExceptionInterface.php
+++ b/src/Exception/CommonMarkExceptionInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Exception;
 
-final class UnexpectedEncodingException extends \RuntimeException implements CommonMarkExceptionInterface
+/**
+ * Marker interface for all exceptions thrown by this library.
+ */
+interface CommonMarkExceptionInterface extends \Throwable
 {
 }

--- a/src/Exception/IOException.php
+++ b/src/Exception/IOException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Exception;
+
+class IOException extends \RuntimeException implements CommonMarkExceptionInterface
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements CommonMarkExceptionInterface
+{
+}

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Exception;
+
+class LogicException extends \LogicException implements CommonMarkExceptionInterface
+{
+}

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Exception;
+
+class MissingDependencyException extends \RuntimeException implements CommonMarkExceptionInterface
+{
+}

--- a/src/Extension/Embed/Bridge/OscaroteroEmbedAdapter.php
+++ b/src/Extension/Embed/Bridge/OscaroteroEmbedAdapter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Embed\Bridge;
 
 use Embed\Embed as EmbedLib;
+use League\CommonMark\Exception\MissingDependencyException;
 use League\CommonMark\Extension\Embed\Embed;
 use League\CommonMark\Extension\Embed\EmbedAdapterInterface;
 
@@ -25,7 +26,7 @@ final class OscaroteroEmbedAdapter implements EmbedAdapterInterface
     {
         if ($embed === null) {
             if (! \class_exists(EmbedLib::class)) {
-                throw new \RuntimeException('The embed/embed package is not installed. Please install it with Composer to use this adapter.');
+                throw new MissingDependencyException('The embed/embed package is not installed. Please install it with Composer to use this adapter.');
             }
 
             $embed = new EmbedLib();

--- a/src/Extension/FrontMatter/Data/FrontMatterDataParserInterface.php
+++ b/src/Extension/FrontMatter/Data/FrontMatterDataParserInterface.php
@@ -21,7 +21,6 @@ interface FrontMatterDataParserInterface
      * @return mixed|null The parsed data (which may be null, if the input represents a null value)
      *
      * @throws InvalidFrontMatterException if parsing fails
-     * @throws \RuntimeException if other errors occur
      */
     public function parse(string $frontMatter);
 }

--- a/src/Extension/FrontMatter/Data/LibYamlFrontMatterParser.php
+++ b/src/Extension/FrontMatter/Data/LibYamlFrontMatterParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\FrontMatter\Data;
 
+use League\CommonMark\Exception\MissingDependencyException;
 use League\CommonMark\Extension\FrontMatter\Exception\InvalidFrontMatterException;
 
 final class LibYamlFrontMatterParser implements FrontMatterDataParserInterface
@@ -32,7 +33,7 @@ final class LibYamlFrontMatterParser implements FrontMatterDataParserInterface
     public function parse(string $frontMatter)
     {
         if (! \extension_loaded('yaml')) {
-            throw new \RuntimeException('Failed to parse yaml: "ext-yaml" extension is missing');
+            throw new MissingDependencyException('Failed to parse yaml: "ext-yaml" extension is missing');
         }
 
         $result = @\yaml_parse($frontMatter);

--- a/src/Extension/FrontMatter/Data/SymfonyYamlFrontMatterParser.php
+++ b/src/Extension/FrontMatter/Data/SymfonyYamlFrontMatterParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\FrontMatter\Data;
 
+use League\CommonMark\Exception\MissingDependencyException;
 use League\CommonMark\Extension\FrontMatter\Exception\InvalidFrontMatterException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -25,7 +26,7 @@ final class SymfonyYamlFrontMatterParser implements FrontMatterDataParserInterfa
     public function parse(string $frontMatter)
     {
         if (! \class_exists(Yaml::class)) {
-            throw new \RuntimeException('Failed to parse yaml: "symfony/yaml" library is missing');
+            throw new MissingDependencyException('Failed to parse yaml: "symfony/yaml" library is missing');
         }
 
         try {

--- a/src/Extension/FrontMatter/Exception/InvalidFrontMatterException.php
+++ b/src/Extension/FrontMatter/Exception/InvalidFrontMatterException.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\FrontMatter\Exception;
 
-class InvalidFrontMatterException extends \RuntimeException
+use League\CommonMark\Exception\CommonMarkExceptionInterface;
+
+class InvalidFrontMatterException extends \RuntimeException implements CommonMarkExceptionInterface
 {
     public static function wrap(\Throwable $t): self
     {

--- a/src/Extension/FrontMatter/FrontMatterParser.php
+++ b/src/Extension/FrontMatter/FrontMatterParser.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\FrontMatter;
 
 use League\CommonMark\Extension\FrontMatter\Data\FrontMatterDataParserInterface;
+use League\CommonMark\Extension\FrontMatter\Exception\InvalidFrontMatterException;
 use League\CommonMark\Extension\FrontMatter\Input\MarkdownInputWithFrontMatter;
 use League\CommonMark\Parser\Cursor;
 
@@ -29,6 +30,9 @@ final class FrontMatterParser implements FrontMatterParserInterface
         $this->frontMatterParser = $frontMatterParser;
     }
 
+    /**
+     * @throws InvalidFrontMatterException if the front matter cannot be parsed
+     */
     public function parse(string $markdownContent): MarkdownInputWithFrontMatter
     {
         $cursor = new Cursor($markdownContent);

--- a/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
@@ -22,6 +22,7 @@ use League\CommonMark\Node\RawMarkupContainerInterface;
 use League\CommonMark\Node\StringContainerHelper;
 use League\CommonMark\Normalizer\TextNormalizerInterface;
 use League\Config\ConfigurationInterface;
+use League\Config\Exception\InvalidConfigurationException;
 
 /**
  * Searches the Document for Heading elements and adds HeadingPermalinks to each one
@@ -77,7 +78,7 @@ final class HeadingPermalinkProcessor implements EnvironmentAwareInterface
 
                 return;
             default:
-                throw new \RuntimeException("Invalid configuration value for heading_permalink/insert; expected 'before' or 'after'");
+                throw new InvalidConfigurationException("Invalid configuration value for heading_permalink/insert; expected 'before' or 'after'");
         }
     }
 }

--- a/src/Extension/Mention/Generator/CallbackGenerator.php
+++ b/src/Extension/Mention/Generator/CallbackGenerator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Extension\Mention\Generator;
 
+use League\CommonMark\Exception\LogicException;
 use League\CommonMark\Extension\Mention\Mention;
 use League\CommonMark\Node\Inline\AbstractInline;
 
@@ -30,6 +31,9 @@ final class CallbackGenerator implements MentionGeneratorInterface
         $this->callback = $callback;
     }
 
+    /**
+     * @throws LogicException
+     */
     public function generateMention(Mention $mention): ?AbstractInline
     {
         $result = \call_user_func($this->callback, $mention);
@@ -45,6 +49,6 @@ final class CallbackGenerator implements MentionGeneratorInterface
             return $mention;
         }
 
-        throw new \RuntimeException('CallbackGenerator callable must set the URL on the passed mention and return the mention, return a new AbstractInline based object or null if the mention is not a match');
+        throw new LogicException('CallbackGenerator callable must set the URL on the passed mention and return the mention, return a new AbstractInline based object or null if the mention is not a match');
     }
 }

--- a/src/MarkdownConverter.php
+++ b/src/MarkdownConverter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark;
 
 use League\CommonMark\Environment\EnvironmentInterface;
+use League\CommonMark\Exception\CommonMarkExceptionInterface;
 use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Parser\MarkdownParserInterface;
@@ -51,7 +52,7 @@ class MarkdownConverter implements ConverterInterface, MarkdownConverterInterfac
      *
      * @return RenderedContentInterface Rendered HTML
      *
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function convert(string $input): RenderedContentInterface
     {
@@ -69,7 +70,7 @@ class MarkdownConverter implements ConverterInterface, MarkdownConverterInterfac
      *
      * @return RenderedContentInterface Rendered HTML
      *
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function convertToHtml(string $markdown): RenderedContentInterface
     {
@@ -83,7 +84,7 @@ class MarkdownConverter implements ConverterInterface, MarkdownConverterInterfac
      *
      * @see MarkdownConverter::convert()
      *
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function __invoke(string $markdown): RenderedContentInterface
     {

--- a/src/MarkdownConverterInterface.php
+++ b/src/MarkdownConverterInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark;
 
+use League\CommonMark\Exception\CommonMarkExceptionInterface;
 use League\CommonMark\Output\RenderedContentInterface;
 
 /**
@@ -27,7 +28,7 @@ interface MarkdownConverterInterface
      *
      * @deprecated since 2.2; use {@link ConverterInterface::convert()} instead
      *
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function convertToHtml(string $markdown): RenderedContentInterface;
 }

--- a/src/Node/Block/AbstractBlock.php
+++ b/src/Node/Block/AbstractBlock.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Node\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Node;
 
 /**
@@ -32,7 +33,7 @@ abstract class AbstractBlock extends Node
     protected function setParent(?Node $node = null): void
     {
         if ($node && ! $node instanceof self) {
-            throw new \InvalidArgumentException('Parent of block must also be block (cannot be inline)');
+            throw new InvalidArgumentException('Parent of block must also be block (cannot be inline)');
         }
 
         parent::setParent($node);

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Node;
 
 use Dflydev\DotAccessData\Data;
+use League\CommonMark\Exception\InvalidArgumentException;
 
 abstract class Node
 {
@@ -255,7 +256,7 @@ abstract class Node
     public static function assertInstanceOf(Node $node): void
     {
         if (! $node instanceof static) {
-            throw new \InvalidArgumentException(\sprintf('Incompatible node type: expected %s, got %s', static::class, \get_class($node)));
+            throw new InvalidArgumentException(\sprintf('Incompatible node type: expected %s, got %s', static::class, \get_class($node)));
         }
     }
 }

--- a/src/Parser/Inline/InlineParserMatch.php
+++ b/src/Parser/Inline/InlineParserMatch.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Parser\Inline;
 
+use League\CommonMark\Exception\InvalidArgumentException;
+
 final class InlineParserMatch
 {
     private string $regex;
@@ -74,7 +76,7 @@ final class InlineParserMatch
             if ($caseSensitive === null) {
                 $caseSensitive = $definition->caseSensitive;
             } elseif ($caseSensitive !== $definition->caseSensitive) {
-                throw new \LogicException('Case-sensitive and case-insensitive defintions cannot be comined');
+                throw new InvalidArgumentException('Case-sensitive and case-insensitive definitions cannot be combined');
             }
         }
 

--- a/src/Parser/MarkdownParser.php
+++ b/src/Parser/MarkdownParser.php
@@ -22,6 +22,7 @@ namespace League\CommonMark\Parser;
 use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Event\DocumentPreParsedEvent;
+use League\CommonMark\Exception\CommonMarkExceptionInterface;
 use League\CommonMark\Input\MarkdownInput;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Block\Paragraph;
@@ -81,7 +82,7 @@ final class MarkdownParser implements MarkdownParserInterface
     }
 
     /**
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function parse(string $input): Document
     {
@@ -293,11 +294,14 @@ final class MarkdownParser implements MarkdownParserInterface
         $this->activeBlockParsers[] = $blockParser;
     }
 
+    /**
+     * @throws ParserLogicException
+     */
     private function deactivateBlockParser(): BlockContinueParserInterface
     {
         $popped = \array_pop($this->activeBlockParsers);
         if ($popped === null) {
-            throw new \RuntimeException('The last block parser should not be deactivated');
+            throw new ParserLogicException('The last block parser should not be deactivated');
         }
 
         return $popped;
@@ -327,11 +331,14 @@ final class MarkdownParser implements MarkdownParserInterface
         }
     }
 
+    /**
+     * @throws ParserLogicException
+     */
     public function getActiveBlockParser(): BlockContinueParserInterface
     {
         $active = \end($this->activeBlockParsers);
         if ($active === false) {
-            throw new \RuntimeException('No active block parsers are available');
+            throw new ParserLogicException('No active block parsers are available');
         }
 
         return $active;

--- a/src/Parser/ParserLogicException.php
+++ b/src/Parser/ParserLogicException.php
@@ -14,12 +14,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Parser;
 
 use League\CommonMark\Exception\CommonMarkExceptionInterface;
-use League\CommonMark\Node\Block\Document;
 
-interface MarkdownParserInterface
+class ParserLogicException extends \LogicException implements CommonMarkExceptionInterface
 {
-    /**
-     * @throws CommonMarkExceptionInterface
-     */
-    public function parse(string $input): Document;
 }

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -72,7 +72,7 @@ final class HtmlRenderer implements DocumentRendererInterface, ChildNodeRenderer
     /**
      * @return \Stringable|string
      *
-     * @throws \RuntimeException
+     * @throws NoMatchingRendererException
      */
     private function renderNode(Node $node)
     {
@@ -85,7 +85,7 @@ final class HtmlRenderer implements DocumentRendererInterface, ChildNodeRenderer
             }
         }
 
-        throw new \RuntimeException('Unable to find corresponding renderer for node type ' . \get_class($node));
+        throw new NoMatchingRendererException('Unable to find corresponding renderer for node type ' . \get_class($node));
     }
 
     public function getBlockSeparator(): string

--- a/src/Renderer/NoMatchingRendererException.php
+++ b/src/Renderer/NoMatchingRendererException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Renderer;
+
+use League\CommonMark\Exception\LogicException;
+
+class NoMatchingRendererException extends LogicException
+{
+}

--- a/src/Renderer/NodeRendererInterface.php
+++ b/src/Renderer/NodeRendererInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Renderer;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Node;
 
 interface NodeRendererInterface
@@ -20,7 +21,7 @@ interface NodeRendererInterface
     /**
      * @return \Stringable|string|null
      *
-     * @throws \InvalidArgumentException if the wrong type of Node is provided
+     * @throws InvalidArgumentException if the wrong type of Node is provided
      */
     public function render(Node $node, ChildNodeRendererInterface $childRenderer);
 }

--- a/src/Util/HtmlFilter.php
+++ b/src/Util/HtmlFilter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Util;
 
+use League\CommonMark\Exception\InvalidArgumentException;
+
 /**
  * @psalm-immutable
  */
@@ -33,7 +35,7 @@ final class HtmlFilter
      *
      * @return string Filtered HTML
      *
-     * @throws \InvalidArgumentException when an invalid $filter is given
+     * @throws InvalidArgumentException when an invalid $filter is given
      *
      * @psalm-pure
      */
@@ -47,7 +49,7 @@ final class HtmlFilter
             case self::ALLOW:
                 return $html;
             default:
-                throw new \InvalidArgumentException(\sprintf('Invalid filter provided: "%s"', $filter));
+                throw new InvalidArgumentException(\sprintf('Invalid filter provided: "%s"', $filter));
         }
     }
 }

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Util;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\HtmlBlock;
 
 /**
@@ -161,7 +162,7 @@ final class RegexHelper
      *
      * @phpstan-param HtmlBlock::TYPE_* $type
      *
-     * @throws \InvalidArgumentException if an invalid type is given
+     * @throws InvalidArgumentException if an invalid type is given
      *
      * @psalm-pure
      */
@@ -183,7 +184,7 @@ final class RegexHelper
             case HtmlBlock::TYPE_7_MISC_ELEMENT:
                 return '/^(?:' . self::PARTIAL_OPENTAG . '|' . self::PARTIAL_CLOSETAG . ')\\s*$/i';
             default:
-                throw new \InvalidArgumentException('Invalid HTML block type');
+                throw new InvalidArgumentException('Invalid HTML block type');
         }
     }
 
@@ -196,7 +197,7 @@ final class RegexHelper
      *
      * @phpstan-param HtmlBlock::TYPE_* $type
      *
-     * @throws \InvalidArgumentException if an invalid type is given
+     * @throws InvalidArgumentException if an invalid type is given
      *
      * @psalm-pure
      */
@@ -214,7 +215,7 @@ final class RegexHelper
             case HtmlBlock::TYPE_5_CDATA:
                 return '/\]\]>/';
             default:
-                throw new \InvalidArgumentException('Invalid HTML block type');
+                throw new InvalidArgumentException('Invalid HTML block type');
         }
     }
 

--- a/src/Util/SpecReader.php
+++ b/src/Util/SpecReader.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Util;
 
+use League\CommonMark\Exception\IOException;
+
 /**
  * Reads in a CommonMark spec document and extracts the input/output examples for testing against them
  */
@@ -56,12 +58,12 @@ final class SpecReader
     /**
      * @return iterable<string, array{input: string, output: string, type: string, section: string, number: int}>
      *
-     * @throws \RuntimeException if the file cannot be loaded
+     * @throws IOException if the file cannot be loaded
      */
     public static function readFile(string $filename): iterable
     {
         if (($data = \file_get_contents($filename)) === false) {
-            throw new \RuntimeException(\sprintf('Failed to load spec from %s', $filename));
+            throw new IOException(\sprintf('Failed to load spec from %s', $filename));
         }
 
         return self::read($data);

--- a/src/Xml/MarkdownToXmlConverter.php
+++ b/src/Xml/MarkdownToXmlConverter.php
@@ -15,6 +15,7 @@ namespace League\CommonMark\Xml;
 
 use League\CommonMark\ConverterInterface;
 use League\CommonMark\Environment\EnvironmentInterface;
+use League\CommonMark\Exception\CommonMarkExceptionInterface;
 use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Parser\MarkdownParserInterface;
@@ -37,7 +38,7 @@ final class MarkdownToXmlConverter implements ConverterInterface
     /**
      * Converts Markdown to XML
      *
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function convert(string $input): RenderedContentInterface
     {
@@ -49,7 +50,7 @@ final class MarkdownToXmlConverter implements ConverterInterface
      *
      * @see MarkdownToXmlConverter::convert()
      *
-     * @throws \RuntimeException
+     * @throws CommonMarkExceptionInterface
      */
     public function __invoke(string $input): RenderedContentInterface
     {

--- a/src/Xml/XmlRenderer.php
+++ b/src/Xml/XmlRenderer.php
@@ -6,6 +6,7 @@ namespace League\CommonMark\Xml;
 
 use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Event\DocumentPreRenderEvent;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Node\StringContainerInterface;
@@ -112,7 +113,7 @@ final class XmlRenderer implements DocumentRendererInterface
         }
 
         // @phpstan-ignore-next-line
-        throw new \InvalidArgumentException('$value must be a string, int, float, or bool');
+        throw new InvalidArgumentException('$value must be a string, int, float, or bool');
     }
 
     private function findXmlRenderer(Node $node): XmlNodeRendererInterface

--- a/tests/functional/Delimiter/DelimiterProcessingTest.php
+++ b/tests/functional/Delimiter/DelimiterProcessingTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Functional\Delimiter;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
 use PHPUnit\Framework\TestCase;
@@ -84,7 +85,7 @@ final class DelimiterProcessingTest extends TestCase
 
     public function testMultipleDelimitersWithSameLength(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $e = new Environment();
         $e->addExtension(new CommonMarkCoreExtension());

--- a/tests/functional/Delimiter/UppercaseTextRenderer.php
+++ b/tests/functional/Delimiter/UppercaseTextRenderer.php
@@ -28,9 +28,7 @@ final class UppercaseTextRenderer implements NodeRendererInterface
      */
     public function render(Node $node, ChildNodeRendererInterface $childRenderer)
     {
-        if (! ($node instanceof UppercaseText)) {
-            throw new \InvalidArgumentException('Incompatible node type: ' . \get_class($node));
-        }
+        UppercaseText::assertInstanceOf($node);
 
         foreach ($node->children() as $child) {
             if ($child instanceof Text) {

--- a/tests/functional/Extension/Embed/Bridge/LocalFileClient.php
+++ b/tests/functional/Extension/Embed/Bridge/LocalFileClient.php
@@ -18,6 +18,7 @@ namespace League\CommonMark\Tests\Functional\Extension\Embed\Bridge;
 
 use Embed\Http\CurlClient;
 use Embed\Http\FactoryDiscovery;
+use League\CommonMark\Exception\IOException;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -71,7 +72,7 @@ final class LocalFileClient implements ClientInterface
     {
         $file = \file_get_contents($filename);
         if ($file === false) {
-            throw new \InvalidArgumentException(\sprintf('Unable to read file "%s"', $filename));
+            throw new IOException(\sprintf('Unable to read file "%s"', $filename));
         }
 
         $message  = \json_decode($file, true, JSON_THROW_ON_ERROR);

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -20,6 +20,7 @@ use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
 use League\CommonMark\MarkdownConverter;
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Xml\XmlRenderer;
+use League\Config\Exception\InvalidConfigurationException;
 use PHPUnit\Framework\TestCase;
 
 final class HeadingPermalinkExtensionTest extends TestCase
@@ -120,7 +121,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
 
     public function testHeadingPermalinksWithInvalidInsertConfigurationValue(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $environment = new Environment([
             'heading_permalink' => [

--- a/tests/unit/Delimiter/DelimiterProcessorCollectionTest.php
+++ b/tests/unit/Delimiter/DelimiterProcessorCollectionTest.php
@@ -15,6 +15,7 @@ namespace League\CommonMark\Tests\Unit\Delimiter;
 
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorCollection;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 final class DelimiterProcessorCollectionTest extends TestCase
@@ -39,7 +40,7 @@ final class DelimiterProcessorCollectionTest extends TestCase
 
     public function testAddProcessorForCharacterAlreadyRegistered(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('Delim processor for character "*" already exists');
 
         $collection = new DelimiterProcessorCollection();

--- a/tests/unit/Environment/EnvironmentTest.php
+++ b/tests/unit/Environment/EnvironmentTest.php
@@ -21,6 +21,7 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Event\AbstractEvent;
 use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Exception\AlreadyInitializedException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use League\CommonMark\Extension\ExtensionInterface;
@@ -122,7 +123,7 @@ final class EnvironmentTest extends TestCase
 
     public function testMergeConfigAfterInit(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
         // This triggers the initialization
@@ -142,7 +143,7 @@ final class EnvironmentTest extends TestCase
 
     public function testAddBlockStartParserFailsAfterInitialization(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
 
@@ -165,7 +166,7 @@ final class EnvironmentTest extends TestCase
 
     public function testAddRendererFailsAfterInitialization(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
 
@@ -178,7 +179,7 @@ final class EnvironmentTest extends TestCase
 
     public function testAddInlineParserFailsAfterInitialization(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
 
@@ -202,7 +203,7 @@ final class EnvironmentTest extends TestCase
 
     public function testAddDelimiterProcessorFailsAfterInitialization(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
 
@@ -246,7 +247,7 @@ final class EnvironmentTest extends TestCase
 
     public function testAddExtensionFailsAfterInitialization(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
 
@@ -437,7 +438,7 @@ final class EnvironmentTest extends TestCase
 
     public function testAddEventListenerFailsAfterInitialization(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(AlreadyInitializedException::class);
 
         $environment = new Environment();
 

--- a/tests/unit/Extension/CommonMark/Renderer/Block/BlockQuoteRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/BlockQuoteRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\BlockQuoteRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -63,7 +64,7 @@ final class BlockQuoteRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/FencedCodeRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/FencedCodeRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\FencedCodeRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -84,7 +85,7 @@ final class FencedCodeRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/HeadingRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/HeadingRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\HeadingRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -67,7 +68,7 @@ final class HeadingRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/HtmlBlockRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/HtmlBlockRendererTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\HtmlBlock;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\HtmlBlockRenderer;
@@ -102,7 +103,7 @@ final class HtmlBlockRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/IndentedCodeRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/IndentedCodeRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\IndentedCodeRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -60,7 +61,7 @@ final class IndentedCodeRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/ListBlockRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/ListBlockRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListData;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\ListBlockRenderer;
@@ -83,7 +84,7 @@ final class ListBlockRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/ListItemRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/ListItemRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListData;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\ListItemRenderer;
@@ -49,7 +50,7 @@ final class ListItemRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Block/ThematicBreakRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Block/ThematicBreakRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\ThematicBreakRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -45,7 +46,7 @@ final class ThematicBreakRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/CodeRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/CodeRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Inline;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Code;
 use League\CommonMark\Extension\CommonMark\Renderer\Inline\CodeRenderer;
 use League\CommonMark\Node\Inline\AbstractInline;
@@ -48,7 +49,7 @@ final class CodeRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/EmphasisRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/EmphasisRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Inline;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
 use League\CommonMark\Extension\CommonMark\Renderer\Inline\EmphasisRenderer;
 use League\CommonMark\Node\Inline\AbstractInline;
@@ -49,7 +50,7 @@ final class EmphasisRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/HtmlInlineRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/HtmlInlineRendererTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Inline;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Inline\HtmlInline;
 use League\CommonMark\Extension\CommonMark\Renderer\Inline\HtmlInlineRenderer;
@@ -94,7 +95,7 @@ final class HtmlInlineRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/ImageRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/ImageRendererTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Inline;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Inline\HtmlInline;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
@@ -121,7 +122,7 @@ final class ImageRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/LinkRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/LinkRendererTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Inline;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Extension\CommonMark\Renderer\Inline\LinkRenderer;
@@ -98,7 +99,7 @@ final class LinkRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/StrongRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/StrongRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\CommonMark\Renderer\Inline;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\CommonMark\Extension\CommonMark\Renderer\Inline\StrongRenderer;
 use League\CommonMark\Node\Inline\AbstractInline;
@@ -49,7 +50,7 @@ final class StrongRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/DescriptionList/Renderer/DescriptionListRendererTest.php
+++ b/tests/unit/Extension/DescriptionList/Renderer/DescriptionListRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\DescriptionList\Renderer;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\DescriptionList\Node\Description;
 use League\CommonMark\Extension\DescriptionList\Node\DescriptionList;
 use League\CommonMark\Extension\DescriptionList\Node\DescriptionTerm;
@@ -46,7 +47,7 @@ final class DescriptionListRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $block = $this->getMockForAbstractClass(AbstractBlock::class);
 

--- a/tests/unit/Extension/DescriptionList/Renderer/DescriptionRendererTest.php
+++ b/tests/unit/Extension/DescriptionList/Renderer/DescriptionRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\DescriptionList\Renderer;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\DescriptionList\Node\Description;
 use League\CommonMark\Extension\DescriptionList\Renderer\DescriptionRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -44,7 +45,7 @@ final class DescriptionRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $block = $this->getMockForAbstractClass(AbstractBlock::class);
 

--- a/tests/unit/Extension/DescriptionList/Renderer/DescriptionTermRendererTest.php
+++ b/tests/unit/Extension/DescriptionList/Renderer/DescriptionTermRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\DescriptionList\Renderer;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\DescriptionList\Node\DescriptionTerm;
 use League\CommonMark\Extension\DescriptionList\Renderer\DescriptionTermRenderer;
 use League\CommonMark\Node\Block\AbstractBlock;
@@ -44,7 +45,7 @@ final class DescriptionTermRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $block = $this->getMockForAbstractClass(AbstractBlock::class);
 

--- a/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
+++ b/tests/unit/Extension/Mention/Generator/CallbackGeneratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\Mention\Generator;
 
+use League\CommonMark\Exception\LogicException;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
 use League\CommonMark\Extension\Mention\Generator\CallbackGenerator;
 use League\CommonMark\Extension\Mention\Mention;
@@ -73,7 +74,7 @@ final class CallbackGeneratorTest extends TestCase
 
     public function testWithNoUrlMentionReturn(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LogicException::class);
 
         $generator = new CallbackGenerator(static function (Mention $mention) {
             // This ensures that if the URL is not set, but the mention is
@@ -87,7 +88,7 @@ final class CallbackGeneratorTest extends TestCase
 
     public function testWithNewMentionButNoUrlReturn(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LogicException::class);
 
         $generator = new CallbackGenerator(static function (Mention $mention) {
             // Test what happens when returning a new mention without a URL
@@ -99,7 +100,7 @@ final class CallbackGeneratorTest extends TestCase
 
     public function testWithInvalidReturn(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LogicException::class);
 
         $generator = new CallbackGenerator(static function () {
             return new \stdClass(); // something that is not a string or null

--- a/tests/unit/Extension/Strikethrough/StrikethroughRendererTest.php
+++ b/tests/unit/Extension/Strikethrough/StrikethroughRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\Strikethrough;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\Strikethrough\Strikethrough;
 use League\CommonMark\Extension\Strikethrough\StrikethroughRenderer;
 use League\CommonMark\Node\Inline\Text;
@@ -46,7 +47,7 @@ final class StrikethroughRendererTest extends TestCase
 
     public function testRenderWithInvalidNodeType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = new Text('ruh roh');
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Extension/Table/TableCellRendererTest.php
+++ b/tests/unit/Extension/Table/TableCellRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\Table;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\Table\TableCell;
 use League\CommonMark\Extension\Table\TableCellRenderer;
 use League\CommonMark\Extension\Table\TableSection;
@@ -62,7 +63,7 @@ final class TableCellRendererTest extends TestCase
 
     public function testRenderWithWrongType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new TableCellRenderer())->render(new TableSection(), new FakeChildNodeRenderer());
     }

--- a/tests/unit/Extension/Table/TableRendererTest.php
+++ b/tests/unit/Extension/Table/TableRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\Table;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableRenderer;
 use League\CommonMark\Extension\Table\TableSection;
@@ -36,7 +37,7 @@ final class TableRendererTest extends TestCase
 
     public function testRenderWithWrongType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new TableRenderer())->render(new TableSection(), new FakeChildNodeRenderer());
     }

--- a/tests/unit/Extension/Table/TableRowRendererTest.php
+++ b/tests/unit/Extension/Table/TableRowRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\Table;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\Table\TableRow;
 use League\CommonMark\Extension\Table\TableRowRenderer;
 use League\CommonMark\Extension\Table\TableSection;
@@ -36,7 +37,7 @@ final class TableRowRendererTest extends TestCase
 
     public function testRenderWithWrongType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new TableRowRenderer())->render(new TableSection(), new FakeChildNodeRenderer());
     }

--- a/tests/unit/Extension/Table/TableSectionRendererTest.php
+++ b/tests/unit/Extension/Table/TableSectionRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\Table;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\Table\TableCell;
 use League\CommonMark\Extension\Table\TableRow;
 use League\CommonMark\Extension\Table\TableSection;
@@ -48,7 +49,7 @@ final class TableSectionRendererTest extends TestCase
 
     public function testRenderWithWrongType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         (new TableSectionRenderer())->render(new TableCell(), new FakeChildNodeRenderer());
     }

--- a/tests/unit/Extension/TaskList/TaskListItemMarkerRendererTest.php
+++ b/tests/unit/Extension/TaskList/TaskListItemMarkerRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Extension\TaskList;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\TaskList\TaskListItemMarker;
 use League\CommonMark\Extension\TaskList\TaskListItemMarkerRenderer;
 use League\CommonMark\Node\Inline\AbstractInline;
@@ -54,7 +55,7 @@ final class TaskListItemMarkerRendererTest extends TestCase
 
     public function testWithInvalidInlineElement(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $renderer     = new TaskListItemMarkerRenderer();
         $htmlRenderer = $this->getMockForAbstractClass(ChildNodeRendererInterface::class);

--- a/tests/unit/Node/Block/AbstractBlockTest.php
+++ b/tests/unit/Node/Block/AbstractBlockTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Node\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Node\Inline\AbstractInline;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +37,7 @@ final class AbstractBlockTest extends TestCase
 
     public function testSetParentWithInvalidNode(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $block = $this->getMockForAbstractClass(AbstractBlock::class);
 

--- a/tests/unit/Parser/Inline/InlineParserMatchTest.php
+++ b/tests/unit/Parser/Inline/InlineParserMatchTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Parser\Inline;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Parser\Inline\InlineParserMatch;
 use PHPUnit\Framework\TestCase;
 
@@ -70,7 +71,7 @@ final class InlineParserMatchTest extends TestCase
 
     public function testCannotMixCaseSensitivity(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         InlineParserMatch::join(
             InlineParserMatch::string('foo')->caseSensitive(),

--- a/tests/unit/Renderer/Block/DocumentRendererTest.php
+++ b/tests/unit/Renderer/Block/DocumentRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Node\Block\Document;
@@ -57,7 +58,7 @@ final class DocumentRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Renderer/Block/ParagraphRendererTest.php
+++ b/tests/unit/Renderer/Block/ParagraphRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Renderer\Block;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Block\AbstractBlock;
 use League\CommonMark\Node\Block\Paragraph;
 use League\CommonMark\Renderer\Block\ParagraphRenderer;
@@ -49,7 +50,7 @@ final class ParagraphRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractBlock::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Renderer/HtmlRendererTest.php
+++ b/tests/unit/Renderer/HtmlRendererTest.php
@@ -10,6 +10,7 @@ use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Block\Paragraph;
 use League\CommonMark\Node\Inline\Text;
 use League\CommonMark\Renderer\HtmlRenderer;
+use League\CommonMark\Renderer\NoMatchingRendererException;
 use League\CommonMark\Renderer\NodeRendererInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -85,7 +86,7 @@ final class HtmlRendererTest extends TestCase
 
     public function testRenderNodesWithMissingRenderer(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(NoMatchingRendererException::class);
 
         $environment = $this->createMock(EnvironmentInterface::class);
         $environment->method('getRenderersForClass')->willReturn([]);

--- a/tests/unit/Renderer/Inline/NewlineRendererTest.php
+++ b/tests/unit/Renderer/Inline/NewlineRendererTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace League\CommonMark\Tests\Unit\Renderer\Inline;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Node\Inline\AbstractInline;
 use League\CommonMark\Node\Inline\Newline;
@@ -59,7 +60,7 @@ final class NewlineRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Renderer/Inline/TextRendererTest.php
+++ b/tests/unit/Renderer/Inline/TextRendererTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Renderer\Inline;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Node\Inline\AbstractInline;
 use League\CommonMark\Node\Inline\Text;
 use League\CommonMark\Renderer\Inline\TextRenderer;
@@ -44,7 +45,7 @@ final class TextRendererTest extends TestCase
 
     public function testRenderWithInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $inline       = $this->getMockForAbstractClass(AbstractInline::class);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/unit/Util/HtmlFilterTest.php
+++ b/tests/unit/Util/HtmlFilterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Util;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Util\HtmlFilter;
 use PHPUnit\Framework\TestCase;
 
@@ -44,7 +45,7 @@ final class HtmlFilterTest extends TestCase
 
     public function testInvalidFilter(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         HtmlFilter::filter('', 'some-made-up-option');
     }

--- a/tests/unit/Util/RegexHelperTest.php
+++ b/tests/unit/Util/RegexHelperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Unit\Util;
 
+use League\CommonMark\Exception\InvalidArgumentException;
 use League\CommonMark\Extension\CommonMark\Node\Block\HtmlBlock;
 use League\CommonMark\Util\RegexHelper;
 use PHPUnit\Framework\TestCase;
@@ -341,7 +342,7 @@ final class RegexHelperTest extends TestCase
 
     public function testInvalidHtmlBlockOpenRegex(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         RegexHelper::getHtmlBlockOpenRegex(8);
     }
@@ -371,7 +372,7 @@ final class RegexHelperTest extends TestCase
      */
     public function testInvalidHtmlBlockCloseRegex(int $type): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         RegexHelper::getHtmlBlockCloseRegex($type);
     }


### PR DESCRIPTION
This PR essentially:

 - Fixes incorrect `@throws` docblocks not covering all thrown exception types
 - Changes some exceptions from `RuntimeException` to `LogicException` when the error is caused by a developer
 - Adds new, more-specific exception subclasses

Closes #900 