### PR TITLE
Document that `max_delimiters_per_line` does not limit brackets

### DIFF
--- a/docs/2.x/configuration.md
+++ b/docs/2.x/configuration.md
@@ -83,7 +83,7 @@ Here's a list of the core configuration options available:
   - `escape` - Escape all HTML
 - `allow_unsafe_links` - Remove risky link and image URLs by setting this to `false` (default: `true`)
 - `max_nesting_level` - The maximum nesting level for blocks (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if blocks are too deeply-nested.
-- `max_delimiters_per_line` - The maximum number of delimiters (e.g. `*` or `_`) allowed in a single line (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if lines are too long.
+- `max_delimiters_per_line` - The maximum number of delimiters (e.g. `*` or `_`) allowed in a single line (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if lines are too long. Note that this option only applies to emphasis-style delimiters; it does not limit link or image brackets (`[` and `![`).
 - `slug_normalizer` - Array of options for configuring how URL-safe slugs are created; see [the slug normalizer docs](/2.x/customization/slug-normalizer/#configuration) for more details
   - `instance` - An alternative normalizer to use (defaults to the included `SlugNormalizer`)
   - `max_length` - Limits the size of generated slugs (defaults to 255 characters)

--- a/docs/2.x/security.md
+++ b/docs/2.x/security.md
@@ -102,7 +102,7 @@ See the [configuration](/2.x/configuration/) section for more information.
 
 Similarly to the maximum nesting level, **no maximum number of delimiters per line is enforced by default.**  Delimiters can be nested (like `*a **b** c*`) or un-nested (like `*a* *b* *c*`) - in either case, having too many in a single line can result in long parse times. We therefore have a separate option to limit the number of delimiters per line.
 
-If you need to parse untrusted input, consider setting a reasonable `max_delimiters_per_line` (perhaps 100-1000) depending on your needs.  Once this level is hit, any subsequent delimiters on that line will be rendered as plain text.
+If you need to parse untrusted input, consider setting a reasonable `max_delimiters_per_line` (perhaps 100-1000) depending on your needs.  Once this level is hit, any subsequent delimiters on that line will be rendered as plain text.  Note that this option only applies to emphasis-style delimiters; link and image brackets (`[` and `![`) are not limited by it, so consider also enforcing input size or line length limits upstream.
 
 ### Example - Prevent too many delimiters
 

--- a/tests/functional/MaxDelimitersPerLineTest.php
+++ b/tests/functional/MaxDelimitersPerLineTest.php
@@ -48,5 +48,9 @@ final class MaxDelimitersPerLineTest extends TestCase
         yield ['*a* **b *c **d** c* b**', 8, '<p><em>a</em> <strong>b <em>c <strong>d</strong> c</em> b</strong></p>'];
         yield ['*a* **b *c **d** c* b**', 9, '<p><em>a</em> <strong>b <em>c <strong>d</strong> c</em> b</strong></p>'];
         yield ['*a* **b *c **d** c* b**', 100, '<p><em>a</em> <strong>b <em>c <strong>d</strong> c</em> b</strong></p>'];
+
+        // Link and image bracket openers are tracked separately and are not limited by this option
+        yield ['[text](https://example.com)', 0, '<p><a href="https://example.com">text</a></p>'];
+        yield ['![alt](https://example.com/x.png)', 0, '<p><img src="https://example.com/x.png" alt="alt" /></p>'];
     }
 }


### PR DESCRIPTION
`max_delimiters_per_line` bounds emphasis-style delimiters via `DelimiterStack::push()`, but link and image bracket openers go through `addBracket()`, which never consults that budget. I've clarified the option's scope in the configuration and security docs and adds two characterisation cases to `MaxDelimitersPerLineTest` so any future change to bracket budgeting is a deliberate, visible decision.
