### PR TITLE
Update HeadingPermalinkProcessor.php

### DIFF
--- a/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkProcessor.php
@@ -52,10 +52,11 @@ final class HeadingPermalinkProcessor implements EnvironmentAwareInterface
         $applyToHeading = (bool) $this->config->get('heading_permalink/apply_id_to_heading');
         $idPrefix       = (string) $this->config->get('heading_permalink/id_prefix');
         $slugLength     = (int) $this->config->get('slug_normalizer/max_length');
+        $slugDelimiter  = (string) $this->config->get('slug_normalizer/delimiter');
         $headingClass   = (string) $this->config->get('heading_permalink/heading_class');
 
         if ($idPrefix !== '') {
-            $idPrefix .= '-';
+            $idPrefix .= $slugDelimiter;
         }
 
         foreach ($e->getDocument()->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {


### PR DESCRIPTION
Added slug delimiter config. I needed slugs to use underscores instead of dashes. I could have extended the SlugNormalizer to do a str_replace as a quick solution for my needs, but the class is final. The library could use this option. (I edited the files in the browser, hence the patches rather than a single pull request. I hope it is going to be useful to somebody.)