### PR TITLE
Update Environment.php

### DIFF
--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -442,6 +442,7 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
                 'instance' => Expect::type(TextNormalizerInterface::class)->default(new SlugNormalizer()),
                 'max_length' => Expect::int()->min(0)->default(255),
                 'unique' => Expect::anyOf(UniqueSlugNormalizerInterface::DISABLED, UniqueSlugNormalizerInterface::PER_ENVIRONMENT, UniqueSlugNormalizerInterface::PER_DOCUMENT)->default(UniqueSlugNormalizerInterface::PER_DOCUMENT),
+	            'delimiter' => Expect::string()->default('-')
             ]),
         ]);
     }


### PR DESCRIPTION
Added slug delimiter config. I needed slugs to use underscores instead of dashes. I could have extended the SlugNormalizer to do a str_replace as a quick solution for my needs, but the class is final. The library could use this option. (I edited the files in the browser, hence the patches rather than a single pull request. I hope it is going to be useful to somebody.)