### PR TITLE
Declare `MarkDelimiterProcessor` as a cacheable delimiter processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
     - `normalize_headings/rebase_to_min_level` - rebases each document so its headings begin at `min_level`
 - Added a new `footnote/enable_inline_footnotes` config option to disable the inline `^[Footnote text]` syntax (#1112)
 
+### Fixed
+
+- Fixed `MarkDelimiterProcessor` not being declared as a `CacheableDelimiterProcessorInterface`, preventing the delimiter stack from caching the opener search for `==` runs (#1133)
+
 ## [2.8.3] - 2026-07-12
 
 ### Fixed

--- a/src/Extension/Highlight/MarkDelimiterProcessor.php
+++ b/src/Extension/Highlight/MarkDelimiterProcessor.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\Highlight;
 
 use League\CommonMark\Delimiter\DelimiterInterface;
-use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Delimiter\Processor\CacheableDelimiterProcessorInterface;
 use League\CommonMark\Node\Inline\AbstractStringContainer;
 
-class MarkDelimiterProcessor implements DelimiterProcessorInterface
+class MarkDelimiterProcessor implements CacheableDelimiterProcessorInterface
 {
     public function getOpeningCharacter(): string
     {


### PR DESCRIPTION
`MarkDelimiterProcessor` has a dynamic `getDelimiterUse()`, which the `DelimiterProcessorInterface` contract says must be paired with `CacheableDelimiterProcessorInterface`, as the emphasis and strikethrough processors both do. The class already defines a suitable `getCacheKey()`, but without declaring the interface that method was dead code and the delimiter engine's cached opener-search path was never used for `==` runs. This one-line change declares the interface properly.