### PR TITLE
fix: Home page examples since 2.0

### DIFF
--- a/docs/2.0/index.md
+++ b/docs/2.0/index.md
@@ -35,9 +35,9 @@ Simply instantiate the converter and start converting some Markdown to HTML!
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
-echo $converter->convertToHtml('# Hello World!');
+echo $converter->convert('# Hello, World!')->getContent();
 
-// <h1>Hello World!</h1>
+// <h1>Hello, World!</h1>
 ```
 
 <i class="fa fa-exclamation-triangle"></i>

--- a/docs/2.1/index.md
+++ b/docs/2.1/index.md
@@ -35,9 +35,9 @@ Simply instantiate the converter and start converting some Markdown to HTML!
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
-echo $converter->convertToHtml('# Hello World!');
+echo $converter->convert('# Hello, World!')->getContent();
 
-// <h1>Hello World!</h1>
+// <h1>Hello, World!</h1>
 ```
 
 <i class="fa fa-exclamation-triangle"></i>

--- a/docs/2.2/index.md
+++ b/docs/2.2/index.md
@@ -35,9 +35,9 @@ Simply instantiate the converter and start converting some Markdown to HTML!
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
-echo $converter->convert('# Hello World!');
+echo $converter->convert('# Hello, World!')->getContent();
 
-// <h1>Hello World!</h1>
+// <h1>Hello, World!</h1>
 ```
 
 <i class="fa fa-exclamation-triangle"></i>

--- a/docs/2.3/index.md
+++ b/docs/2.3/index.md
@@ -35,9 +35,9 @@ Simply instantiate the converter and start converting some Markdown to HTML!
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
-echo $converter->convert('# Hello World!');
+echo $converter->convert('# Hello, World!')->getContent();
 
-// <h1>Hello World!</h1>
+// <h1>Hello, World!</h1>
 ```
 
 <i class="fa fa-exclamation-triangle"></i>

--- a/docs/2.4/index.md
+++ b/docs/2.4/index.md
@@ -35,9 +35,9 @@ Simply instantiate the converter and start converting some Markdown to HTML!
 use League\CommonMark\CommonMarkConverter;
 
 $converter = new CommonMarkConverter();
-echo $converter->convert('# Hello World!');
+echo $converter->convert('# Hello, World!')->getContent();
 
-// <h1>Hello World!</h1>
+// <h1>Hello, World!</h1>
 ```
 
 <i class="fa fa-exclamation-triangle"></i>


### PR DESCRIPTION
The example on the home page for 2.x didn't include:

1. a call to `getContent()` and
2. a comma in "Hello, World!"