### PR TITLE
docs/2.6/extensions/front-matter.md: add missing newline

### DIFF
--- a/docs/2.6/extensions/front-matter.md
+++ b/docs/2.6/extensions/front-matter.md
@@ -68,7 +68,8 @@ Configure your `Environment` as usual and add the `FrontMatterExtension`:
 
 ```php
 use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\MarkdownConverter;
 


### PR DESCRIPTION
In docs/2.6/extensions/front-matter.md, add a missing newline so that `use` statements are on individual lines
