### PR TITLE
Render the TOC once and share it across placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Added
+- Added a new `table_of_contents/max_placeholder_entries` option to limit how many table of contents entries a document may render across all of its placeholders (#1134)
+
 ### Changed
 - Improved performance of reading single characters from multibyte lines
 - Improved performance of locating the next non-space character on lines without tabs
 - Optimized `Cursor::advanceToNextNonSpaceOrNewline()` to scan the line in place instead of copying everything left in the block on every call
 - Optimized inline link destination parsing to scan the line in place, so its cost follows the length of the destination rather than the length of everything left in the block
+- Changed the `TableOfContents` extension to render the table of contents once and share it across all placeholders instead of cloning it into each one (#1134)
+    - A custom renderer registered for the `TableOfContents` node is no longer called once per placeholder, so it must return the same markup each time it is called for a given document (#1134)
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)

--- a/docs/2.x/extensions/table-of-contents.md
+++ b/docs/2.x/extensions/table-of-contents.md
@@ -53,6 +53,7 @@ $config = [
         'max_heading_level' => 6,
         'normalize' => 'relative',
         'placeholder' => null,
+        'max_placeholder_entries' => null,
     ],
 ];
 
@@ -97,9 +98,19 @@ This `string` controls where in the document your table of contents will be plac
 
 If you'd like to customize this further, you can implement a [custom event listener](/2.x/customization/event-dispatcher/#registering-listeners) to locate the `TableOfContents` node and reposition it somewhere else in the document prior to rendering.
 
+In `'placeholder'` mode the table of contents is rendered once and that result is reused for every placeholder, so a [custom renderer](/2.x/customization/rendering/) for the `TableOfContents` node is not called once per placeholder and must return the same markup each time it is called for a given document.
+
 ### `placeholder`
 
 When combined with `'position' => 'placeholder'`, this setting tells the extension which placeholder content should be replaced with the Table of Contents.  For example, if you set this option to `[TOC]`, then any lines in your document consisting of that `[TOC]` placeholder will be replaced by the Table of Contents. Note that this option has no default value - you must provide this string yourself.
+
+### `max_placeholder_entries`
+
+When combined with `'position' => 'placeholder'`, this option limits how many table of contents entries a single document may render across all of its placeholders.  This defaults to `null`, meaning no limit is applied.  Setting an `int` is recommended when rendering untrusted input, as a document full of placeholders will otherwise repeat the entire table of contents at every one.
+
+The budget is spent in whole copies: placeholders are filled in document order until the next complete table of contents no longer fits, and the rest are left alone (rendering as an HTML comment, just like a placeholder with [no table of contents to insert](#placeholder)).  Nothing is ever truncated, so a limit smaller than a single table of contents renders none at all.
+
+Entries are counted as list items, which equals the number of linked headings under every [normalization strategy](#normalization-strategies) except `'as-is'` - that one adds empty items for skipped heading levels, and those count too.
 
 ### `style`
 

--- a/src/Extension/TableOfContents/Node/TableOfContentsReference.php
+++ b/src/Extension/TableOfContents/Node/TableOfContentsReference.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\TableOfContents\Node;
+
+use League\CommonMark\Extension\TableOfContents\TableOfContentsRenderCache;
+use League\CommonMark\Node\Block\AbstractBlock;
+
+/**
+ * Lightweight stand-in for a placeholder which references the shared table of contents instead of holding a full copy
+ */
+final class TableOfContentsReference extends AbstractBlock
+{
+    /** @psalm-readonly */
+    private TableOfContents $tableOfContents;
+
+    /** @psalm-readonly */
+    private TableOfContentsRenderCache $renderCache;
+
+    public function __construct(TableOfContents $tableOfContents, TableOfContentsRenderCache $renderCache)
+    {
+        parent::__construct();
+
+        $this->tableOfContents = $tableOfContents;
+        $this->renderCache     = $renderCache;
+    }
+
+    public function getTableOfContents(): TableOfContents
+    {
+        return $this->tableOfContents;
+    }
+
+    public function getRenderCache(): TableOfContentsRenderCache
+    {
+        return $this->renderCache;
+    }
+}

--- a/src/Extension/TableOfContents/TableOfContentsBuilder.php
+++ b/src/Extension/TableOfContents/TableOfContentsBuilder.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace League\CommonMark\Extension\TableOfContents;
 
 use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Event\DocumentPreRenderEvent;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalink;
 use League\CommonMark\Extension\TableOfContents\Node\TableOfContents;
 use League\CommonMark\Extension\TableOfContents\Node\TableOfContentsPlaceholder;
+use League\CommonMark\Extension\TableOfContents\Node\TableOfContentsReference;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\NodeIterator;
 use League\Config\ConfigurationAwareInterface;
@@ -89,14 +92,55 @@ final class TableOfContentsBuilder implements ConfigurationAwareInterface
 
     private function replacePlaceholders(Document $document, TableOfContents $toc): void
     {
+        $maxEntries = $this->config->get('table_of_contents/max_placeholder_entries');
+        \assert(\is_int($maxEntries) || $maxEntries === null);
+        $perCopy = $maxEntries === null ? 0 : self::countEntries($toc);
+        $cache   = new TableOfContentsRenderCache();
+        $entries = 0;
+
         foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
             // Add the block once we find a placeholder
             if (! $node instanceof TableOfContentsPlaceholder) {
                 continue;
             }
 
-            $node->replaceWith(clone $toc);
+            // Leave any remaining placeholders as-is once the entry budget is spent
+            if ($maxEntries !== null && $entries + $perCopy > $maxEntries) {
+                continue;
+            }
+
+            $node->replaceWith(new TableOfContentsReference($toc, $cache));
+            $entries += $perCopy;
         }
+    }
+
+    public function onDocumentPreRender(DocumentPreRenderEvent $event): void
+    {
+        // The shared references are an HTML rendering optimization; other formats
+        // (like XML) walk the node tree directly and expect complete copies
+        if ($event->getFormat() === 'html') {
+            return;
+        }
+
+        foreach ($event->getDocument()->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
+            if (! $node instanceof TableOfContentsReference) {
+                continue;
+            }
+
+            $node->replaceWith(clone $node->getTableOfContents());
+        }
+    }
+
+    private static function countEntries(TableOfContents $toc): int
+    {
+        $count = 0;
+        foreach ($toc->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
+            if ($node instanceof ListItem) {
+                $count++;
+            }
+        }
+
+        return $count;
     }
 
     public function setConfiguration(ConfigurationInterface $configuration): void

--- a/src/Extension/TableOfContents/TableOfContentsExtension.php
+++ b/src/Extension/TableOfContents/TableOfContentsExtension.php
@@ -15,11 +15,13 @@ namespace League\CommonMark\Extension\TableOfContents;
 
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Event\DocumentPreRenderEvent;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Extension\CommonMark\Renderer\Block\ListBlockRenderer;
 use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use League\CommonMark\Extension\TableOfContents\Node\TableOfContents;
 use League\CommonMark\Extension\TableOfContents\Node\TableOfContentsPlaceholder;
+use League\CommonMark\Extension\TableOfContents\Node\TableOfContentsReference;
 use League\Config\ConfigurationBuilderInterface;
 use Nette\Schema\Expect;
 
@@ -35,19 +37,26 @@ final class TableOfContentsExtension implements ConfigurableExtensionInterface
             'max_heading_level' => Expect::int()->min(1)->max(6)->default(6),
             'html_class' => Expect::string()->default('table-of-contents'),
             'placeholder' => Expect::anyOf(Expect::string(), Expect::null())->default(null),
+            'max_placeholder_entries' => Expect::anyOf(Expect::int()->min(0), Expect::null())->default(null),
         ]));
     }
 
     public function register(EnvironmentBuilderInterface $environment): void
     {
+        $builder = new TableOfContentsBuilder();
+
         $environment->addRenderer(TableOfContents::class, new TableOfContentsRenderer(new ListBlockRenderer()));
-        $environment->addEventListener(DocumentParsedEvent::class, [new TableOfContentsBuilder(), 'onDocumentParsed'], -150);
+        $environment->addEventListener(DocumentParsedEvent::class, [$builder, 'onDocumentParsed'], -150);
 
         // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
         if ($environment->getConfiguration()->get('table_of_contents/position') === TableOfContentsBuilder::POSITION_PLACEHOLDER) {
             $environment->addBlockStartParser(TableOfContentsPlaceholderParser::blockStartParser(), 200);
             // If a placeholder cannot be replaced with a TOC element this renderer will ensure the parser won't error out
             $environment->addRenderer(TableOfContentsPlaceholder::class, new TableOfContentsPlaceholderRenderer());
+            // Placeholders become lightweight references to a single shared TOC which is only rendered once
+            $environment->addRenderer(TableOfContentsReference::class, new TableOfContentsReferenceRenderer());
+            // Non-HTML formats walk the node tree directly, so expand the references back into complete copies there
+            $environment->addEventListener(DocumentPreRenderEvent::class, [$builder, 'onDocumentPreRender']);
         }
     }
 }

