### PR TITLE
Fixed config typo in autolinks.md

### DIFF
--- a/docs/2.5/extensions/autolinks.md
+++ b/docs/2.5/extensions/autolinks.md
@@ -35,7 +35,7 @@ use League\CommonMark\MarkdownConverter;
 $config = [
     'autolink' => [
         'allowed_protocols' => ['https'], // defaults to ['https', 'http', 'ftp']
-        'default_protocols' => 'https', // defaults to 'http'
+        'default_protocol' => 'https', // defaults to 'http'
     ],
 ];
 


### PR DESCRIPTION
The current docs result in an error:
```
[League\Config\Exception\ValidationException] Unexpected item 'autolink › default_protocols', did you mean 'default_protocol'? 
```

