### PR TITLE
Fix phpstan error

### DIFF
--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -43,6 +43,7 @@ final class AttributesHelper
             $cursor->advanceBy(1);
         }
 
+        /** @var array<string, mixed> $attributes */
         $attributes = [];
         while ($attribute = \trim((string) $cursor->match(self::REGEX))) {
             if ($attribute[0] === '#') {


### PR DESCRIPTION
Inform phpstan of the desired array types so it stops erroring on newer versions.