### PR TITLE
Make it possible to add extension from the CommonMarkConverter class

### DIFF
--- a/src/CommonMarkConverter.php
+++ b/src/CommonMarkConverter.php
@@ -18,6 +18,7 @@ namespace League\CommonMark;
 
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\ExtensionInterface;
 
 /**
  * Converts CommonMark-compatible Markdown to HTML.
@@ -42,5 +43,10 @@ final class CommonMarkConverter extends MarkdownConverter
         \assert($this->environment instanceof Environment);
 
         return $this->environment;
+    }
+
+    public function addExtension(ExtensionInterface $extension): void
+    {
+        $this->environment->addExtension($extension);
     }
 }

--- a/tests/unit/CommonMarkConverterTest.php
+++ b/tests/unit/CommonMarkConverterTest.php
@@ -20,6 +20,7 @@ use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Exception\UnexpectedEncodingException;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\Util\HtmlFilter;
 use PHPUnit\Framework\TestCase;
 
@@ -69,5 +70,19 @@ final class CommonMarkConverterTest extends TestCase
         $converter = new CommonMarkConverter();
 
         $this->assertInstanceOf(Environment::class, $converter->getEnvironment());
+    }
+
+    public function testAddExtensionToEnvironment(): void
+    {
+        $converter = new CommonMarkConverter();
+
+        $environment = $converter->getEnvironment();
+
+        $this->assertCount(1, $environment->getExtensions());
+        $this->assertInstanceOf(CommonMarkCoreExtension::class, $environment->getExtensions()[0]);
+
+        $environment->addExtension(new TableExtension());
+        $this->assertCount(2, $environment->getExtensions());
+        $this->assertInstanceOf(TableExtension::class, $environment->getExtensions()[1]);
     }
 }


### PR DESCRIPTION
In my use-case, the application is using CommonMark in a non-usual way, and I just need to add extensions to it **and** append configuration to the Environment (it's in a Symfony context).

However, considering the current architecture, there are only two possibilities for the package in Symfony DI's setup:

* Use the `LeagueCommonMarkConverterFactory` from TwigExtraBundle. You can add extensions (they're injected in the constructor, and services can just be tagged, but you cannot add any configuration to the `array $config` constructor parameter.
* Create a standard DI's `Definition` with any DI way (I'm using Yaml, but all other formats are concerned). This allows adding custom configuration to the constructor. But to add extensions, you have to call `$converter->getEnvironment()->addExtension()`, which is not possible with Symfony's DI.

For now, there is no way to do it, either from TwigExtra or from CommonMark itself.

I will also make a PR on TwigExtra to allow better customization of the factory itself, for more flexibility