### PR TITLE
Replace symbol with backref_symbol

### DIFF
--- a/docs/2.4/extensions/footnotes.md
+++ b/docs/2.4/extensions/footnotes.md
@@ -130,13 +130,13 @@ This `string` option defines the prefix prepended to footnote elements.
 
 ## Adding Icons
 
-You can use CSS to add a custom icon instead of providing a `symbol`:
+You can use CSS to add a custom icon instead of providing a `backref_symbol`:
 
 ```php
 $config = [
     'footnote' => [
         'backref_class' => 'footnote-backref',
-        'symbol' => '',
+        'backref_symbol' => '',
     ],
 ];
 ```


### PR DESCRIPTION
It should be `backref_symbol`, not `symbol`.

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
