### PR TITLE
Add opt-in literal default attribute strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Added
+- Added a `default_attributes_literal_strings` option to treat callable strings and string arrays as literal values in the `DefaultAttributesExtension`
+
 ## [2.8.3] - 2026-07-12
 
 ### Fixed

--- a/docs/2.x/extensions/default-attributes.md
+++ b/docs/2.x/extensions/default-attributes.md
@@ -49,6 +49,7 @@ use League\CommonMark\Node\Block\Paragraph;
 // Extension defaults are shown below
 // If you're happy with the defaults, feel free to remove them from this array
 $config = [
+    'default_attributes_literal_strings' => false,
     'default_attributes' => [
         Heading::class => [
             'class' => static function (Heading $node) {
@@ -93,7 +94,11 @@ Attribute values may be any of the following types:
 - `string`
 - `string[]`
 - `bool`
-- `callable` (parameter is the `Node`, return value may be `string|string[]|bool`)
+- `callable` (parameter is the `Node`, return value may be `string|string[]|bool|null`)
+
+For backwards compatibility, strings and string arrays that PHP considers callable are invoked by default. Set `default_attributes_literal_strings` to `true` to always treat those values as literal attributes. Other callable types, such as closures and invokable objects, remain callable.
+
+When literal string values are enabled, wrap named function or method callbacks with `\Closure::fromCallable()`.
 
 ## Examples
 

--- a/src/Extension/DefaultAttributes/ApplyDefaultAttributesProcessor.php
+++ b/src/Extension/DefaultAttributes/ApplyDefaultAttributesProcessor.php
@@ -26,6 +26,7 @@ final class ApplyDefaultAttributesProcessor implements ConfigurationAwareInterfa
     {
         /** @var array<string, array<string, mixed>> $map */
         $map = $this->config->get('default_attributes');
+        $literalStrings = $this->config->get('default_attributes_literal_strings');
 
         // Don't bother iterating if no default attributes are configured
         if (! $map) {
@@ -40,7 +41,7 @@ final class ApplyDefaultAttributesProcessor implements ConfigurationAwareInterfa
 
             $newAttributes = [];
             foreach ($attributesToApply as $name => $value) {
-                if (\is_callable($value)) {
+                if ((! $literalStrings || ! self::isStringValue($value)) && \is_callable($value)) {
                     $value = $value($node);
                     // Callables are allowed to return `null` indicating that no changes should be made
                     if ($value !== null) {
@@ -61,5 +62,27 @@ final class ApplyDefaultAttributesProcessor implements ConfigurationAwareInterfa
     public function setConfiguration(ConfigurationInterface $configuration): void
     {
         $this->config = $configuration;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function isStringValue($value): bool
+    {
+        if (\is_string($value)) {
+            return true;
+        }
+
+        if (! \is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $item) {
+            if (! \is_string($item)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Extension/DefaultAttributes/DefaultAttributesExtension.php
+++ b/src/Extension/DefaultAttributes/DefaultAttributesExtension.php
@@ -23,6 +23,7 @@ final class DefaultAttributesExtension implements ConfigurableExtensionInterface
 {
     public function configureSchema(ConfigurationBuilderInterface $builder): void
     {
+        $builder->addSchema('default_attributes_literal_strings', Expect::bool()->default(false));
         $builder->addSchema('default_attributes', Expect::arrayOf(
             Expect::arrayOf(
                 Expect::type('string|string[]|bool|callable'), // attribute value(s)

--- a/tests/functional/Extension/DefaultAttributes/DefaultAttributesExtensionTest.php
+++ b/tests/functional/Extension/DefaultAttributes/DefaultAttributesExtensionTest.php
@@ -23,6 +23,7 @@ use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 use League\CommonMark\Node\Block\Paragraph;
+use League\CommonMark\Node\Node;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -85,8 +86,59 @@ HTML,
         ];
 
         yield [
+            '[Example](https://example.com)',
+            [
+                'default_attributes_literal_strings' => true,
+                'default_attributes' => [
+                    Link::class => [
+                        'class' => 'link',
+                    ],
+                ],
+            ],
+            '<p><a class="link" href="https://example.com">Example</a></p>',
+        ];
+
+        yield [
+            '[Example](https://example.com)',
+            [
+                'default_attributes' => [
+                    Link::class => [
+                        'class' => self::class . '::provideAttributeClass',
+                    ],
+                ],
+            ],
+            '<p><a class="callback-link" href="https://example.com">Example</a></p>',
+        ];
+
+        yield [
+            '[Example](https://example.com)',
+            [
+                'default_attributes' => [
+                    Link::class => [
+                        'class' => [self::class, 'provideAttributeClass'],
+                    ],
+                ],
+            ],
+            '<p><a class="callback-link" href="https://example.com">Example</a></p>',
+        ];
+
+        yield [
+            '[Example](https://example.com)',
+            [
+                'default_attributes_literal_strings' => true,
+                'default_attributes' => [
+                    Link::class => [
+                        'class' => [self::class, 'provideAttributeClass'],
+                    ],
+                ],
+            ],
+            '<p><a class="' . self::class . ' provideAttributeClass" href="https://example.com">Example</a></p>',
+        ];
+
+        yield [
             $markdown,
             [
+                'default_attributes_literal_strings' => true,
                 'default_attributes' => [
                     Paragraph::class => [
                         'class' => ['text-center', 'font-comic-sans'],
@@ -189,5 +241,12 @@ MD
 </table>
 HTML,
         ];
+    }
+
+    public static function provideAttributeClass(Node $node): string
+    {
+        self::assertInstanceOf(Link::class, $node);
+
+        return 'callback-link';
     }
 }


### PR DESCRIPTION
## Summary

- add a `default_attributes_literal_strings` option for treating callable strings and string arrays as literal attribute values
- preserve existing string and array callback behavior by default for backwards compatibility
- keep closures and other non-string callable types working when the option is enabled
- document the option, callable return values, and named callback wrapping

## Testing

- focused DefaultAttributes tests: 8 tests, 10 assertions
- full PHPUnit suite: 4,184 tests, 5,168 assertions
- pathological suite: 44 cases
- targeted PHPStan analysis: no errors
- PHP syntax and `git diff --check`

Closes #1123