### PR TITLE
Fix autolink extension URL detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Fixed autolink extension not detecting some URIs with underscores (#956)
+
 ## [2.3.8] - 2022-12-10
 
 ### Fixed

--- a/src/Extension/Autolink/UrlAutolinkParser.php
+++ b/src/Extension/Autolink/UrlAutolinkParser.php
@@ -22,16 +22,22 @@ final class UrlAutolinkParser implements InlineParserInterface
 {
     private const ALLOWED_AFTER = [null, ' ', "\t", "\n", "\x0b", "\x0c", "\x0d", '*', '_', '~', '('];
 
-    // RegEx adapted from https://github.com/symfony/symfony/blob/4.2/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+    // RegEx adapted from https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Validator/Constraints/UrlValidator.php
     private const REGEX = '~
         (
             # Must start with a supported scheme + auth, or "www"
             (?:
-                (?:%s)://                                 # protocol
-                (?:([\.\pL\pN-]+:)?([\.\pL\pN-]+)@)?      # basic auth
+                (?:%s)://                                                                            # protocol
+                (?:(?:(?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+)@)? # basic auth
             |www\.)
             (?:
-                (?:[\pL\pN\pS\-\.])+(?:\.?(?:[\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                (?:
+                    (?:xn--[a-z0-9-]++\.)*+xn--[a-z0-9-]++            # a domain name using punycode
+                        |
+                    (?:[\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++          # a multi-level domain name
+                        |
+                    [a-z0-9\-\_]++                                    # a single-level domain name
+                )\.?
                     |                                                 # or
                 \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                    # an IP address
                     |                                                 # or
@@ -40,9 +46,9 @@ final class UrlAutolinkParser implements InlineParserInterface
                 \]  # an IPv6 address
             )
             (?::[0-9]+)?                              # a port (optional)
-            (?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*      # a path
-            (?:\? (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a query (optional)
-            (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a fragment (optional)
+            (?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*        # a path
+            (?:\? (?:[\pL\pN\-._\~!$&\'\[\]()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )? # a query (optional)
+            (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?     # a fragment (optional)
         )~ixu';
 
     /**

--- a/tests/functional/Extension/Autolink/UrlAutolinkParserTest.php
+++ b/tests/functional/Extension/Autolink/UrlAutolinkParserTest.php
@@ -44,6 +44,7 @@ final class UrlAutolinkParserTest extends TestCase
         // Basic examples
         yield ['You can search on http://google.com for stuff.', '<p>You can search on <a href="http://google.com">http://google.com</a> for stuff.</p>'];
         yield ['https://google.com', '<p><a href="https://google.com">https://google.com</a></p>'];
+        yield ['https://sub_domain.example.com', '<p><a href="https://sub_domain.example.com">https://sub_domain.example.com</a></p>'];
         yield ['ftp://example.com', '<p><a href="ftp://example.com">ftp://example.com</a></p>'];
         yield ['www.google.com', '<p><a href="http://www.google.com">www.google.com</a></p>'];
         yield [' http://leadingwhitespace.example.com', '<p><a href="http://leadingwhitespace.example.com">http://leadingwhitespace.example.com</a></p>'];


### PR DESCRIPTION
The extension was not detecting URI with a `_` symbol correctly.

The issue was already fixed in [the regex used by the Symfony project](https://github.com/symfony/symfony/blob/7b0ca3ab5678232f876a95991b66778f4aaa33e3/src/Symfony/Component/Validator/Constraints/UrlValidator.php#L25-L41).
The regex used by the extension is updated to integrate all the changes that been made to it.

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
