### PR TITLE
Strengthen unsafe link and image renderer test assertions

### DIFF
--- a/tests/unit/Extension/CommonMark/Renderer/Inline/ImageRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/ImageRendererTest.php
@@ -117,7 +117,7 @@ final class ImageRendererTest extends TestCase
         $result = $this->renderer->render($inline, $fakeRenderer);
 
         $this->assertTrue($result instanceof HtmlElement);
-        $this->assertEquals('', $result->getAttribute('src'));
+        $this->assertSame('', $result->getAttribute('src'));
     }
 
     public function testRenderWithInvalidType(): void

--- a/tests/unit/Extension/CommonMark/Renderer/Inline/LinkRendererTest.php
+++ b/tests/unit/Extension/CommonMark/Renderer/Inline/LinkRendererTest.php
@@ -94,7 +94,8 @@ final class LinkRendererTest extends TestCase
         $result = $this->renderer->render($inline, $fakeRenderer);
 
         $this->assertTrue($result instanceof HtmlElement);
-        $this->assertEquals('', $result->getAttribute('href'));
+        $this->assertNull($result->getAttribute('href'));
+        $this->assertSame('<a></a>', (string) $result);
     }
 
     public function testRenderWithInvalidType(): void


### PR DESCRIPTION
Just a quick PR to make some test assertions stricter and more consistent with sister tests.