### PR TITLE
Fix the parser behavior for texts containing curly-braces when the Attributes extension is enabled

### DIFF
--- a/docs/2.5/extensions/attributes.md
+++ b/docs/2.5/extensions/attributes.md
@@ -55,6 +55,21 @@ Output:
 <p>This is <em style="color: red">red</em>.</p>
 ```
 
+### Empty-Value Attributes
+
+Attributes can be rendered in HTML without a value by using `true` value in the markdown document:
+
+```markdown
+{itemscope=true}
+## Header
+```
+
+Output:
+
+```html
+<h2 itemscope>Header</h2>
+```
+
 ## Installation
 
 This extension is bundled with `league/commonmark`. This library can be installed via Composer:

--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -23,8 +23,8 @@ use League\CommonMark\Util\RegexHelper;
  */
 final class AttributesHelper
 {
-    private const SINGLE_ATTRIBUTE = '\s*([.]-?[_a-z][^\s}]*|[#][^\s}]+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . '?)\s*';
-    private const ATTRIBUTE_LIST   = '/^{:?(' . self::SINGLE_ATTRIBUTE . ')+}(?!})/i';
+    private const SINGLE_ATTRIBUTE = '\s*([.]-?[_a-z][^\s}]*|[#][^\s}]+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . ')\s*';
+    private const ATTRIBUTE_LIST   = '/^{:?(' . self::SINGLE_ATTRIBUTE . ')+}/i';
 
     /**
      * @return array<string, mixed>
@@ -72,14 +72,8 @@ final class AttributesHelper
                 continue;
             }
 
-            $parts = \explode('=', $attribute, 2);
-            if (\count($parts) === 1) {
-                $attributes[$attribute] = true;
-                continue;
-            }
-
             /** @psalm-suppress PossiblyUndefinedArrayOffset */
-            [$name, $value] = $parts;
+            [$name, $value] = \explode('=', $attribute, 2);
 
             $first = $value[0];
             $last  = \substr($value, -1);

--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -75,6 +75,11 @@ final class AttributesHelper
             /** @psalm-suppress PossiblyUndefinedArrayOffset */
             [$name, $value] = \explode('=', $attribute, 2);
 
+            if ('true' === $value) {
+                $attributes[$name] = true;
+                continue;
+            }
+
             $first = $value[0];
             $last  = \substr($value, -1);
             if (($first === '"' && $last === '"') || ($first === "'" && $last === "'") && \strlen($value) > 1) {

--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -75,7 +75,7 @@ final class AttributesHelper
             /** @psalm-suppress PossiblyUndefinedArrayOffset */
             [$name, $value] = \explode('=', $attribute, 2);
 
-            if ('true' === $value) {
+            if ($value === 'true') {
                 $attributes[$name] = true;
                 continue;
             }

--- a/tests/functional/Extension/Attributes/data/special_attributes.html
+++ b/tests/functional/Extension/Attributes/data/special_attributes.html
@@ -22,7 +22,8 @@
 <p>c. <a class="text" href="https://example.com">Some</a>.</p>
 <p>d. <a href="https://example.com">Some{text}</a>.</p>
 <p>e. <a text="text" href="https://example.com">Some</a>.</p>
-<p>f. <a href="https://example.com">Some{{text}}</a>.</p>
+<p>f. <a text href="https://example.com">Some</a>.</p>
+<p>g. <a href="https://example.com">Some{{text}}</a>.</p>
 <p hello="hello">some</p>
 <p class="test" hello="hello">some</p>
 <p class="test" hello="hello">some</p>

--- a/tests/functional/Extension/Attributes/data/special_attributes.html
+++ b/tests/functional/Extension/Attributes/data/special_attributes.html
@@ -12,7 +12,18 @@
 <p>Attributes without quote and non-whitespace char <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a></p>
 <p>Attributes without quote and non-whitespace char and a dot <a target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>
 <p>Multiple attributes without quote and non-whitespace char and a dot <a class="class" id="id" target="_blank" href="http://url.com" rel="noopener noreferrer">link</a>.</p>
-<p><img valueless-attribute src="/assets/image.jpg" alt="image" /></p>
+<p><img src="/assets/image.jpg" alt="image" />{some-text}</p>
+<p><img boolean-attribute="boolean-attribute" src="/assets/image.jpg" alt="image" /></p>
 <p>A paragraph containing {{ mustache }} templating</p>
 <p>A paragraph ending with {{ mustache }} templating</p>
 <p>{{ mustache }} A paragraph starting with mustache templating</p>
+<p>a. <a href="https://example.com">Some{text}</a>.</p>
+<p>b. <a href="https://example.com">Some</a>.</p>
+<p>c. <a class="text" href="https://example.com">Some</a>.</p>
+<p>d. <a href="https://example.com">Some{text}</a>.</p>
+<p>e. <a text="text" href="https://example.com">Some</a>.</p>
+<p>f. <a href="https://example.com">Some{{text}}</a>.</p>
+<p hello="hello">some</p>
+<p class="test" hello="hello">some</p>
+<p class="test" hello="hello">some</p>
+<p hello="hello" goodbye="goodbye">some</p>

--- a/tests/functional/Extension/Attributes/data/special_attributes.md
+++ b/tests/functional/Extension/Attributes/data/special_attributes.md
@@ -29,7 +29,9 @@ Attributes without quote and non-whitespace char and a dot [link](http://url.com
 
 Multiple attributes without quote and non-whitespace char and a dot [link](http://url.com){#id .class target=_blank}.
 
-![image](/assets/image.jpg){valueless-attribute}
+![image](/assets/image.jpg){some-text}
+
+![image](/assets/image.jpg){boolean-attribute="boolean-attribute"}
 
 A paragraph containing {{ mustache }} templating
 
@@ -37,3 +39,26 @@ A paragraph ending with {{ mustache }} templating
 
 {{ mustache }} A paragraph starting with mustache templating
 
+a. [Some{text}](https://example.com).
+
+b. [Some{.text}](https://example.com).
+
+c. [Some](https://example.com){.text}.
+
+d. [Some{text}](https://example.com).
+
+e. [Some](https://example.com){text="text"}.
+
+f. [Some{{text}}](https://example.com).
+
+{hello="hello"}
+some
+
+{.test hello="hello"}
+some
+
+{hello="hello" .test}
+some
+
+{hello="hello" goodbye="goodbye"}
+some

--- a/tests/functional/Extension/Attributes/data/special_attributes.md
+++ b/tests/functional/Extension/Attributes/data/special_attributes.md
@@ -49,7 +49,9 @@ d. [Some{text}](https://example.com).
 
 e. [Some](https://example.com){text="text"}.
 
-f. [Some{{text}}](https://example.com).
+f. [Some](https://example.com){text=true}.
+
+g. [Some{{text}}](https://example.com).
 
 {hello="hello"}
 some

--- a/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
+++ b/tests/unit/Extension/Attributes/Util/AttributesHelperTest.php
@@ -53,12 +53,13 @@ final class AttributesHelperTest extends TestCase
         yield [new Cursor('{: #custom-id }'), ['id' => 'custom-id']];
         yield [new Cursor('{: #custom-id #another-id }'), ['id' => 'another-id']];
         yield [new Cursor('{: .class1 .class2 }'), ['class' => 'class1 class2']];
-        yield [new Cursor('{: #custom-id .class1 .class2 title="My Title" disabled }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title', 'disabled' => true]];
+        yield [new Cursor('{: #custom-id .class1 .class2 title="My Title" disabled=true }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title', 'disabled' => true]];
+        yield [new Cursor('{: #custom-id .class1 .class2 title="My Title" disabled="disabled" }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title', 'disabled' => 'disabled']];
         yield [new Cursor('{:target=_blank}'), ['target' => '_blank']];
         yield [new Cursor('{: target=_blank}'), ['target' => '_blank']];
         yield [new Cursor('{: target=_blank }'), ['target' => '_blank']];
         yield [new Cursor('{:   target=_blank   }'), ['target' => '_blank']];
-        yield [new Cursor('{: disabled}'), ['disabled' => true]];
+        yield [new Cursor('{: disabled=disabled}'), ['disabled' => 'disabled']];
 
         // Examples without colons
         yield [new Cursor('{title="My Title"}'), ['title' => 'My Title']];
@@ -69,12 +70,13 @@ final class AttributesHelperTest extends TestCase
         yield [new Cursor('{ #custom-id }'), ['id' => 'custom-id']];
         yield [new Cursor('{ #custom-id #another-id }'), ['id' => 'another-id']];
         yield [new Cursor('{ .class1 .class2 }'), ['class' => 'class1 class2']];
-        yield [new Cursor('{ #custom-id .class1 .class2 title="My Title" disabled }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title', 'disabled' => true]];
+        yield [new Cursor('{ #custom-id .class1 .class2 title="My Title" disabled=true }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title', 'disabled' => true]];
+        yield [new Cursor('{ #custom-id .class1 .class2 title="My Title" disabled="disabled" }'), ['id' => 'custom-id', 'class' => 'class1 class2', 'title' => 'My Title', 'disabled' => 'disabled']];
         yield [new Cursor('{target=_blank}'), ['target' => '_blank']];
         yield [new Cursor('{ target=_blank}'), ['target' => '_blank']];
         yield [new Cursor('{target=_blank }'), ['target' => '_blank']];
         yield [new Cursor('{   target=_blank   }'), ['target' => '_blank']];
-        yield [new Cursor('{disabled}'), ['disabled' => true]];
+        yield [new Cursor('{disabled=disabled}'), ['disabled' => 'disabled']];
 
         // Stuff at the beginning
         yield [new Cursor(' {: #custom-id }'), ['id' => 'custom-id']];


### PR DESCRIPTION
## The issue

As stated in https://github.com/thephpleague/commonmark/pull/1035#issuecomment-2284664894, the PR #986 , which introduced the ability to create valueless attributes using the Attributes extension, causes issues when a markdown document includes text strings that contain curly braces.

For example, the following markdown text

```md
Elastic{ON} Tour San Francisco
```

is rendered by [the official commonmark dingus](https://spec.commonmark.org/dingus/) as:

```html
<p>Elastic{ON} Tour San Francisco</p>
```

The `league/commonmark` library with the "Attributes" extension enabled was used to render such markdown the same way until the commit 2138460860e2cee78498846a9d6e2da1913bbadb. Since then, it renders this markdown as:

```html
<p>Elastic Tour San Francisco</p>
```

which is obviously something we do not want.

## What does this PR

This PR reverts the changes introduced in #986 and  #1035 and adds more test cases, to show how to create valid [boolean-attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes).

A section has also been added in the documentation to show how to write attributes that will be rendered as empty-value attributes in HTML.