### PR TITLE
Fix PHP 8.5 deprecation

### DIFF
--- a/src/Util/UrlEncoder.php
+++ b/src/Util/UrlEncoder.php
@@ -56,7 +56,7 @@ final class UrlEncoder
                 }
             }
 
-            if (\ord($code) < 128) {
+            if (\strlen($code) === 1 && \ord($code) < 128) {
                 $result .= self::ENCODE_CACHE[\ord($code)];
                 continue;
             }


### PR DESCRIPTION
Passing strings of more than one byte to ord() is deprecated in PHP 8.5. This change ensures that ord() is only called if the string is one byte.

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
