### PR TITLE
Fix attribute parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Fixed unquoted attribute parsing when closing curly brace is followed by certain characters (like a `.`) (#943)
+
 ## [2.3.5] - 2022-07-29
 
 ### Fixed

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -42,7 +42,7 @@ final class RegexHelper
     public const PARTIAL_TAGNAME               = '[a-z][a-z0-9-]*';
     public const PARTIAL_BLOCKTAGNAME          = '(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)';
     public const PARTIAL_ATTRIBUTENAME         = '[a-z_:][a-z0-9:._-]*';
-    public const PARTIAL_UNQUOTEDVALUE         = '[^"\'=<>}`\x00-\x20]+';
+    public const PARTIAL_UNQUOTEDVALUE         = '[^"\'=<>`\x00-\x20]+';
     public const PARTIAL_SINGLEQUOTEDVALUE     = '\'[^\']*\'';
     public const PARTIAL_DOUBLEQUOTEDVALUE     = '"[^"]*"';
     public const PARTIAL_ATTRIBUTEVALUE        = '(?:' . self::PARTIAL_UNQUOTEDVALUE . '|' . self::PARTIAL_SINGLEQUOTEDVALUE . '|' . self::PARTIAL_DOUBLEQUOTEDVALUE . ')';

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -42,7 +42,7 @@ final class RegexHelper
     public const PARTIAL_TAGNAME               = '[a-z][a-z0-9-]*';
     public const PARTIAL_BLOCKTAGNAME          = '(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)';
     public const PARTIAL_ATTRIBUTENAME         = '[a-z_:][a-z0-9:._-]*';
-    public const PARTIAL_UNQUOTEDVALUE         = '[^"\'=<>`\x00-\x20]+';
+    public const PARTIAL_UNQUOTEDVALUE         = '[^"\'=<>}`\x00-\x20]+';
     public const PARTIAL_SINGLEQUOTEDVALUE     = '\'[^\']*\'';
     public const PARTIAL_DOUBLEQUOTEDVALUE     = '"[^"]*"';
     public const PARTIAL_ATTRIBUTEVALUE        = '(?:' . self::PARTIAL_UNQUOTEDVALUE . '|' . self::PARTIAL_SINGLEQUOTEDVALUE . '|' . self::PARTIAL_DOUBLEQUOTEDVALUE . ')';

--- a/tests/functional/AbstractLocalDataTest.php
+++ b/tests/functional/AbstractLocalDataTest.php
@@ -76,7 +76,7 @@ abstract class AbstractLocalDataTest extends TestCase
             $parsed   = (new FrontMatterParser(new SymfonyYamlFrontMatterParser()))->parse($input);
             $html     = \file_get_contents($dir . '/' . $testName . $outputFormat);
 
-            yield [$parsed->getContent(), $html, (array) $parsed->getFrontMatter(), $testName];
+            yield $testName => [$parsed->getContent(), $html, (array) $parsed->getFrontMatter(), $testName];
         }
     }
 }

--- a/tests/functional/Extension/Attributes/data/special_attributes.html
+++ b/tests/functional/Extension/Attributes/data/special_attributes.html
@@ -9,3 +9,5 @@
 <p>some } brackets</p>
 <p>some { } brackets</p>
 <p>A link inside of an emphasis tag: <em><a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a></em>.</p>
+<p>Attributes without quote and non-whitespace char <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a></p>
+<p>Attributes without quote and non-whitespace char and a dot <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>

--- a/tests/functional/Extension/Attributes/data/special_attributes.html
+++ b/tests/functional/Extension/Attributes/data/special_attributes.html
@@ -11,3 +11,4 @@
 <p>A link inside of an emphasis tag: <em><a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a></em>.</p>
 <p>Attributes without quote and non-whitespace char <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a></p>
 <p>Attributes without quote and non-whitespace char and a dot <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>
+<p>Multiple attributes without quote and non-whitespace char and a dot <a class="class" id="id" target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>

--- a/tests/functional/Extension/Attributes/data/special_attributes.md
+++ b/tests/functional/Extension/Attributes/data/special_attributes.md
@@ -1,7 +1,7 @@
 Header 1            {#header1}
 ========
 
-## Header 2 ##      
+## Header 2 ##
 {#header2}
 
 ## The Site    {.main}
@@ -22,3 +22,7 @@ some } brackets
 some { } brackets
 
 A link inside of an emphasis tag: *[link](http://url.com){target="_blank"}*.
+
+Attributes without quote and non-whitespace char [link](http://url.com){target=_blank}
+
+Attributes without quote and non-whitespace char and a dot [link](http://url.com){target=_blank}.

--- a/tests/functional/Extension/Attributes/data/special_attributes.md
+++ b/tests/functional/Extension/Attributes/data/special_attributes.md
@@ -26,3 +26,5 @@ A link inside of an emphasis tag: *[link](http://url.com){target="_blank"}*.
 Attributes without quote and non-whitespace char [link](http://url.com){target=_blank}
 
 Attributes without quote and non-whitespace char and a dot [link](http://url.com){target=_blank}.
+
+Multiple attributes without quote and non-whitespace char and a dot [link](http://url.com){#id .class target=_blank}.

--- a/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
+++ b/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
@@ -53,6 +53,10 @@ final class AttributesHelperTest extends TestCase
         yield [new Cursor('{: #custom-id #another-id }'), ['id' => 'another-id']];
         yield [new Cursor('{: .class1 .class2 }'), ['class' => 'class1 class2']];
         yield [new Cursor('{: #custom-id .class1 .class2 title="My Title" }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title']];
+        yield [new Cursor('{:target=_blank}'), ['target' => '_blank']];
+        yield [new Cursor('{: target=_blank}'), ['target' => '_blank']];
+        yield [new Cursor('{: target=_blank }'), ['target' => '_blank']];
+        yield [new Cursor('{:   target=_blank   }'), ['target' => '_blank']];
 
         // Examples without colons
         yield [new Cursor('{title="My Title"}'), ['title' => 'My Title']];
@@ -64,6 +68,10 @@ final class AttributesHelperTest extends TestCase
         yield [new Cursor('{ #custom-id #another-id }'), ['id' => 'another-id']];
         yield [new Cursor('{ .class1 .class2 }'), ['class' => 'class1 class2']];
         yield [new Cursor('{ #custom-id .class1 .class2 title="My Title" }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title']];
+        yield [new Cursor('{target=_blank}'), ['target' => '_blank']];
+        yield [new Cursor('{ target=_blank}'), ['target' => '_blank']];
+        yield [new Cursor('{target=_blank }'), ['target' => '_blank']];
+        yield [new Cursor('{   target=_blank   }'), ['target' => '_blank']];
 
         // Stuff at the beginning
         yield [new Cursor(' {: #custom-id }'), ['id' => 'custom-id']];


### PR DESCRIPTION
As discovered in #943 and #944, unquoted attribute parsing sometimes consumes the trailing curly brace as part of the attribute value, causing the lazy check for the brace to fail.  This PR adjusts the parsing logic to match and extract the inner attributes from the `{ ... }` syntax first to avoid this.