### PR TITLE
[Docs] Fix "rendering" page rendering

### DIFF
--- a/docs/2.x/customization/rendering.md
+++ b/docs/2.x/customization/rendering.md
@@ -12,8 +12,8 @@ redirect_from:
   - /2.5/customization/rendering/
   - /2.6/customization/rendering/
   - /2.7/customization/rendering/
-- /customization/block-rendering/
-- /customization/inline-rendering/
+  - /customization/block-rendering/
+  - /customization/inline-rendering/
 ---
 
 # Custom Rendering


### PR DESCRIPTION
https://commonmark.thephpleague.com/2.x/customization/rendering/ is broken:
<img width="1285" height="799" alt="image" src="https://github.com/user-attachments/assets/d1270ad0-9467-44e7-9efc-d8105e2f9385" />

due to Yaml syntax issue I believe: 
<img width="1800" height="853" alt="Capture d’écran 2025-12-29 à 09 37 49" src="https://github.com/user-attachments/assets/58841698-b575-42a2-84ad-4e8c9f031db4" />