--- a/src/Extension/TableOfContents/TableOfContentsReferenceRenderer.php
+++ b/src/Extension/TableOfContents/TableOfContentsReferenceRenderer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\TableOfContents;
+
+use League\CommonMark\Extension\TableOfContents\Node\TableOfContentsReference;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+
+final class TableOfContentsReferenceRenderer implements NodeRendererInterface
+{
+    /**
+     * @param TableOfContentsReference $node
+     *
+     * {@inheritDoc}
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
+     */
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
+    {
+        TableOfContentsReference::assertInstanceOf($node);
+
+        $cache = $node->getRenderCache();
+
+        $html = $cache->getHtml();
+        if ($html === null) {
+            $html = $childRenderer->renderNodes([$node->getTableOfContents()]);
+            $cache->setHtml($html);
+        }
+
+        return $html;
+    }
+}

--- a/src/Extension/TableOfContents/TableOfContentsRenderCache.php
+++ b/src/Extension/TableOfContents/TableOfContentsRenderCache.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Extension\TableOfContents;
+
+/**
+ * Caches the rendered HTML of a document's table of contents so all placeholders can share a single render
+ *
+ * @internal
+ */
+final class TableOfContentsRenderCache
+{
+    private ?string $html = null;
+
+    public function getHtml(): ?string
+    {
+        return $this->html;
+    }
+
+    public function setHtml(string $html): void
+    {
+        $this->html = $html;
+    }
+}

