### PR TITLE
Fix boolean default value in tag method

### DIFF
--- a/src/Xml/XmlRenderer.php
+++ b/src/Xml/XmlRenderer.php
@@ -79,7 +79,7 @@ final class XmlRenderer implements DocumentRendererInterface
     /**
      * @param array<string, string|int|float|bool> $attrs
      */
-    private static function tag(string $name, array $attrs = [], bool $selfClosing = \false): string
+    private static function tag(string $name, array $attrs = [], bool $selfClosing = false): string
     {
         $result = '<' . $name;
         foreach ($attrs as $key => $value) {


### PR DESCRIPTION
It's not technically wrong but it's different then in other parts of the code and some parsers struggle with it.

<!-- Please read our contributing guide before opening a new PR: https://github.com/thephpleague/commonmark/blob/main/.github/CONTRIBUTING.md -->

<!--
Replace this section with a short README for your feature/bugfix. This will help people understand your PR.

Additionally:
 - Always add tests and ensure they pass.
 - Avoid breaking backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches will be merged to upper ones so they get the fixes too.)
 - New features and deprecations must be submitted against the "main" branch
-->
