### PR TITLE
Fix links to `Mentions` extension documentation

### DIFF
--- a/docs/2.0/extensions/autolinks.md
+++ b/docs/2.0/extensions/autolinks.md
@@ -47,6 +47,6 @@ echo $converter->convertToHtml('I successfully installed the https://github.com/
 
 ## `@mention`-style Autolinking
 
-As of v1.5, [mention autolinking is now handled by a Mention Parser outside of this extension](/2.0/extensions/mention/).
+As of v1.5, [mention autolinking is now handled by a Mention Parser outside of this extension](/2.0/extensions/mentions/).
 
 [link-gfm-spec-autolinking]: https://github.github.com/gfm/#autolinks-extension-

--- a/docs/2.1/extensions/autolinks.md
+++ b/docs/2.1/extensions/autolinks.md
@@ -47,6 +47,6 @@ echo $converter->convertToHtml('I successfully installed the https://github.com/
 
 ## `@mention`-style Autolinking
 
-As of v1.5, [mention autolinking is now handled by a Mention Parser outside of this extension](/2.1/extensions/mention/).
+As of v1.5, [mention autolinking is now handled by a Mention Parser outside of this extension](/2.1/extensions/mentions/).
 
 [link-gfm-spec-autolinking]: https://github.github.com/gfm/#autolinks-extension-

--- a/docs/2.4/extensions/autolinks.md
+++ b/docs/2.4/extensions/autolinks.md
@@ -48,6 +48,6 @@ echo $converter->convert('I successfully installed the https://github.com/thephp
 
 ## `@mention`-style Autolinking
 
-As of v1.5, [mention autolinking is now handled by a Mention Parser outside of this extension](/2.4/extensions/mention/).
+As of v1.5, [mention autolinking is now handled by a Mention Parser outside of this extension](/2.4/extensions/mentions/).
 
 [link-gfm-spec-autolinking]: https://github.github.com/gfm/#autolinks-extension-


### PR DESCRIPTION
Currently those links 404 because they link to `mention` instead of `mentions`.