### PR TITLE
Add missing newline in Front Matter documentation example

### DIFF
--- a/docs/2.0/extensions/front-matter.md
+++ b/docs/2.0/extensions/front-matter.md
@@ -67,7 +67,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 

--- a/docs/2.1/extensions/front-matter.md
+++ b/docs/2.1/extensions/front-matter.md
@@ -67,7 +67,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 

--- a/docs/2.2/extensions/front-matter.md
+++ b/docs/2.2/extensions/front-matter.md
@@ -67,7 +67,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 

--- a/docs/2.3/extensions/front-matter.md
+++ b/docs/2.3/extensions/front-matter.md
@@ -67,7 +67,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 

--- a/docs/2.4/extensions/front-matter.md
+++ b/docs/2.4/extensions/front-matter.md
@@ -67,7 +67,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 

--- a/docs/2.5/extensions/front-matter.md
+++ b/docs/2.5/extensions/front-matter.md
@@ -67,7 +67,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 

--- a/docs/2.6/extensions/front-matter.md
+++ b/docs/2.6/extensions/front-matter.md
@@ -68,7 +68,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 


### PR DESCRIPTION
There's a missing newline between imports in one of the documentation examples for the Front Matter extension that affects its readability.