### PR TITLE
Documentation update for embed.md

### DIFF
--- a/docs/2.5/extensions/embed.md
+++ b/docs/2.5/extensions/embed.md
@@ -110,6 +110,12 @@ of embeddable content.
 To use that library, you'll need to `composer install embed/embed` and then pass `new OscaroteroEmbedAdapter()` as the `adapter`
 configuration option, as shown in the [**Usage**](#usage) section above.
 
+Note: `embed/embed` *requires* a PSR-17 implementation to be installed.  If you do not have one installed, the library will not work.  By default these libraries are detected automatically:
+  * [laminas/laminas-diactoros](https://github.com/laminas/laminas-diactoros)
+  * [guzzle/psr7](https://github.com/guzzle/psr7)
+  * [nyholm/psr7](https://github.com/Nyholm/psr7)
+  * [sunrise/http-message](https://github.com/sunrise-php/http-message)
+
 Need to customize the maximum width/height of the embedded content? You can do that by instantiating the service provided by
 `embed/embed`, [configuring it as needed](https://github.com/oscarotero/Embed#settings), and passing that customized instance into the adapter:
 


### PR DESCRIPTION
I ran into this error with a fresh install - as have several other people. This clarifies that it isn't sufficient just to install the library.

The error was:

> `PHP Fatal error:  Uncaught RuntimeException: No ResponseFactoryInterface detected in /vendor/embed/embed/src/Http/FactoryDiscovery.php:61`

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
