### PR TITLE
Update HeadingPermalinkRenderer.php

### DIFF
--- a/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
@@ -50,8 +50,10 @@ final class HeadingPermalinkRenderer implements NodeRendererInterface, XmlNodeRe
         $slug = $node->getSlug();
 
         $fragmentPrefix = (string) $this->config->get('heading_permalink/fragment_prefix');
+		$slugDelimiter  = (string) $this->config->get('slug_normalizer/delimiter');
+
         if ($fragmentPrefix !== '') {
-            $fragmentPrefix .= '-';
+            $fragmentPrefix .= $slugDelimiter;
         }
 
         $attrs    = $node->data->getData('attributes');
@@ -61,7 +63,7 @@ final class HeadingPermalinkRenderer implements NodeRendererInterface, XmlNodeRe
             $idPrefix = (string) $this->config->get('heading_permalink/id_prefix');
 
             if ($idPrefix !== '') {
-                $idPrefix .= '-';
+                $idPrefix .= $slugDelimiter;
             }
 
             $attrs->set('id', $idPrefix . $slug);


### PR DESCRIPTION
Added slug delimiter config. I needed slugs to use underscores instead of dashes. I could have extended the SlugNormalizer to do a str_replace as a quick solution for my needs, but the class is final. The library could use this option. (I edited the files in the browser, hence the patches rather than a single pull request. I hope it is going to be useful to somebody.)