### PR TITLE
UrlAutolinkParser fails for text containing WWW and a subsequent link

### DIFF
--- a/tests/functional/Extension/Autolink/UrlAutolinkParserTest.php
+++ b/tests/functional/Extension/Autolink/UrlAutolinkParserTest.php
@@ -71,6 +71,7 @@ final class UrlAutolinkParserTest extends TestCase
         yield ['(www.google.com/search?q=Markup+(business)', '<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>'];
         yield ['www.google.com/search?q=(business))+ok', '<p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>'];
         yield ['(https://www.example.com/test).', '<p>(<a href="https://www.example.com/test">https://www.example.com/test</a>).</p>'];
+        yield ['WWW text followed by [link](https://example.com/)', '<p>WWW text followed by <a href="https://example.com/">link</a></p>'];
 
         // Tests involving semi-colon endings
         yield ['www.google.com/search?q=commonmark&hl=en', '<p><a href="http://www.google.com/search?q=commonmark&amp;hl=en">www.google.com/search?q=commonmark&amp;hl=en</a></p>'];


### PR DESCRIPTION
For strings containing `www` followed by a link using `[link](https://…)` format, the parser mangles the resulting HTML:

```html
<!-- given this string of markdown -->
WWW text followed by a [link](https://example.com/foo-bar-test)

<!-- expected result -->
<p>WWW text followed by a <a href="https://example.com/foo-bar-test">link</a></p>

<!-- actual result -->
<p><a href="https://example.com/foo-bar-test">https://example.com/foo-bar-test</a>tps://example.com/foo-bar-test)</p>
```