### PR TITLE
Repair skipped heading levels in NormalizeHeadingsExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 ### Added
 
 - Added a new `NormalizeHeadingsExtension` to constrain headings to a configured level range (#989)
+    - Rewrites headings that skip levels so the resulting HTML is valid (#1115)
+    - `normalize_headings/rebase_to_min_level` - rebases each document so its headings begin at `min_level`
 - Added a new `footnote/enable_inline_footnotes` config option to disable the inline `^[Footnote text]` syntax (#1112)
 
 ## [2.8.2] - 2026-03-19

--- a/docs/2.x/extensions/normalize-headings.md
+++ b/docs/2.x/extensions/normalize-headings.md
@@ -8,12 +8,20 @@ redirect_from:
 
 # Normalize Headings Extension
 
-This extension lets you constrain heading levels to a configured range.
+This extension rewrites the heading levels in your document so that the resulting HTML is valid and
+sits wherever you need it to.
 
-For example, if you configure the allowed levels as `2` through `4`:
+It always repairs headings which skip a level - an `<h1>` followed by an `<h3>` is invalid HTML, and
+becomes an `<h1>` followed by an `<h2>`. Documents whose headings are already valid are left alone.
+
+It can also constrain headings to a configured range of levels. For example, if you configure the
+allowed levels as `2` through `4`:
 
 - `#` headings (`<h1>`) will be converted to `<h2>`
 - `#####` and `######` headings (`<h5>` / `<h6>`) will be converted to `<h4>`
+
+And it can optionally rebase each document so that its headings always begin at that lowest level,
+regardless of which level the author started at.
 
 ## Installation
 
@@ -41,6 +49,7 @@ $config = [
     'normalize_headings' => [
         'min_level' => 1,
         'max_level' => 6,
+        'rebase_to_min_level' => false,
     ],
 ];
 
@@ -56,16 +65,72 @@ $converter = new MarkdownConverter($environment);
 echo $converter->convert("# Heading 1\n\n## Heading 2");
 ```
 
+## Repairing Skipped Levels
+
+The [W3C validator](https://validator.w3.org/) reports an error when a heading descends by more than one
+level at a time - an `<h1>` may be followed by an `<h2>`, but not by an `<h3>`. (Ascending by any amount
+is fine.)
+
+This extension always rewrites headings so that each one descends at most one level below the heading
+it's nested under. A heading's new level is based on how deeply it's nested, so headings which were
+siblings in the original document remain siblings:
+
+```markdown
+# Header 1
+
+#### Header 4a
+
+#### Header 4b
+
+# Header 1a
+
+### Header 3
+```
+
+produces `<h1>`, `<h2>`, `<h2>`, `<h1>`, `<h2>`.
+
+Documents whose headings are already valid come out unchanged.
+
 ## Configuration
 
-This extension can be configured by providing a `normalize_headings` array with two nested options.
+This extension can be configured by providing a `normalize_headings` array with three nested options.
 
 ### `min_level` and `max_level`
 
 These two settings control the allowed heading range. By default, all six levels (`1` to `6`) are allowed.
 The `min_level` value must be less than or equal to `max_level`.
 
-When a parsed heading level falls outside the configured range, it is converted to the nearest boundary:
+When a heading falls outside the configured range, it is converted to the nearest boundary:
 
 - below `min_level` -> `min_level`
 - above `max_level` -> `max_level`
+
+Setting `min_level` and `max_level` to the same value will therefore flatten every heading to that level.
+
+### `rebase_to_min_level`
+
+By default, top-level headings keep the level they were written at, so a document which deliberately
+starts at `<h3>` stays there and only its skipped levels are repaired. This respects an author who starts
+at `<h2>` because the surrounding page template already provides the `<h1>`.
+
+When `rebase_to_min_level` is enabled, top-level headings are moved to `min_level` instead, so that every
+document begins at a known level regardless of how it was written. Consider a document which starts at
+`<h3>`:
+
+```markdown
+### Introduction
+
+##### A Nested Heading
+
+### Conclusion
+```
+
+With the default `min_level` of `1`:
+
+| `rebase_to_min_level` | Output |
+| --------------------- | ------ |
+| `false` (default) | `<h3>`, `<h4>`, `<h3>` |
+| `true` | `<h1>`, `<h2>`, `<h1>` |
+
+This works in both directions: with a `min_level` of `2`, a document starting at `<h1>` would be moved
+*down* so that its top-level headings become `<h2>`.

--- a/docs/2.x/extensions/normalize-headings.md
+++ b/docs/2.x/extensions/normalize-headings.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Normalize Headings Extension
-description: The NormalizeHeadingsExtension constrains heading levels to a configured range
+description: The NormalizeHeadingsExtension rewrites heading levels to produce a valid outline within a configured range
 redirect_from:
   - /extensions/normalize-headings/
 ---

--- a/docs/2.x/extensions/overview.md
+++ b/docs/2.x/extensions/overview.md
@@ -41,7 +41,7 @@ to enhance your experience out-of-the-box depending on your specific use-cases.
 | [Highlight] | Mark text as being highlighted for reference or notation purposes | `2.8.0` | |
 | [Inlines Only] | Only includes standard CommonMark inline elements - perfect for handling comments and other short bits of text where you only want bold, italic, links, etc. | `1.3.0` | |
 | [Mentions] | Easy parsing of `@mention` and `#123`-style references | `1.5.0` | |
-| [Normalize Headings] | Constrains heading levels to a configured min/max range | `2.9.0` | |
+| [Normalize Headings] | Rewrites heading levels to produce a valid outline within a configured min/max range | `2.9.0` | |
 | [Strikethrough] | Allows using tilde characters (`~~`) for ~strikethrough~ formatting | `1.3.0`  | <i class="fab fa-github"></i> |
 | [Tables] | Enables you to create HTML tables | `1.3.0`  | <i class="fab fa-github"></i> |
 | [Table of Contents] | Automatically inserts links to the headings at the top of your document | `1.4.0` | |

--- a/src/Extension/NormalizeHeadings/NormalizeHeadingsExtension.php
+++ b/src/Extension/NormalizeHeadings/NormalizeHeadingsExtension.php
@@ -26,6 +26,7 @@ final class NormalizeHeadingsExtension implements ConfigurableExtensionInterface
         $builder->addSchema('normalize_headings', Expect::structure([
             'min_level' => Expect::int()->min(1)->max(6)->default(1),
             'max_level' => Expect::int()->min(1)->max(6)->default(6),
+            'rebase_to_min_level' => Expect::bool()->default(false),
         ])->assert(
             static function (\stdClass $config): bool {
                 $headingLevels = (array) $config;

--- a/src/Extension/NormalizeHeadings/NormalizeHeadingsProcessor.php
+++ b/src/Extension/NormalizeHeadings/NormalizeHeadingsProcessor.php
@@ -61,8 +61,8 @@ final class NormalizeHeadingsProcessor implements EnvironmentAwareInterface
             if ($parent === false) {
                 $newLevel = $rebaseToMinLevel ? $minLevel : self::clamp($level, $minLevel, $maxLevel);
             } else {
-                // The original level always exceeds the parent's original level, which in turn is never
-                // shallower than the parent's new level, so descending by one is always allowed here
+                // Place this heading exactly one level below its parent, regardless of the level it was
+                // written at - unless that would exceed the maximum, in which case it becomes a sibling
                 $newLevel = \min($parent['output'] + 1, $maxLevel);
             }
 

--- a/src/Extension/NormalizeHeadings/NormalizeHeadingsProcessor.php
+++ b/src/Extension/NormalizeHeadings/NormalizeHeadingsProcessor.php
@@ -32,19 +32,47 @@ final class NormalizeHeadingsProcessor implements EnvironmentAwareInterface
 
     public function __invoke(DocumentParsedEvent $event): void
     {
-        $minLevel = (int) $this->config->get('normalize_headings/min_level');
-        $maxLevel = (int) $this->config->get('normalize_headings/max_level');
+        $minLevel         = (int) $this->config->get('normalize_headings/min_level');
+        $maxLevel         = (int) $this->config->get('normalize_headings/max_level');
+        $rebaseToMinLevel = (bool) $this->config->get('normalize_headings/rebase_to_min_level');
+
+        /**
+         * The headings the current one is nested within, tracked by both their original level (which
+         * determines that nesting) and their new level (which limits how far the current one may descend)
+         *
+         * @var array<int, array{original: int, output: int}> $ancestors
+         */
+        $ancestors = [];
 
         foreach ($event->getDocument()->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
             if (! $node instanceof Heading) {
                 continue;
             }
 
-            if ($node->getLevel() < $minLevel) {
-                $node->setLevel($minLevel);
-            } elseif ($node->getLevel() > $maxLevel) {
-                $node->setLevel($maxLevel);
+            $level = $node->getLevel();
+
+            // Pop any headings this one isn't nested within - they're siblings or cousins, not ancestors
+            $parent = \end($ancestors);
+            while ($parent !== false && $level <= $parent['original']) {
+                \array_pop($ancestors);
+                $parent = \end($ancestors);
             }
+
+            if ($parent === false) {
+                $newLevel = $rebaseToMinLevel ? $minLevel : self::clamp($level, $minLevel, $maxLevel);
+            } else {
+                // The original level always exceeds the parent's original level, which in turn is never
+                // shallower than the parent's new level, so descending by one is always allowed here
+                $newLevel = \min($parent['output'] + 1, $maxLevel);
+            }
+
+            $node->setLevel($newLevel);
+            $ancestors[] = ['original' => $level, 'output' => $newLevel];
         }
+    }
+
+    private static function clamp(int $level, int $minLevel, int $maxLevel): int
+    {
+        return \max($minLevel, \min($level, $maxLevel));
     }
 }

--- a/tests/functional/Extension/NormalizeHeadings/md/clamps-levels.html
+++ b/tests/functional/Extension/NormalizeHeadings/md/clamps-levels.html
@@ -1,6 +1,6 @@
 <h2>Level 1</h2>
-<h2>Level 2</h2>
-<h3>Level 3</h3>
+<h3>Level 2</h3>
+<h4>Level 3</h4>
 <h4>Level 4</h4>
 <h4>Level 5</h4>
 <h4>Level 6</h4>

--- a/tests/functional/Extension/NormalizeHeadings/md/clamps-setext-and-atx.html
+++ b/tests/functional/Extension/NormalizeHeadings/md/clamps-setext-and-atx.html
@@ -1,4 +1,4 @@
 <h2>Setext Level 1</h2>
-<h2>Setext Level 2</h2>
+<h3>Setext Level 2</h3>
 <h3>ATX Level 3</h3>
 <h3>ATX Level 4</h3>

--- a/tests/functional/Extension/NormalizeHeadings/md/normalizes-nested-headings.html
+++ b/tests/functional/Extension/NormalizeHeadings/md/normalizes-nested-headings.html
@@ -1,0 +1,10 @@
+<h1>Title</h1>
+<blockquote>
+<h2>Heading Inside a Blockquote</h2>
+</blockquote>
+<ul>
+<li>
+<h2>Heading Inside a List Item</h2>
+</li>
+</ul>
+<h3>Back Outside</h3>

--- a/tests/functional/Extension/NormalizeHeadings/md/normalizes-nested-headings.md
+++ b/tests/functional/Extension/NormalizeHeadings/md/normalizes-nested-headings.md
@@ -1,0 +1,7 @@
+# Title
+
+> #### Heading Inside a Blockquote
+
+- #### Heading Inside a List Item
+
+##### Back Outside

--- a/tests/functional/Extension/NormalizeHeadings/md/rebases-deep-document-to-min-level.html
+++ b/tests/functional/Extension/NormalizeHeadings/md/rebases-deep-document-to-min-level.html
@@ -1,0 +1,3 @@
+<h1>Deepest Heading in This Document</h1>
+<h2>Nested Below It</h2>
+<h1>Back to the Top Level</h1>

--- a/tests/functional/Extension/NormalizeHeadings/md/rebases-deep-document-to-min-level.md
+++ b/tests/functional/Extension/NormalizeHeadings/md/rebases-deep-document-to-min-level.md
@@ -1,0 +1,10 @@
+---
+normalize_headings:
+    rebase_to_min_level: true
+---
+
+### Deepest Heading in This Document
+
+##### Nested Below It
+
+### Back to the Top Level

--- a/tests/functional/Extension/NormalizeHeadings/md/rebases-to-min-level.html
+++ b/tests/functional/Extension/NormalizeHeadings/md/rebases-to-min-level.html
@@ -1,0 +1,4 @@
+<h2>Title</h2>
+<h3>Section</h3>
+<h4>Skipped a level</h4>
+<h3>Another Section</h3>

--- a/tests/functional/Extension/NormalizeHeadings/md/rebases-to-min-level.md
+++ b/tests/functional/Extension/NormalizeHeadings/md/rebases-to-min-level.md
@@ -1,0 +1,13 @@
+---
+normalize_headings:
+    min_level: 2
+    rebase_to_min_level: true
+---
+
+# Title
+
+## Section
+
+#### Skipped a level
+
+## Another Section

--- a/tests/functional/Extension/NormalizeHeadings/md/repairs-skipped-levels.html
+++ b/tests/functional/Extension/NormalizeHeadings/md/repairs-skipped-levels.html
@@ -1,0 +1,6 @@
+<h1>Header 1</h1>
+<h2>Header 4a</h2>
+<h2>Header 4b</h2>
+<h2>Header 4c</h2>
+<h1>Header 1a</h1>
+<h2>Header 3</h2>

--- a/tests/functional/Extension/NormalizeHeadings/md/repairs-skipped-levels.md
+++ b/tests/functional/Extension/NormalizeHeadings/md/repairs-skipped-levels.md
@@ -1,0 +1,11 @@
+# Header 1
+
+#### Header 4a
+
+#### Header 4b
+
+#### Header 4c
+
+# Header 1a
+
+### Header 3

--- a/tests/unit/Extension/NormalizeHeadings/NormalizeHeadingsProcessorTest.php
+++ b/tests/unit/Extension/NormalizeHeadings/NormalizeHeadingsProcessorTest.php
@@ -22,89 +22,117 @@ use League\CommonMark\Extension\NormalizeHeadings\NormalizeHeadingsProcessor;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\NodeIterator;
 use League\Config\Exception\InvalidConfigurationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class NormalizeHeadingsProcessorTest extends TestCase
 {
     /**
+     * @dataProvider provideNormalizationCases
+     *
+     * @param array<string, mixed> $config
+     * @param int[]                $levels
+     * @param int[]                $expected
+     *
      * @throws \PHPUnit\Framework\ExpectationFailedException
      */
-    public function testClampsHeadingLevelsWithinConfiguredRange(): void
+    #[DataProvider('provideNormalizationCases')]
+    public function testNormalization(array $config, array $levels, array $expected): void
     {
-        $processor = new NormalizeHeadingsProcessor();
-        $processor->setEnvironment($this->createEnvironment([
-            'normalize_headings' => [
-                'min_level' => 2,
-                'max_level' => 4,
-            ],
-        ]));
-
-        $document = new Document();
-        foreach ([1, 2, 3, 4, 5, 6] as $level) {
-            $document->appendChild(new Heading($level));
-        }
-
-        $processor(new DocumentParsedEvent($document));
-
-        $levels = [];
-        foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
-            if ($node instanceof Heading) {
-                $levels[] = $node->getLevel();
-            }
-        }
-
-        $this->assertSame([2, 2, 3, 4, 4, 4], $levels);
+        $this->assertSame($expected, $this->process($config, $levels));
     }
 
     /**
-     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @return iterable<string, array{array<string, mixed>, int[], int[]}>
      */
-    public function testLeavesHeadingsUntouchedWithDefaultConfig(): void
+    public static function provideNormalizationCases(): iterable
     {
-        $processor = new NormalizeHeadingsProcessor();
-        $processor->setEnvironment($this->createEnvironment());
+        yield 'skipped levels are repaired, keeping siblings together' => [[], [1, 4, 4, 4, 1, 3], [1, 2, 2, 2, 1, 2]];
 
-        $document = new Document();
-        foreach ([1, 2, 3, 4, 5, 6] as $level) {
-            $document->appendChild(new Heading($level));
-        }
+        yield 'already-valid headings are left alone' => [[], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]];
 
-        $processor(new DocumentParsedEvent($document));
+        yield 'a deep first heading stays where the author put it' => [[], [3, 5], [3, 4]];
 
-        $levels = [];
-        foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
-            if ($node instanceof Heading) {
-                $levels[] = $node->getLevel();
-            }
-        }
+        yield 'headings are clamped to the configured range' => [
+            ['min_level' => 2, 'max_level' => 4],
+            [1, 2, 3, 4, 5, 6],
+            [2, 3, 4, 4, 4, 4],
+        ];
 
-        $this->assertSame([1, 2, 3, 4, 5, 6], $levels);
+        yield 'headings deeper than max_level collapse into siblings' => [
+            ['max_level' => 2],
+            [1, 2, 3, 4],
+            [1, 2, 2, 2],
+        ];
+
+        yield 'an identical min and max flattens every heading' => [
+            ['min_level' => 2, 'max_level' => 2],
+            [1, 2, 3],
+            [2, 2, 2],
+        ];
+
+        yield 'rebasing moves a deep document up to min_level' => [
+            ['rebase_to_min_level' => true],
+            [3, 5],
+            [1, 2],
+        ];
+
+        yield 'rebasing moves a shallow document down to min_level' => [
+            ['min_level' => 2, 'rebase_to_min_level' => true],
+            [1, 2, 3],
+            [2, 3, 4],
+        ];
+
+        yield 'rebasing applies to every top-level heading, not just the first' => [
+            ['rebase_to_min_level' => true],
+            [2, 4, 2],
+            [1, 2, 1],
+        ];
     }
 
     public function testThrowsExceptionWhenMinLevelExceedsMaxLevel(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
-        $processor = new NormalizeHeadingsProcessor();
-        $processor->setEnvironment($this->createEnvironment([
-            'normalize_headings' => [
-                'min_level' => 4,
-                'max_level' => 2,
-            ],
-        ]));
-
-        $document = new Document();
-        $document->appendChild(new Heading(3));
-
-        $processor(new DocumentParsedEvent($document));
+        $this->process(['min_level' => 4, 'max_level' => 2], [3]);
     }
 
     /**
-     * @param array<string, mixed> $values
+     * Runs the processor over a document containing headings of the given levels, returning their new levels
+     *
+     * @param array<string, mixed> $config
+     * @param int[]                $levels
+     *
+     * @return int[]
      */
-    private function createEnvironment(array $values = []): EnvironmentInterface
+    private function process(array $config, array $levels): array
     {
-        $environment = new Environment($values);
+        $processor = new NormalizeHeadingsProcessor();
+        $processor->setEnvironment($this->createEnvironment($config));
+
+        $document = new Document();
+        foreach ($levels as $level) {
+            $document->appendChild(new Heading($level));
+        }
+
+        $processor(new DocumentParsedEvent($document));
+
+        $newLevels = [];
+        foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
+            if ($node instanceof Heading) {
+                $newLevels[] = $node->getLevel();
+            }
+        }
+
+        return $newLevels;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createEnvironment(array $config): EnvironmentInterface
+    {
+        $environment = new Environment($config === [] ? [] : ['normalize_headings' => $config]);
         $environment->addExtension(new NormalizeHeadingsExtension());
 
         return $environment;


### PR DESCRIPTION
Builds on `NormalizeHeadingsExtension` (#1113) so that it always produces a valid heading outline, and adds one new option for controlling where that outline starts.

### Repairing skipped levels

The W3C validator rejects HTML where a heading descends by more than one level at a time — an `<h1>` may be followed by an `<h2>`, but not by an `<h3>`. (Ascending by any amount is fine.) The extension now always rewrites such headings.

A heading's new level is derived from **how deeply it's nested**, not from a running counter, so headings which were siblings in the original document remain siblings. Using the example from #1115:

| Input | Output |
| ----- | ------ |
| `# Header 1` | `<h1>` |
| `#### Header 4a` | `<h2>` |
| `#### Header 4b` | `<h2>` |
| `#### Header 4c` | `<h2>` |
| `# Header 1a` | `<h1>` |
| `### Header 3` | `<h2>` |

This deliberately differs from the algorithm proposed in the issue, which would have renumbered the three sibling `<h4>`s to `<h2>`/`<h3>`/`<h4>` — valid HTML, but it invents a hierarchy the author didn't write.

Documents whose headings are already valid come out unchanged. Top-level headings keep the level they were written at, so a document which deliberately starts at `<h3>` stays there and only its skipped levels are repaired.

This is deliberately *not* behind a config flag. "Clamp the range but leave the invalid skips in place" isn't a use case anyone wants, and the extension's whole purpose is normalization — a zero-config `new NormalizeHeadingsExtension()` should produce valid HTML. If a real need for opting out ever surfaces, adding a flag later is fully backward compatible; removing one wouldn't be.

### `rebase_to_min_level` option (disabled by default)

This additional option moves each document's top-level headings **up** to `min_level`, so that every document begins at a known level regardless of which level its author started at. Useful when generating a table of contents, or anywhere the outline needs to be predictable rather than faithful.

Given a document which starts at `<h3>`:

```markdown
### Introduction

##### A Nested Heading

### Conclusion
```

| `rebase_to_min_level` | Output |
| --------------------- | ------ |
| `false` (default) | `<h3>`, `<h4>`, `<h3>` |
| `true` | `<h1>`, `<h2>`, `<h1>` |

It works in both directions — with `min_level` set to `2`, a document starting at `<h1>` is moved *down* so its top-level headings become `<h2>`.

It's off by default because it's the one decision the library can't make for you. Whether an `<h1>` may be followed by an `<h3>` is a fact about HTML. Where your headings should *start* depends on what surrounds them on the page — an author who begins at `<h2>` because the page template already renders the title as `<h1>` is right to do so, and defaulting this on would silently give them a second `<h1>`.

### Note on the existing clamping behavior

Because skipped levels are now always repaired, clamping re-levels within its range rather than only bounding it. With `min_level: 2`, a document of `# Title` / `## Section` previously rendered as two sibling `<h2>`s; it now renders as `<h2>` / `<h3>`, preserving the distinction. The `NormalizeHeadingsExtension` hasn't been in a tagged release yet, so this only affects behavior added in #1113.

### Also included

- Unit tests covering repair, clamping, `max_level` collapse, flattening (`min_level == max_level`), and rebasing in both directions
- Functional `.md`/`.html` fixtures for each behavior, including one with headings nested inside a blockquote and a list item
- Documentation and changelog entries

Fixes #1115 
Fixes #989 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