--- a/tests/functional/Extension/TableOfContents/md/max-placeholder-entries.html
+++ b/tests/functional/Extension/TableOfContents/md/max-placeholder-entries.html
@@ -1,0 +1,12 @@
+<p>This TOC has two entries, so a budget of four covers exactly two of the three placeholders.</p>
+<ul class="table-of-contents">
+<li><a href="#content-alpha">Alpha</a></li>
+<li><a href="#content-bravo">Bravo</a></li>
+</ul>
+<h1><a id="content-alpha" href="#content-alpha" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Alpha</h1>
+<ul class="table-of-contents">
+<li><a href="#content-alpha">Alpha</a></li>
+<li><a href="#content-bravo">Bravo</a></li>
+</ul>
+<h1><a id="content-bravo" href="#content-bravo" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Bravo</h1>
+<!-- table of contents -->

--- a/tests/functional/Extension/TableOfContents/md/max-placeholder-entries.md
+++ b/tests/functional/Extension/TableOfContents/md/max-placeholder-entries.md
@@ -1,0 +1,17 @@
+---
+table_of_contents:
+    position: placeholder
+    placeholder: '[TOC]'
+    max_placeholder_entries: 4
+---
+This TOC has two entries, so a budget of four covers exactly two of the three placeholders.
+
+[TOC]
+
+# Alpha
+
+[TOC]
+
+# Bravo
+
+[TOC]

--- a/tests/functional/Extension/TableOfContents/xml/max-placeholder-entries.md
+++ b/tests/functional/Extension/TableOfContents/xml/max-placeholder-entries.md
@@ -1,0 +1,17 @@
+---
+table_of_contents:
+    position: placeholder
+    placeholder: '[TOC]'
+    max_placeholder_entries: 4
+---
+This TOC has two entries, so a budget of four covers exactly two of the three placeholders.
+
+[TOC]
+
+# Alpha
+
+[TOC]
+
+# Bravo
+
+[TOC]

--- a/tests/functional/Extension/TableOfContents/xml/max-placeholder-entries.xml
+++ b/tests/functional/Extension/TableOfContents/xml/max-placeholder-entries.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://commonmark.org/xml/1.0">
+    <paragraph>
+        <text>This TOC has two entries, so a budget of four covers exactly two of the three placeholders.</text>
+    </paragraph>
+    <table_of_contents type="bullet" tight="false">
+        <item>
+            <link destination="#content-alpha" title="">
+                <text>Alpha</text>
+            </link>
+        </item>
+        <item>
+            <link destination="#content-bravo" title="">
+                <text>Bravo</text>
+            </link>
+        </item>
+    </table_of_contents>
+    <heading level="1">
+        <heading_permalink slug="alpha" />
+        <text>Alpha</text>
+    </heading>
+    <table_of_contents type="bullet" tight="false">
+        <item>
+            <link destination="#content-alpha" title="">
+                <text>Alpha</text>
+            </link>
+        </item>
+        <item>
+            <link destination="#content-bravo" title="">
+                <text>Bravo</text>
+            </link>
+        </item>
+    </table_of_contents>
+    <heading level="1">
+        <heading_permalink slug="bravo" />
+        <text>Bravo</text>
+    </heading>
+    <table_of_contents_placeholder />
+</document>


### PR DESCRIPTION
When the TableOfContents extension runs in placeholder mode, every placeholder currently receives its own deep clone of the generated TOC, so a document with `P` placeholders and `H` headings does `O(P × H)` cloning and rendering work. This change replaces each placeholder with a lightweight `TableOfContentsReference` that points at a single shared TOC, which is rendered once and reused — the HTML output stays byte-for-byte identical (the existing fixtures pin this), while the AST and render work drop to `O(P + H)`. Non-HTML formats like XML still see complete copies via a pre-render expansion, so XML output is unchanged too.

There's also a new opt-in `table_of_contents/max_toc_entries` option (default unlimited) that caps the total number of rendered TOC entries for anyone feeding placeholder mode untrusted input; once the budget is spent, remaining placeholders are simply left unrendered.

---

Some quick benchmarks (PHP 8.4, `P` placeholders × `H` headings, identical output confirmed by hash):

| P = H | Time before | Time after | Peak memory before | Peak memory after | Output size |
|------:|------------:|-----------:|-------------------:|------------------:|------------:|
|    50 |      0.022s |     0.009s |             6.0 MB |            4.0 MB |     0.14 MB |
|   100 |      0.066s |     0.009s |            12.0 MB |            6.0 MB |     0.53 MB |
|   200 |      0.251s |     0.012s |            34.3 MB |            8.3 MB |     2.13 MB |
|   400 |      1.003s |     0.021s |           121.1 MB |           23.1 MB |     8.53 MB |
