### PR TITLE
Update Strikethrough parsing to match GFM spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - `HeadingPermalinkProcessor` now throws `InvalidConfigurationException` instead of `RuntimeException` when invalid config values are given.
 - `HtmlElement::setAttribute()` no longer requires the second parameter for boolean attributes
 - Several small micro-optimizations
+- Changed Strikethrough to only allow 1 or 2 tildes per the updated GFM spec
 
 ### Fixed
 

--- a/src/Extension/Strikethrough/StrikethroughDelimiterProcessor.php
+++ b/src/Extension/Strikethrough/StrikethroughDelimiterProcessor.php
@@ -31,14 +31,20 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
 
     public function getMinLength(): int
     {
-        return 2;
+        return 1;
     }
 
     public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int
     {
-        $min = \min($opener->getLength(), $closer->getLength());
+        if ($opener->getLength() > 2 && $closer->getLength() > 2) {
+            return 0;
+        }
 
-        return $min >= 2 ? $min : 0;
+        if ($opener->getLength() !== $closer->getLength()) {
+            return 0;
+        }
+
+        return \min($opener->getLength(), $closer->getLength());
     }
 
     public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse): void

--- a/tests/functional/Extension/Strikethrough/StrikethroughExtensionTest.php
+++ b/tests/functional/Extension/Strikethrough/StrikethroughExtensionTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace League\CommonMark\Tests\Unit\Extension\Strikethrough;
+namespace League\CommonMark\Tests\Functional\Extension\Strikethrough;
 
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
@@ -20,7 +20,7 @@ use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Renderer\HtmlRenderer;
 use PHPUnit\Framework\TestCase;
 
-final class IntegrationTest extends TestCase
+final class StrikethroughExtensionTest extends TestCase
 {
     /**
      * @dataProvider dataForIntegrationTest
@@ -47,23 +47,35 @@ final class IntegrationTest extends TestCase
     public function dataForIntegrationTest(): array
     {
         return [
+            ['~~Hi~~ Hello, ~there~ world!', "<p><del>Hi</del> Hello, <del>there</del> world!</p>\n"],
             ['This is a test without any strikethroughs', "<p>This is a test without any strikethroughs</p>\n"],
-            ['This is a test without any ~valid~ strikethroughs', "<p>This is a test without any ~valid~ strikethroughs</p>\n"],
-            ['This is a test `without` any ~valid~ strikethroughs', "<p>This is a test <code>without</code> any ~valid~ strikethroughs</p>\n"],
+            ['This is a test with ~valid~ strikethroughs', "<p>This is a test with <del>valid</del> strikethroughs</p>\n"],
+            ['This is a test `with` ~valid~ strikethroughs', "<p>This is a test <code>with</code> <del>valid</del> strikethroughs</p>\n"],
             ['This is a ~~unit~~ integration test', "<p>This is a <del>unit</del> integration test</p>\n"],
             ['~~Strikethrough~~ on the left', "<p><del>Strikethrough</del> on the left</p>\n"],
             ['Strikethrough on the ~~right~~', "<p>Strikethrough on the <del>right</del></p>\n"],
             ['~~Strikethrough everywhere~~', "<p><del>Strikethrough everywhere</del></p>\n"],
             ['This ~~test has no ending match', "<p>This ~~test has no ending match</p>\n"],
-            ['This ~~test~~~ has mismatched tildes', "<p>This <del>test</del>~ has mismatched tildes</p>\n"],
-            ['This ~~~test~~ also has mismatched tildes', "<p>This ~<del>test</del> also has mismatched tildes</p>\n"],
-            ['This one has ~~~three~~~ tildes', "<p>This one has <del>three</del> tildes</p>\n"],
+            ['This ~~test~~~ has mismatched tildes', "<p>This ~~test~~~ has mismatched tildes</p>\n"],
+            ['This ~~~test~~ also has mismatched tildes', "<p>This ~~~test~~ also has mismatched tildes</p>\n"],
+            ['This one has ~~~three~~~ tildes', "<p>This one has ~~~three~~~ tildes</p>\n"],
             ["This ~~has a\n\nnew paragraph~~.", "<p>This ~~has a</p>\n<p>new paragraph~~.</p>\n"],
             ['Hello ~~ ~~ world', "<p>Hello ~~ ~~ world</p>\n"],
             ['This **is ~~a little** test of mismatched delimiters~~', "<p>This <strong>is ~~a little</strong> test of mismatched delimiters~~</p>\n"],
             ['Из: твоя ~~тест~~ ветка', "<p>Из: твоя <del>тест</del> ветка</p>\n"],
             ['This one combines ~~nested ~~strikethrough~~ text~~', "<p>This one combines <del>nested <del>strikethrough</del> text</del></p>\n"],
             ['Here we have **emphasized text containing a ~~strikethrough~~**', "<p>Here we have <strong>emphasized text containing a <del>strikethrough</del></strong></p>\n"],
+            ['Four trailing tildes ~~~~', "<p>Four trailing tildes ~~~~</p>\n"],
+            ['~~Unmatched left', "<p>~~Unmatched left</p>\n"],
+            ['Unmatched right~~', "<p>Unmatched right~~</p>\n"],
+            ['~~foo~bar~~', "<p><del>foo~bar</del></p>\n"],
+            ['~~foo~~bar~~', "<p><del>foo</del>bar~~</p>\n"],
+            ['~~foo~~~bar~~', "<p><del>foo~~~bar</del></p>\n"],
+            ['~~foo~~~~bar~~', "<p><del>foo~~~~bar</del></p>\n"],
+            ['~~foo~~~~~bar~~', "<p><del>foo~~~~~bar</del></p>\n"],
+            ['~~foo~~~~~~bar~~', "<p><del>foo~~~~~~bar</del></p>\n"],
+            ['~~foo~~~~~~~bar~~', "<p><del>foo~~~~~~~bar</del></p>\n"],
+            ['> inside a ~~blockquote~~', "<blockquote>\n<p>inside a <del>blockquote</del></p>\n</blockquote>\n"],
         ];
     }
 }


### PR DESCRIPTION
See https://github.com/github/cmark-gfm/issues/271. **TL;DR:** Strikethrough requires a matching pair of 1 or 2 tildes, instead of 2+.

Unfortunately, due to https://github.com/github/cmark-gfm/issues/288, the `spec.txt` we test against does not yet have these changes, so we'll rely on our own tests to verify this modified behavior for now.