### PR TITLE
Update README to list PHP 8 as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## 📦 Installation & Basic Usage
 
-This project requires PHP 7.4 or higher with the `mbstring` extension.  To install it via [Composer] simply run:
+This project requires PHP 8.0 or higher with the `mbstring` extension.  To install it via [Composer] simply run:
 
 ``` bash
 $ composer require league/commonmark


### PR DESCRIPTION
nette/utils requires PHP >= 8.0 < 8.4, so PHP 7.4 will no longer pass.

