### PR TITLE
Remove redundant code

### DIFF
--- a/src/Extension/Strikethrough/StrikethroughDelimiterProcessor.php
+++ b/src/Extension/Strikethrough/StrikethroughDelimiterProcessor.php
@@ -44,7 +44,7 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
             return 0;
         }
 
-        return \min($opener->getLength(), $closer->getLength());
+        return $opener->getLength();
     }
 
     public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse): void

--- a/src/Extension/Strikethrough/StrikethroughDelimiterProcessor.php
+++ b/src/Extension/Strikethrough/StrikethroughDelimiterProcessor.php
@@ -44,6 +44,7 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
             return 0;
         }
 
+        // $opener and $closer are the same length so we just return one of them
         return $opener->getLength();
     }
 


### PR DESCRIPTION
This PR removes a call to `min()` for two values that by virtue of the previous if statement must already be exactly identical. As they are always the same we can remove both the call to `min()` and one of the two `->getLength()` calls.