### PR TITLE
case insensitive for HTML attributes

### DIFF
--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -42,7 +42,7 @@ final class RegexHelper
     public const PARTIAL_IN_PARENS_NOSP        = '\((' . self::PARTIAL_REG_CHAR . '|' . self::PARTIAL_ESCAPED_CHAR . '|\\\\)*\)';
     public const PARTIAL_TAGNAME               = '[a-z][a-z0-9-]*';
     public const PARTIAL_BLOCKTAGNAME          = '(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)';
-    public const PARTIAL_ATTRIBUTENAME         = '[a-z_:][a-z0-9:._-]*';
+    public const PARTIAL_ATTRIBUTENAME         = '[A-Za-z_:][A-Za-z0-9:._-]*';
     public const PARTIAL_UNQUOTEDVALUE         = '[^"\'=<>`\x00-\x20]+';
     public const PARTIAL_SINGLEQUOTEDVALUE     = '\'[^\']*\'';
     public const PARTIAL_DOUBLEQUOTEDVALUE     = '"[^"]*"';

--- a/tests/functional/data/raw_html_uppercase_attributes.html
+++ b/tests/functional/data/raw_html_uppercase_attributes.html
@@ -1,0 +1,1 @@
+<p>Icon: <svg viewBox="0 0 4 4"><path d="M0 0h4v4z"/></svg> end.</p>

--- a/tests/functional/data/raw_html_uppercase_attributes.md
+++ b/tests/functional/data/raw_html_uppercase_attributes.md
@@ -1,0 +1,1 @@
+Icon: <svg viewBox="0 0 4 4"><path d="M0 0h4v4z"/></svg> end.

--- a/tests/unit/Util/RegexHelperTest.php
+++ b/tests/unit/Util/RegexHelperTest.php
@@ -110,6 +110,7 @@ final class RegexHelperTest extends TestCase
         $this->assertRegexMatches($regex, 'href');
         $this->assertRegexMatches($regex, 'class');
         $this->assertRegexMatches($regex, 'data-src');
+        $this->assertRegexMatches($regex, 'viewBox');
         $this->assertRegexDoesNotMatch($regex, '-key');
     }
 
@@ -177,6 +178,7 @@ final class RegexHelperTest extends TestCase
         $this->assertRegexMatches($regex, '<hr>');
         $this->assertRegexMatches($regex, '<a href="http://www.google.com">');
         $this->assertRegexMatches($regex, '<img src="http://www.google.com/logo.png" />');
+        $this->assertRegexMatches($regex, '<svg viewBox="0 0 4 4">');
         $this->assertRegexDoesNotMatch($regex, '</p>');
     }
 


### PR DESCRIPTION
The HTML parser treated attribute names in a case-sensitive manner, which is not compliant with the HTML specifications.

This behavior caused incorrect escaping of tags containing attributes with uppercase letters, such as the `viewBox` attribute in SVG tags.

This change updates the `PARTIAL_ATTRIBUTENAME` regular expression to accept both uppercase and lowercase letters, ensuring that HTML attributes are correctly recognized regardless of their case.