### PR TITLE
Fix class reference in Extensions section of docs

### DIFF
--- a/docs/2.0/customization/extensions.md
+++ b/docs/2.0/customization/extensions.md
@@ -8,15 +8,15 @@ description: Creating custom extensions to add new syntax and other custom funct
 
 Extensions provide a way to group related parsers, renderers, etc. together with pre-defined priorities, configuration settings, etc.  They are perfect for distributing your customizations as reusable, open-source packages that others can plug into their own projects!
 
-To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `ConfigurableEnvironmentInterface` to register whatever things you need to. For example:
+To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `EnvironmentBuilderInterface` to register whatever things you need to. For example:
 
 ```php
 use League\CommonMark\Extension\ExtensionInterface;
-use League\CommonMark\Environment\ConfigurableEnvironmentInterface;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
 
 final class EmojiExtension implements ExtensionInterface
 {
-    public function register(ConfigurableEnvironmentInterface $environment): void
+    public function register(EnvironmentBuilderInterface $environment): void
     {
         $environment
             // TODO: Create the EmojiParser, Emoji, and EmojiRenderer classes

--- a/docs/2.1/customization/extensions.md
+++ b/docs/2.1/customization/extensions.md
@@ -8,15 +8,15 @@ description: Creating custom extensions to add new syntax and other custom funct
 
 Extensions provide a way to group related parsers, renderers, etc. together with pre-defined priorities, configuration settings, etc.  They are perfect for distributing your customizations as reusable, open-source packages that others can plug into their own projects!
 
-To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `ConfigurableEnvironmentInterface` to register whatever things you need to. For example:
+To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `EnvironmentBuilderInterface` to register whatever things you need to. For example:
 
 ```php
 use League\CommonMark\Extension\ExtensionInterface;
-use League\CommonMark\Environment\ConfigurableEnvironmentInterface;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
 
 final class EmojiExtension implements ExtensionInterface
 {
-    public function register(ConfigurableEnvironmentInterface $environment): void
+    public function register(EnvironmentBuilderInterface $environment): void
     {
         $environment
             // TODO: Create the EmojiParser, Emoji, and EmojiRenderer classes

--- a/docs/2.2/customization/extensions.md
+++ b/docs/2.2/customization/extensions.md
@@ -8,15 +8,15 @@ description: Creating custom extensions to add new syntax and other custom funct
 
 Extensions provide a way to group related parsers, renderers, etc. together with pre-defined priorities, configuration settings, etc.  They are perfect for distributing your customizations as reusable, open-source packages that others can plug into their own projects!
 
-To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `ConfigurableEnvironmentInterface` to register whatever things you need to. For example:
+To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `EnvironmentBuilderInterface` to register whatever things you need to. For example:
 
 ```php
 use League\CommonMark\Extension\ExtensionInterface;
-use League\CommonMark\Environment\ConfigurableEnvironmentInterface;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
 
 final class EmojiExtension implements ExtensionInterface
 {
-    public function register(ConfigurableEnvironmentInterface $environment): void
+    public function register(EnvironmentBuilderInterface $environment): void
     {
         $environment
             // TODO: Create the EmojiParser, Emoji, and EmojiRenderer classes

--- a/docs/2.3/customization/extensions.md
+++ b/docs/2.3/customization/extensions.md
@@ -9,15 +9,15 @@ redirect_from: /customization/extensions/
 
 Extensions provide a way to group related parsers, renderers, etc. together with pre-defined priorities, configuration settings, etc.  They are perfect for distributing your customizations as reusable, open-source packages that others can plug into their own projects!
 
-To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `ConfigurableEnvironmentInterface` to register whatever things you need to. For example:
+To create an extension, simply create a new class implementing `ExtensionInterface`.  This has a single method where you're given a `EnvironmentBuilderInterface` to register whatever things you need to. For example:
 
 ```php
 use League\CommonMark\Extension\ExtensionInterface;
-use League\CommonMark\Environment\ConfigurableEnvironmentInterface;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
 
 final class EmojiExtension implements ExtensionInterface
 {
-    public function register(ConfigurableEnvironmentInterface $environment): void
+    public function register(EnvironmentBuilderInterface $environment): void
     {
         $environment
             // TODO: Create the EmojiParser, Emoji, and EmojiRenderer classes


### PR DESCRIPTION
`ConfigurableEnvironmentInterface` appears to be a vestige of the 1.x branch.

https://github.com/thephpleague/commonmark/blob/1.6/src/ConfigurableEnvironmentInterface.php

`EnvironmentBuilderInterface` appears to be the corresponding interface used by `ExtensionInterface` in 2.x branches.

https://github.com/thephpleague/commonmark/blob/2.3/src/Extension/ExtensionInterface.php#L19-L23

This issue appears to be present in the docs for all 2.x branches.

- https://github.com/thephpleague/commonmark/blob/2.3/docs/2.3/customization/extensions.md?plain=1#L16-L20
- https://github.com/thephpleague/commonmark/blob/2.2/docs/2.2/customization/extensions.md?plain=1#L15-L19
- https://github.com/thephpleague/commonmark/blob/2.1/docs/2.1/customization/extensions.md?plain=1#L16-L20
- https://github.com/thephpleague/commonmark/blob/2.0/docs/2.0/customization/extensions.md?plain=1#L16-L20

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
