### PR TITLE
Cap the default block nesting level at 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Improved performance of locating the next non-space character on lines without tabs
 - Optimized `Cursor::advanceToNextNonSpaceOrNewline()` to scan the line in place instead of copying everything left in the block on every call
 - Optimized inline link destination parsing to scan the line in place, so its cost follows the length of the destination rather than the length of everything left in the block
+- Changed the default `max_nesting_level` from `PHP_INT_MAX` to `100`, so deeply-nested blocks are rendered as plain text unless the limit is raised explicitly (#1136)
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)

--- a/docs/2.x/configuration.md
+++ b/docs/2.x/configuration.md
@@ -85,7 +85,7 @@ Here's a list of the core configuration options available:
   - `allow` - Allow all HTML input as-is (default value; equivalent to `'safe' => false`)
   - `escape` - Escape all HTML
 - `allow_unsafe_links` - Remove risky link and image URLs by setting this to `false` (default: `true`)
-- `max_nesting_level` - The maximum nesting level for blocks (default: `PHP_INT_MAX`). Set this to `100` when parsing untrusted input to protect against long parse times and/or segfaults if blocks are too deeply-nested.
+- `max_nesting_level` - The maximum nesting level for blocks (default: `100`). Lower values can help protect against long parse times and/or segfaults if blocks are too deeply-nested.
 - `max_delimiters_per_line` - The maximum number of delimiters (e.g. `*` or `_`) allowed in a single line (default: `PHP_INT_MAX`). Setting this to a positive integer can help protect against long parse times and/or segfaults if lines are too long. Note that this option only applies to emphasis-style delimiters; it does not limit link or image brackets (`[` and `![`).
 - `xml` - Array of options for [rendering XML](/2.x/xml/)
   - `max_indentation_level` - The maximum depth to indent nested elements by when pretty-printing XML (default: `16`). Elements nested more deeply than this are still rendered, just without any additional indentation. Set this to `0` to disable indentation entirely.

--- a/docs/2.x/security.md
+++ b/docs/2.x/security.md
@@ -71,9 +71,9 @@ To prevent these from being parsed and rendered, you should set the `allow_unsaf
 
 ## Nesting Level
 
-**No maximum nesting level is enforced by default.**  Markdown content which is too deeply-nested (like 10,000 nested blockquotes: '> > > > > ...') [could result in long render times or segfaults](https://github.com/thephpleague/commonmark/issues/243#issuecomment-217580285).
+**A maximum nesting level of 100 is enforced by default.**  Without a reasonable limit, deeply-nested Markdown (like 10,000 nested blockquotes: '> > > > > ...') [could result in long render times or segfaults](https://github.com/thephpleague/commonmark/issues/243#issuecomment-217580285).
 
-When parsing untrusted input, set `max_nesting_level` to `100`.  Once this nesting level is hit, any subsequent Markdown will be rendered as plain text.  The limit can be lowered for stricter protection or raised explicitly for trusted documents which legitimately require deeper nesting.
+This default is recommended when parsing untrusted input.  Once this nesting level is hit, any subsequent Markdown will be rendered as plain text.  The limit can be lowered for stricter protection or raised explicitly for trusted documents which legitimately require deeper nesting.
 
 ### Example - Prevent deep nesting
 

--- a/docs/2.x/upgrading.md
+++ b/docs/2.x/upgrading.md
@@ -53,10 +53,11 @@ resolving the `[text][label]` form.  A label longer than 999 characters which co
 once its whitespace was normalized will no longer resolve, and is left as literal text instead.  This matches the
 behavior of the reference `cmark` implementation.
 
-### Recommended: Set a Maximum Nesting Level
+### A Maximum Nesting Level Is Now Enforced by Default
 
-If you're parsing untrusted input, we now recommend setting `max_nesting_level` to `100`.  See the
-[security documentation](/2.x/security/) for details.
+`max_nesting_level` now defaults to `100` instead of `PHP_INT_MAX`.  Blocks nested more deeply than that are rendered
+as plain text, so trusted documents which legitimately nest deeper than 100 levels need the limit raised explicitly.
+See the [security documentation](/2.x/security/) for details.
 
 ## Upgrading from 2.7 to 2.8
 

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -431,7 +431,7 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
         return new Configuration([
             'html_input' => Expect::anyOf(HtmlFilter::STRIP, HtmlFilter::ALLOW, HtmlFilter::ESCAPE)->default(HtmlFilter::ALLOW),
             'allow_unsafe_links' => Expect::bool(true),
-            'max_nesting_level' => Expect::type('int')->default(PHP_INT_MAX),
+            'max_nesting_level' => Expect::type('int')->default(100),
             'max_delimiters_per_line' => Expect::type('int')->default(PHP_INT_MAX),
             'renderer' => Expect::structure([
                 'block_separator' => Expect::string("\n"),

--- a/tests/pathological/test.php
+++ b/tests/pathological/test.php
@@ -208,6 +208,9 @@ $cases = [
         'sizes' => [100, 1_000],
         'input' => static fn($n) => \str_repeat('> ', $n) . "a\n",
         'expected' => static fn($n) => \str_repeat("<blockquote>\n", $n) . "<p>a</p>\n" . \str_repeat("</blockquote>\n", $n),
+        'configuration' => [
+            'max_nesting_level' => 5_000,
+        ],
     ],
     'Backticks' => [
         'ref' => 'https://github.com/commonmark/commonmark.js/issues/129',
@@ -317,6 +320,9 @@ $cases = [
         'sizes' => [100, 1_000, 2_000, 3_000],
         'input' => static fn($n) => \str_repeat(">", $n) . \str_repeat(".", $n) . "\n",
         'expected' => static fn($n) => \str_repeat("<blockquote>\n", $n) . '<p>' . \str_repeat('.', $n) . "</p>\n" . \str_repeat("</blockquote>\n", $n),
+        'configuration' => [
+            'max_nesting_level' => 5_000,
+        ],
     ],
     'CVE-2023-24824 test 1' => [
         'ref' => 'https://github.com/github/cmark-gfm/security/advisories/GHSA-66g8-4hjf-77xh',
@@ -334,13 +340,10 @@ $cases = [
             'max_nesting_level' => 500,
         ],
     ],
-    'Nested list markers with trailing blanks (limited nesting)' => [
+    'Nested list markers with trailing blanks (default config)' => [
         'ref' => 'https://github.com/thephpleague/commonmark/issues/243',
         'sizes' => [1_000, 10_000, 100_000],
         'input' => static fn($n) => \str_repeat('- ', $n) . "x\n" . \str_repeat("\n", $n),
-        'configuration' => [
-            'max_nesting_level' => 100,
-        ],
     ],
     'CVE-2023-26485 test 1' => [
         'ref' => 'https://github.com/github/cmark-gfm/security/advisories/GHSA-r8vr-c48j-fcc5',


### PR DESCRIPTION
This is the behavior-changing alternative to #1135. It caps nesting at 100 by default, preserves intentionally deeper fixtures with explicit overrides, and documents the compatibility trade-off.