### PR TITLE
Prevent templating being treated as attributes

### DIFF
--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -24,7 +24,7 @@ use League\CommonMark\Util\RegexHelper;
 final class AttributesHelper
 {
     private const SINGLE_ATTRIBUTE = '\s*([.]-?[_a-z][^\s}]*|[#][^\s}]+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . '?)\s*';
-    private const ATTRIBUTE_LIST   = '/^{:?(' . self::SINGLE_ATTRIBUTE . ')+}/i';
+    private const ATTRIBUTE_LIST   = '/^{(?!{):?(' . self::SINGLE_ATTRIBUTE . ')+}(?!})/i';
 
     /**
      * @return array<string, mixed>

--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -24,7 +24,7 @@ use League\CommonMark\Util\RegexHelper;
 final class AttributesHelper
 {
     private const SINGLE_ATTRIBUTE = '\s*([.]-?[_a-z][^\s}]*|[#][^\s}]+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . '?)\s*';
-    private const ATTRIBUTE_LIST   = '/^{(?!{):?(' . self::SINGLE_ATTRIBUTE . ')+}(?!})/i';
+    private const ATTRIBUTE_LIST   = '/^{:?(' . self::SINGLE_ATTRIBUTE . ')+}(?!})/i';
 
     /**
      * @return array<string, mixed>

--- a/tests/functional/Extension/Attributes/data/special_attributes.html
+++ b/tests/functional/Extension/Attributes/data/special_attributes.html
@@ -13,3 +13,6 @@
 <p>Attributes without quote and non-whitespace char and a dot <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>
 <p>Multiple attributes without quote and non-whitespace char and a dot <a class="class" id="id" target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>
 <p><img valueless-attribute src="/assets/image.jpg" alt="image" /></p>
+<p>A paragraph containing {{ mustache }} templating</p>
+<p>A paragraph ending with {{ mustache }} templating</p>
+<p>{{ mustache }} A paragraph starting with mustache templating</p>

--- a/tests/functional/Extension/Attributes/data/special_attributes.md
+++ b/tests/functional/Extension/Attributes/data/special_attributes.md
@@ -30,3 +30,10 @@ Attributes without quote and non-whitespace char and a dot [link](http://url.com
 Multiple attributes without quote and non-whitespace char and a dot [link](http://url.com){#id .class target=_blank}.
 
 ![image](/assets/image.jpg){valueless-attribute}
+
+A paragraph containing {{ mustache }} templating
+
+A paragraph ending with {{ mustache }} templating
+
+{{ mustache }} A paragraph starting with mustache templating
+

--- a/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
+++ b/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
@@ -105,6 +105,7 @@ final class AttributesHelperTest extends TestCase
         // Avoid mustache style templating language being parsed as attributes
         yield [new Cursor('{{ foo }}'), [], '{{ foo }}'];
         yield [new Cursor(' {{ foo }}'), [], ' {{ foo }}'];
+        yield [new Cursor('{ foo }}'), [], '{ foo }}'];
     }
 
     /**

--- a/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
+++ b/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
@@ -101,6 +101,10 @@ final class AttributesHelperTest extends TestCase
         // Curly braces inside of values
         yield [new Cursor('{: data-json="{1,2,3}" }'), ['data-json' => '{1,2,3}']];
         yield [new Cursor('{data-json={1,2,3}} test'), ['data-json' => '{1,2,3}'], ' test'];
+
+        // Avoid mustache style templating language being parsed as attributes
+        yield [new Cursor('{{ foo }}'), [], '{{ foo }}'];
+        yield [new Cursor(' {{ foo }}'), [], ' {{ foo }}'];
     }
 
     /**


### PR DESCRIPTION
This PR prevents mustache-style template language strings being interpreted as attributes.

This was introduced in 2.5.0 by #986. It caused template strings to be wiped out.

```php
$converter->convert('# Hello {{ foo }}');
```
```diff
-<h1>Hello {{ foo }}</h1>
+<h1>Hello {}</h1>
```

This PR adds negative lookaheads to the regex to ignore the double-braces, allowing the template strings to be maintained:

```diff
-<h1>Hello {}</h1>
+<h1>Hello {{ foo }}</h1>
```

I'm not sure if the changes to `AttributesHelperTest` are needed. They passed before making the regex change too.