### PR TITLE
Fix the Markdownlint CI job (super-linter v7 configuration)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,6 +136,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0 # super-linter needs the full git history
 
             - uses: github/super-linter/slim@v7
               env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,6 @@ jobs:
 
             - uses: github/super-linter/slim@v7
               env:
-                  DEFAULT_BRANCH: main
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   LINTER_RULES_PATH: '.' # From https://github.com/github/super-linter/pull/859#issuecomment-709625090
                   VALIDATE_MARKDOWN: true


### PR DESCRIPTION
## Problem

The `Markdownlint` CI job has failed on every run since [`0259ca2`](https://github.com/thephpleague/commonmark/commit/0259ca24) ("Update github/super-linter action to v7", 2026-04-27). markdownlint itself never ran — super-linter aborted during initialization. Two separate configuration problems, both of which v6 tolerated and v7 treats as fatal:

**1. `DEFAULT_BRANCH` pointed at the wrong branch**

```
[INFO]  The default branch for this repository is set to: main
[FATAL] Neither main, nor origin/main exist in /github/workspace
```

The job hardcoded `DEFAULT_BRANCH: main`. This repo does have a `main` branch, but it isn't the default branch (`2.8` is), and it isn't fetched into the workspace. super-linter diffs against `DEFAULT_BRANCH` to decide which files to lint, so this was also pointing it at the wrong lineage. Their docs say not to set this on GitHub Actions "unless you want to compare changes against a branch that's not the GitHub repository default branch" — we don't, so the override is removed and the real default (`2.8`) is auto-detected.

**2. The shallow checkout hid the commit under test**

With the branch resolved, super-linter then failed on:

```
[FATAL] The GITHUB_SHA reference (e6dc715) doesn't exist in this Git repository
```

`actions/checkout` defaults to a shallow clone, but super-linter "needs the full git history to get the list of files that changed across commits". Setting `fetch-depth: 0` resolves it.

## Result

Markdownlint now actually runs and passes: `--> Linted: MARKDOWN: pass`.

No lint rules, linter versions, or documentation content were changed — this is purely CI configuration. `github/super-linter/slim@v7` stays on the floating tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)