### PR TITLE
Fix ExternalLinkProcessor not fully disabling the `rel` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Fixed `ExternalLinkProcessor` not fully disabling the `rel` attribute when configured to do so (#992)
+
 ## [2.4.0] - 2023-03-24
 
 ### Added

--- a/src/Extension/ExternalLink/ExternalLinkProcessor.php
+++ b/src/Extension/ExternalLink/ExternalLinkProcessor.php
@@ -90,6 +90,11 @@ final class ExternalLinkProcessor
                     $link->data->append('attributes/rel', $type);
             }
         }
+
+        // No rel attributes? Mark the attribute as 'false' so LinkRenderer doesn't add defaults
+        if (! $link->data->has('attributes/rel')) {
+            $link->data->set('attributes/rel', false);
+        }
     }
 
     /**

--- a/tests/functional/Extension/ExternalLink/ExternalLinkExtensionTest.php
+++ b/tests/functional/Extension/ExternalLink/ExternalLinkExtensionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\CommonMark\Tests\Functional\Extension\ExternalLink;
 
+use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
@@ -64,5 +65,26 @@ final class ExternalLinkExtensionTest extends TestCase
         $environment2->addExtension(new ExternalLinkExtension());
 
         yield 'Register Autolink extension first' => [$environment2];
+    }
+
+    public function testExtensionWithRelAttrsDisabled(): void
+    {
+        $config = [
+            'external_link' => [
+                'internal_hosts' => ['my-internal-domain.com'],
+                'open_in_new_window' => true,
+                'nofollow' => '',
+                'noopener' => '',
+                'noreferrer' => '',
+            ],
+        ];
+
+        $converter = new CommonMarkConverter($config);
+        $converter->getEnvironment()->addExtension(new ExternalLinkExtension());
+
+        $input        = 'This is an external link [Google](https://google.com/).';
+        $expectedHtml = '<p>This is an external link <a target="_blank" href="https://google.com/">Google</a>.</p>';
+
+        $this->assertSame($expectedHtml, \rtrim($converter->convert($input)->getContent()));
     }
 }


### PR DESCRIPTION
Fixes #992 
