### PR TITLE
Recommend a finite block nesting limit

### DIFF
--- a/docs/2.x/configuration.md
+++ b/docs/2.x/configuration.md
@@ -35,7 +35,7 @@ $config = [
     ],
     'html_input' => 'escape',
     'allow_unsafe_links' => false,
-    'max_nesting_level' => PHP_INT_MAX,
+    'max_nesting_level' => 100,
     'max_delimiters_per_line' => PHP_INT_MAX,
     'slug_normalizer' => [
         'max_length' => 255,
@@ -82,7 +82,7 @@ Here's a list of the core configuration options available:
   - `allow` - Allow all HTML input as-is (default value; equivalent to `'safe' => false`)
   - `escape` - Escape all HTML
 - `allow_unsafe_links` - Remove risky link and image URLs by setting this to `false` (default: `true`)
-- `max_nesting_level` - The maximum nesting level for blocks (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if blocks are too deeply-nested.
+- `max_nesting_level` - The maximum nesting level for blocks (default: `PHP_INT_MAX`). Set this to `100` when parsing untrusted input to protect against long parse times and/or segfaults if blocks are too deeply-nested.
 - `max_delimiters_per_line` - The maximum number of delimiters (e.g. `*` or `_`) allowed in a single line (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if lines are too long. Note that this option only applies to emphasis-style delimiters; it does not limit link or image brackets (`[` and `![`).
 - `slug_normalizer` - Array of options for configuring how URL-safe slugs are created; see [the slug normalizer docs](/2.x/customization/slug-normalizer/#configuration) for more details
   - `instance` - An alternative normalizer to use (defaults to the included `SlugNormalizer`)

--- a/docs/2.x/security.md
+++ b/docs/2.x/security.md
@@ -72,7 +72,7 @@ To prevent these from being parsed and rendered, you should set the `allow_unsaf
 
 **No maximum nesting level is enforced by default.**  Markdown content which is too deeply-nested (like 10,000 nested blockquotes: '> > > > > ...') [could result in long render times or segfaults](https://github.com/thephpleague/commonmark/issues/243#issuecomment-217580285).
 
-If you need to parse untrusted input, consider setting a reasonable `max_nesting_level` (perhaps 10-50) depending on your needs.  Once this nesting level is hit, any subsequent Markdown will be rendered as plain text.
+When parsing untrusted input, set `max_nesting_level` to `100`.  Once this nesting level is hit, any subsequent Markdown will be rendered as plain text.  The limit can be lowered for stricter protection or raised explicitly for trusted documents which legitimately require deeper nesting.
 
 ### Example - Prevent deep nesting
 

--- a/tests/pathological/test.php
+++ b/tests/pathological/test.php
@@ -237,6 +237,14 @@ $cases = [
             'max_nesting_level' => 500,
         ],
     ],
+    'Nested list markers with trailing blanks (limited nesting)' => [
+        'ref' => 'https://github.com/thephpleague/commonmark/issues/243',
+        'sizes' => [1_000, 10_000, 100_000],
+        'input' => static fn($n) => \str_repeat('- ', $n) . "x\n" . \str_repeat("\n", $n),
+        'configuration' => [
+            'max_nesting_level' => 100,
+        ],
+    ],
     'CVE-2023-26485 test 1' => [
         'ref' => 'https://github.com/github/cmark-gfm/security/advisories/GHSA-r8vr-c48j-fcc5',
         'sizes' => [50, 500, 5_000], // ideally should be 1000, 10_000, 100_000 but recursive rendering makes large sizes fail


### PR DESCRIPTION
This is the compatibility-preserving alternative to #1136. It recommends an explicit nesting limit of 100 for untrusted Markdown and tests that configuration without changing the default.