### PR TITLE
Allow CSS level 3 selectors for classes and ids in the attributes extension

### DIFF
--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -23,7 +23,7 @@ use League\CommonMark\Util\RegexHelper;
  */
 final class AttributesHelper
 {
-    private const SINGLE_ATTRIBUTE = '\s*([.#][_a-z0-9-]+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . ')\s*';
+    private const SINGLE_ATTRIBUTE = '\s*([.]-?[_a-z]\S*|[#]\S+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . ')\s*';
     private const ATTRIBUTE_LIST   = '/^{:?(' . self::SINGLE_ATTRIBUTE . ')+}/i';
 
     /**

--- a/tests/functional/Extension/Attributes/data/class_names.html
+++ b/tests/functional/Extension/Attributes/data/class_names.html
@@ -1,0 +1,6 @@
+<p class="some-class(value)">Some text</p>
+<p class="some-class(value)">Some text</p>
+<p class="-hello">Some text</p>
+<p class="smile-😎 some-class">Some text</p>
+<p id="smile-😎">Some text</p>
+<p id="smile-😎">Some text</p>

--- a/tests/functional/Extension/Attributes/data/class_names.md
+++ b/tests/functional/Extension/Attributes/data/class_names.md
@@ -1,0 +1,17 @@
+{class="some-class(value)"}
+Some text
+
+{.some-class(value)}
+Some text
+
+{.-hello}
+Some text
+
+{.smile-😎 .some-class}
+Some text
+
+{id="smile-😎"}
+Some text
+
+{#smile-😎}
+Some text


### PR DESCRIPTION
The [CSS level 3 Syntax](https://www.w3.org/TR/selectors-3/), which is a Recommendation since 2018, allows much more characters in `id` and `class` selectors than the ones currently supported by the "Attributes" extension:

https://github.com/thephpleague/commonmark/blob/91c24291965bd6d7c46c46a12ba7492f83b1cadf/src/Extension/Attributes/Util/AttributesHelper.php#L26

The formal CSS level 3 selectors grammar is detailed here: https://www.w3.org/TR/selectors-3/#w3cselgrammar

This pull request adds a test to check several valid `class` and `id` names that are currently failing to be parsed as valid attribute values by the "Attributes" extension, and it proposes a fix for this issue.