### PR TITLE
Fix tab handling in fenced code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Fixed tab-indented fenced code blocks inside list items losing the first character of each line and having their info string mangled (#981, #1130)
+
 ## [2.8.2] - 2026-03-19
 
 This is a **security release** to address an issue where the `allowed_domains` setting for the `Embed` extension can be bypassed, resulting in a possible SSRF and XSS vulnerabilities.

--- a/src/Extension/CommonMark/Parser/Block/FencedCodeParser.php
+++ b/src/Extension/CommonMark/Parser/Block/FencedCodeParser.php
@@ -51,10 +51,11 @@ final class FencedCodeParser extends AbstractBlockContinueParser
             }
         }
 
-        // Skip optional spaces of fence offset
-        // Optimization: don't attempt to match if we're at a non-space position
-        if ($cursor->getNextNonSpacePosition() > $cursor->getPosition()) {
-            $cursor->match('/^ {0,' . $this->block->getOffset() . '}/');
+        // Skip optional spaces of fence offset, counting columns instead of characters
+        // so that tabs are only partially consumed when needed
+        $fenceOffset = $this->block->getOffset();
+        while ($fenceOffset > 0 && $cursor->advanceBySpaceOrTab()) {
+            $fenceOffset--;
         }
 
         return BlockContinue::at($cursor);

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -417,9 +417,23 @@ class Cursor
             $matchLength = \strlen($matches[0][0]);
         }
 
-        // [0][0] contains the matched text
-        // [0][1] contains the index of that match
-        $this->advanceBy($offset + $matchLength);
+        $advance = $offset + $matchLength;
+
+        // The remainder we matched against had any partially-consumed tab expanded into spaces,
+        // so those columns must be advanced by column instead of by character
+        if ($this->partiallyConsumedTab) {
+            $charsToTab = 4 - ($this->column % 4);
+            if ($advance < $charsToTab) {
+                $this->advanceBy($advance, true);
+
+                return $matches[0][0];
+            }
+
+            $this->advanceBy($charsToTab, true);
+            $advance -= $charsToTab;
+        }
+
+        $this->advanceBy($advance);
 
         return $matches[0][0];
     }

--- a/tests/functional/data/fenced_code_tabs.html
+++ b/tests/functional/data/fenced_code_tabs.html
@@ -1,0 +1,19 @@
+<ul>
+<li>
+<p>Something more:</p>
+<pre><code>What's happening?
+</code></pre>
+</li>
+<li>
+<p>With an info string:</p>
+<pre><code class="language-js">console.log(&quot;hi&quot;);
+</code></pre>
+</li>
+<li>
+<p>Extra tabs are preserved:</p>
+<pre><code>	indented
+</code></pre>
+</li>
+</ul>
+<pre><code>   Partially-consumed tab
+</code></pre>

--- a/tests/functional/data/fenced_code_tabs.md
+++ b/tests/functional/data/fenced_code_tabs.md
@@ -1,0 +1,18 @@
+- Something more:
+	```
+	What's happening?
+	```
+
+- With an info string:
+	```js
+	console.log("hi");
+	```
+
+- Extra tabs are preserved:
+	```
+		indented
+	```
+
+ ```
+	Partially-consumed tab
+ ```


### PR DESCRIPTION
Fixes #981.

## The bug

A fenced code block indented with a **tab** inside a list item drops the first character of every line:

```markdown
- Something more:
	```
	What's happening?
	```
```

renders as `<pre><code>hat's happening?` — the `W` is gone. The same bug also mangles the info string (a tab-indented ` ```js ` produces `class="language-s"` and eats a character of the first content line), which appears not to have been noticed before.

## Root cause

The parser tracks *columns*, and a tab may be **partially consumed**: with `- Something more:` the list content begins at column 2, so a leading tab (columns 0–3) is only consumed as far as column 2. The cursor then sits *inside* the tab — `currentPosition` is still 0, `column` is 2, `partiallyConsumedTab` is true.

`Cursor::getRemainder()` represents that state by expanding the tab's remaining columns into spaces (`"  What's happening?"`). But `Cursor::match()` matched the regex against that expanded string and then called `advanceBy($offset + $matchLength)` in **character** mode against the **raw** line. Those expanded spaces don't exist in the raw line, so each one consumed a real character instead.

`FencedCodeParser::tryContinue()` had a second, related defect: it skipped the fence offset with `match('/^ {0,N}/')`, i.e. literal space *characters*. cmark and commonmark.js skip N *columns* of space-or-tab, so a tab could never be partially consumed there and a raw tab leaked into the code block.

## The fix

- `Cursor::match()` now advances through a partially-consumed tab by column before advancing through the remaining characters, restoring the method's documented contract.
- `FencedCodeParser::tryContinue()` now skips up to *fence offset* columns of space-or-tab, matching the reference implementations.

Both changes are necessary: without the first, the info string is still corrupted (`FencedCodeStartParser` calls `match()` independently); without the second, a space-indented fence with tab-indented content still leaks a literal tab.

## Verification

- Full suite passes (4,169 tests, incl. the CommonMark and GFM spec suites).
- New `fenced_code_tabs` local-data fixture, whose expected HTML was generated from the **reference implementation**, not from this parser.
- Differential fuzz over 4,000 generated tab/fence/list/blockquote documents against the reference: mismatches drop from 107 to 29, with **zero regressions** (the 29 remaining are identical before and after — artifacts of the reference port being on an older spec version).
- Re-rendering the entire 122-file test corpus with all extensions enabled changes exactly one file: the new fixture.

## Compatibility & performance

No BC break — Roave's BC checker reports no backwards-incompatible changes, and the only output that changes belongs to documents that were previously rendered incorrectly per the spec. Suitable for a patch release.

Performance improves. The old fence-offset "optimization" built a regex string, ran `preg_match` with `PREG_OFFSET_CAPTURE`, and called `advanceBy(0)` (which invalidates `nextNonSpaceCache`, forcing a re-scan) on every whitespace-leading code line — all to match the empty string and move nothing. Isolated micro-benchmarks of `tryContinue()` show ~604ns vs ~1092ns per call in the most common case, and the new code is faster in every scenario tested, including one built to be worst-case for it. The added branch in `Cursor::match()` is unmeasurable against its `preg_match` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NJyV1J63etrSYGfWRtvph