### PR TITLE
Replace the array_merge with spread array operator

### DIFF
--- a/src/Extension/SmartPunct/QuoteParser.php
+++ b/src/Extension/SmartPunct/QuoteParser.php
@@ -29,7 +29,7 @@ final class QuoteParser implements InlineParserInterface
 
     public function getMatchDefinition(): InlineParserMatch
     {
-        return InlineParserMatch::oneOf(...\array_merge(self::DOUBLE_QUOTES, self::SINGLE_QUOTES));
+        return InlineParserMatch::oneOf(...[...self::DOUBLE_QUOTES, ...self::SINGLE_QUOTES]);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- According to the [reference](https://wiki.php.net/rfc/spread_operator_for_array), it's great to use the spread array operator to replace the `array_merge` function.
- There're two reasons about using the spread array operator:
  - Spread operator should have a better performance than array_merge and compile time optimization can be performant for constant arrays.
  - `array_merge` only supports array, while the spread operator also supports objects implementing `Traversable`.