### PR TITLE
Fix typos and broken formatting in the 2.x docs

### DIFF
--- a/docs/2.x/configuration.md
+++ b/docs/2.x/configuration.md
@@ -79,12 +79,12 @@ Here's a list of the core configuration options available:
   - `soft_break` - String to use for rendering soft breaks
 - `html_input` - How to handle HTML input.  Set this option to one of the following strings:
   - `strip` - Strip all HTML (equivalent to `'safe' => true`)
-  - `allow` - Allow all HTML input as-is (default value; equivalent to `'safe' => false)
+  - `allow` - Allow all HTML input as-is (default value; equivalent to `'safe' => false`)
   - `escape` - Escape all HTML
 - `allow_unsafe_links` - Remove risky link and image URLs by setting this to `false` (default: `true`)
 - `max_nesting_level` - The maximum nesting level for blocks (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if blocks are too deeply-nested.
 - `max_delimiters_per_line` - The maximum number of delimiters (e.g. `*` or `_`) allowed in a single line (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if lines are too long.
-- `slug_normalizer` - Array of options for configuring how URL-safe slugs are created; see [the slug normalizer docs](/2.5/customization/slug-normalizer/#configuration) for more details
+- `slug_normalizer` - Array of options for configuring how URL-safe slugs are created; see [the slug normalizer docs](/2.x/customization/slug-normalizer/#configuration) for more details
   - `instance` - An alternative normalizer to use (defaults to the included `SlugNormalizer`)
   - `max_length` - Limits the size of generated slugs (defaults to 255 characters)
   - `unique` - Controls whether slugs should be unique per `'document'` (default) or per `'environment'`; can be disabled with `false`

--- a/docs/2.x/customization/slug-normalizer.md
+++ b/docs/2.x/customization/slug-normalizer.md
@@ -102,7 +102,7 @@ This can be configured to limit the length of that slug to prevent overly-long v
 
 ### `unique`
 
-This options controls whether slugs should be unique.  Possible values include:
+This option controls whether slugs should be unique.  Possible values include:
 
 - `'document'` (string; **default**) - Ensures slugs are unique within a single document
 - `'environment'` (string) - Ensures slugs are unique across multiple documents - see below

--- a/docs/2.x/extensions/embed.md
+++ b/docs/2.x/extensions/embed.md
@@ -93,13 +93,13 @@ By default, this option is an empty array (`[]`), which means that all domains a
 
 ### `fallback` option
 
-This options defines the behavior when a URL cannot be embedded, either because it's not in the list of `allowed_domains`,
+This option defines the behavior when a URL cannot be embedded, either because it's not in the list of `allowed_domains`,
 or because the `adapter` could not find embeddable content for that URL.
 
 There are two possible values for this option:
 
 - `'link'` - the URL will be kept in the document as a link (**default**)
--`'remove'` - the URL will be completely removed from the document
+- `'remove'` - the URL will be completely removed from the document
 
 ## Adapter
 


### PR DESCRIPTION
Just a quick PR to fix some typos in the docs. :)