### PR TITLE
Make autolinking protocols configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 ### Added
 
 - The `AttributesExtension` now supports attributes without values (#985, #986)
+- The `AutolinkExtension` exposes two new configuration options to override the default behavior (#969, #987):
+    - `autolink/allowed_protocols` - an array of protocols to allow autolinking for
+    - `autolink/default_protocol` - the default protocol to use when none is specified
 
 ## [2.4.0] - 2023-03-24
 

--- a/docs/2.5/extensions/autolinks.md
+++ b/docs/2.5/extensions/autolinks.md
@@ -32,7 +32,12 @@ use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\MarkdownConverter;
 
 // Define your configuration, if needed
-$config = [];
+$config = [
+    'autolink' => [
+        'allowed_protocols' => ['https'], // defaults to ['https', 'http', 'ftp']
+        'default_protocols' => 'https', // defaults to 'http'
+    ],
+];
 
 // Configure the Environment with all the CommonMark parsers/renderers
 $environment = new Environment($config);
@@ -45,6 +50,18 @@ $environment->addExtension(new AutolinkExtension());
 $converter = new MarkdownConverter($environment);
 echo $converter->convert('I successfully installed the https://github.com/thephpleague/commonmark project with the Autolink extension!');
 ```
+
+## Configuration
+
+As of version 2.5.0, this extension supports the following configuration options under the `autolink` configuration:
+
+### `allowed_protocols` option
+
+This option defines which types of URLs will be autolinked. The default value of `['https', 'http', 'ftp']` means that only URLs using those protocols will be autolinked. Setting this to just `['https']` means that only HTTPS URLs will be autolinked.
+
+### `default_protocol` option
+
+This option defines the default protocol for URLs that start with `www.` and don't have an explicit protocol set. For example, setting this to `https` would convert `www.example.com` to `https://www.example.com`.
 
 ## `@mention`-style Autolinking
 

--- a/src/Extension/Autolink/AutolinkExtension.php
+++ b/src/Extension/Autolink/AutolinkExtension.php
@@ -14,13 +14,26 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Autolink;
 
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
-use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\ConfigurableExtensionInterface;
+use League\Config\ConfigurationBuilderInterface;
+use Nette\Schema\Expect;
 
-final class AutolinkExtension implements ExtensionInterface
+final class AutolinkExtension implements ConfigurableExtensionInterface
 {
+    public function configureSchema(ConfigurationBuilderInterface $builder): void
+    {
+        $builder->addSchema('autolink', Expect::structure([
+            'allowed_protocols' => Expect::listOf('string')->default(['http', 'https', 'ftp'])->mergeDefaults(false),
+            'default_protocol' => Expect::string()->default('http'),
+        ]));
+    }
+
     public function register(EnvironmentBuilderInterface $environment): void
     {
         $environment->addInlineParser(new EmailAutolinkParser());
-        $environment->addInlineParser(new UrlAutolinkParser());
+        $environment->addInlineParser(new UrlAutolinkParser(
+            $environment->getConfiguration()->get('autolink.allowed_protocols'),
+            $environment->getConfiguration()->get('autolink.default_protocol'),
+        ));
     }
 }

--- a/src/Extension/Autolink/UrlAutolinkParser.php
+++ b/src/Extension/Autolink/UrlAutolinkParser.php
@@ -65,10 +65,12 @@ final class UrlAutolinkParser implements InlineParserInterface
      */
     private string $finalRegex;
 
+    private string $defaultProtocol;
+
     /**
      * @param array<int, string> $allowedProtocols
      */
-    public function __construct(array $allowedProtocols = ['http', 'https', 'ftp'])
+    public function __construct(array $allowedProtocols = ['http', 'https', 'ftp'], string $defaultProtocol = 'http')
     {
         /**
          * @psalm-suppress PropertyTypeCoercion
@@ -78,6 +80,8 @@ final class UrlAutolinkParser implements InlineParserInterface
         foreach ($allowedProtocols as $protocol) {
             $this->prefixes[] = $protocol . '://';
         }
+
+        $this->defaultProtocol = $defaultProtocol;
     }
 
     public function getMatchDefinition(): InlineParserMatch
@@ -120,9 +124,9 @@ final class UrlAutolinkParser implements InlineParserInterface
 
         $cursor->advanceBy(\mb_strlen($url, 'UTF-8'));
 
-        // Auto-prefix 'http://' onto 'www' URLs
+        // Auto-prefix 'http(s)://' onto 'www' URLs
         if (\substr($url, 0, 4) === 'www.') {
-            $inlineContext->getContainer()->appendChild(new Link('http://' . $url, $url));
+            $inlineContext->getContainer()->appendChild(new Link($this->defaultProtocol . '://' . $url, $url));
 
             return true;
         }


### PR DESCRIPTION
This is an alternative approach to #969 allowing users to customize both the default and allowed protocols via configuration.