### PR TITLE
Fix over-blocking of safe URLs by the unsafe link filter

### DIFF
--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -66,7 +66,7 @@ final class RegexHelper
         '|' . '\((' . self::PARTIAL_ESCAPED_CHAR . '|[^()\x00])*+\))';
 
     public const REGEX_PUNCTUATION        = '/^[\p{P}\p{S}]/u';
-    public const REGEX_UNSAFE_PROTOCOL    = '/^javascript:|vbscript:|file:|data:/i';
+    public const REGEX_UNSAFE_PROTOCOL    = '/^(?:javascript|vbscript|file|data):/i';
     public const REGEX_SAFE_DATA_PROTOCOL = '/^data:image\/(?:png|gif|jpeg|webp)/i';
     public const REGEX_NON_SPACE          = '/[^ \t\f\v\r\n]/';
 

--- a/tests/unit/Util/RegexHelperTest.php
+++ b/tests/unit/Util/RegexHelperTest.php
@@ -402,6 +402,38 @@ final class RegexHelperTest extends TestCase
         yield [8];
     }
 
+    /**
+     * @dataProvider dataForTestIsLinkPotentiallyUnsafe
+     */
+    #[DataProvider('dataForTestIsLinkPotentiallyUnsafe')]
+    public function testIsLinkPotentiallyUnsafe(string $url, bool $expected): void
+    {
+        $this->assertSame($expected, RegexHelper::isLinkPotentiallyUnsafe($url));
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public static function dataForTestIsLinkPotentiallyUnsafe(): iterable
+    {
+        return [
+            // Dangerous leading schemes are unsafe
+            ['javascript:alert(1)', true],
+            ['JAVASCRIPT:alert(1)', true],
+            ['vbscript:msgbox(1)', true],
+            ['file:///etc/passwd', true],
+            ['data:text/html,<script>alert(1)</script>', true],
+            ['data:image/svg+xml,<svg onload=alert(1)>', true],
+            // Safe data: images are allowed
+            ['data:image/png;base64,iVBORw0KGgo=', false],
+            // URLs merely containing those schemes elsewhere are safe
+            ['https://example.com/view?src=data:image/png', false],
+            ['https://example.com/download?to=file:report', false],
+            ['https://example.com/wiki/vbscript:_basics', false],
+            ['https://example.com/ok', false],
+        ];
+    }
+
     private function assertRegexMatches(string $pattern, string $string, string $message = ''): void
     {
         if (\method_exists($this, 'assertMatchesRegularExpression')) {


### PR DESCRIPTION
When `allow_unsafe_links` is disabled, the `^` anchor in `REGEX_UNSAFE_PROTOCOL` binds only to the first alternative, so `vbscript:`, `file:`, and `data:` match anywhere in the URL rather than just at the start. Safe links such as https://example.com/view?src=data:image/png are misclassified as unsafe and silently lose their `href/src`.

The first commit adds tests demonstrating the bug and the second applies the one-line fix.

---

The JS implementation has a similar bug: https://github.com/commonmark/commonmark.js/pull/305.