### PR TITLE
Keep aria-hidden heading permalinks out of the tab order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)
+
 ## [2.9.1] - 2026-08-09
 
 This is a **security release** to address multiple denial of service vulnerabilities and one cross-site scripting (XSS) vulnerability.

--- a/docs/2.x/extensions/heading-permalinks.md
+++ b/docs/2.x/extensions/heading-permalinks.md
@@ -137,12 +137,17 @@ This option sets the `aria-hidden` attribute on the `<a>` tag. This defaults to 
 
 Setting this option to false would render the `<a>` tag excluding the `aria-hidden` entirely.
 
+The link is also given `tabindex="-1"` whenever `aria-hidden="true"` is applied. A focusable element that has been
+removed from the accessibility tree can still be reached with the keyboard but has nothing to announce when it is,
+which fails [WCAG 4.1.2](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html), so the two attributes
+must travel together. Mouse and touch users are unaffected.
+
 ## Non-ASCII Headings
 
 Headings containing non-ASCII characters produce slugs that keep those characters as-is:
 
 ```html
-<h1><a id="content-まとめ" href="#content-まとめ" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>まとめ</h1>
+<h1><a id="content-まとめ" href="#content-まとめ" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>まとめ</h1>
 ```
 
 This matches how GitHub and most other Markdown renderers behave, and browsers resolve percent-encoded fragments (like the `#%E3%81%BE%E3%81%A8%E3%82%81` produced when parsing a Markdown link to that heading) against these unencoded `id` attributes just fine.

--- a/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
+++ b/src/Extension/HeadingPermalink/HeadingPermalinkRenderer.php
@@ -73,6 +73,9 @@ final class HeadingPermalinkRenderer implements NodeRendererInterface, XmlNodeRe
         $hidden = $this->config->get('heading_permalink/aria_hidden');
         if ($hidden) {
             $attrs->set('aria-hidden', 'true');
+            // A focusable element removed from the accessibility tree is a WCAG 4.1.2 failure,
+            // so the link must also be taken out of the tab order
+            $attrs->set('tabindex', '-1');
         }
 
         $attrs->set('title', $this->config->get('heading_permalink/title'));

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -44,11 +44,11 @@ final class HeadingPermalinkExtensionTest extends TestCase
 
     public static function dataProviderForTestHeadingPermalinksWithDefaultOptions(): \Generator
     {
-        yield ['# Hello World!', \sprintf('<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
-        yield ['# Hello *World*', \sprintf('<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello <em>World</em></h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
-        yield ['# Hello `World`', \sprintf('<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello <code>World</code></h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
-        yield ["Test\n----", \sprintf('<h2><a id="content-test" href="#content-test" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Test</h2>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
-        yield ["# Hello World!\n\n# Hello World!", \sprintf("<h1><a id=\"content-hello-world\" href=\"#content-hello-world\" class=\"heading-permalink\" aria-hidden=\"true\" title=\"Permalink\">%s</a>Hello World!</h1>\n<h1><a id=\"content-hello-world-1\" href=\"#content-hello-world-1\" class=\"heading-permalink\" aria-hidden=\"true\" title=\"Permalink\">%s</a>Hello World!</h1>", HeadingPermalinkRenderer::DEFAULT_SYMBOL, HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
+        yield ['# Hello World!', \sprintf('<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
+        yield ['# Hello *World*', \sprintf('<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Hello <em>World</em></h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
+        yield ['# Hello `World`', \sprintf('<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Hello <code>World</code></h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
+        yield ["Test\n----", \sprintf('<h2><a id="content-test" href="#content-test" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Test</h2>', HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
+        yield ["# Hello World!\n\n# Hello World!", \sprintf("<h1><a id=\"content-hello-world\" href=\"#content-hello-world\" class=\"heading-permalink\" aria-hidden=\"true\" tabindex=\"-1\" title=\"Permalink\">%s</a>Hello World!</h1>\n<h1><a id=\"content-hello-world-1\" href=\"#content-hello-world-1\" class=\"heading-permalink\" aria-hidden=\"true\" tabindex=\"-1\" title=\"Permalink\">%s</a>Hello World!</h1>", HeadingPermalinkRenderer::DEFAULT_SYMBOL, HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
     }
 
     /**
@@ -98,9 +98,41 @@ final class HeadingPermalinkExtensionTest extends TestCase
         $converter = new MarkdownConverter($environment);
 
         $input    = '# Hello World!';
-        $expected = \sprintf('<h1><a id="hello-world" href="#hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
+        $expected = \sprintf('<h1><a id="hello-world" href="#hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
 
         $this->assertEquals($expected, \trim((string) $converter->convert($input)));
+    }
+
+    /**
+     * @dataProvider dataProviderForTestAriaHiddenPermalinksAreNotFocusable
+     */
+    #[DataProvider('dataProviderForTestAriaHiddenPermalinksAreNotFocusable')]
+    public function testAriaHiddenPermalinksAreNotFocusable(bool $ariaHidden, string $expectedAttributes): void
+    {
+        $environment = new Environment([
+            'heading_permalink' => [
+                'aria_hidden'     => $ariaHidden,
+                'id_prefix'       => '',
+                'fragment_prefix' => '',
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        $expected = \sprintf('<h1><a id="hello-world" href="#hello-world" class="heading-permalink" %stitle="Permalink">%s</a>Hello World!</h1>', $expectedAttributes, HeadingPermalinkRenderer::DEFAULT_SYMBOL);
+
+        $this->assertEquals($expected, \trim((string) $converter->convert('# Hello World!')));
+    }
+
+    /**
+     * @return \Generator<array{bool, string}>
+     */
+    public static function dataProviderForTestAriaHiddenPermalinksAreNotFocusable(): \Generator
+    {
+        yield 'hidden from the accessibility tree, so also removed from the tab order' => [true, 'aria-hidden="true" tabindex="-1" '];
+        yield 'exposed to the accessibility tree, so left focusable' => [false, ''];
     }
 
     public function testHeadingPermalinksWithEmptySymbol(): void
@@ -118,7 +150,7 @@ final class HeadingPermalinkExtensionTest extends TestCase
         $converter = new MarkdownConverter($environment);
 
         $input    = '# Hello World!';
-        $expected = '<h1><a id="hello-world" href="#hello-world" class="heading-permalink" aria-hidden="true" title="Permalink"></a>Hello World!</h1>';
+        $expected = '<h1><a id="hello-world" href="#hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink"></a>Hello World!</h1>';
 
         $this->assertEquals($expected, \trim((string) $converter->convert($input)));
     }
@@ -160,8 +192,8 @@ final class HeadingPermalinkExtensionTest extends TestCase
 EOT;
         $expected = <<<EOT
 <h1>1</h1>
-<h2><a id="content-2" href="#content-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>2</h2>
-<h3><a id="content-3" href="#content-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>3</h3>
+<h2><a id="content-2" href="#content-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>2</h2>
+<h3><a id="content-3" href="#content-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>3</h3>
 <h4>4</h4>
 EOT;
 
@@ -181,7 +213,7 @@ EOT;
         $converter = new MarkdownConverter($environment);
 
         $input    = '# Hello World!';
-        $expected = \sprintf('<h1 id="content-hello-world"><a href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
+        $expected = \sprintf('<h1 id="content-hello-world"><a href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
 
         $this->assertEquals($expected, \trim((string) $converter->convert($input)));
     }
@@ -200,7 +232,7 @@ EOT;
         $converter = new MarkdownConverter($environment);
 
         $input    = '# Hello World!';
-        $expected = \sprintf('<h1 id="content-hello-world" class="heading-anchor"><a href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
+        $expected = \sprintf('<h1 id="content-hello-world" class="heading-anchor"><a href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Hello World!</h1>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
 
         $this->assertEquals($expected, \trim((string) $converter->convert($input)));
     }

--- a/tests/functional/Extension/NormalizeHeadings/NormalizeHeadingsExtensionTest.php
+++ b/tests/functional/Extension/NormalizeHeadings/NormalizeHeadingsExtensionTest.php
@@ -78,7 +78,7 @@ final class NormalizeHeadingsExtensionTest extends AbstractLocalDataTestCase
         $expected = '<ul class="table-of-contents">
 <li><a href="#content-clamped-heading">Clamped Heading</a></li>
 </ul>
-<h2><a id="content-clamped-heading" href="#content-clamped-heading" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Clamped Heading</h2>';
+<h2><a id="content-clamped-heading" href="#content-clamped-heading" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Clamped Heading</h2>';
 
         $this->assertSame($expected, \trim((string) $converter->convert($input)));
     }

--- a/tests/functional/Extension/TableOfContents/md/custom-class.html
+++ b/tests/functional/Extension/TableOfContents/md/custom-class.html
@@ -6,5 +6,5 @@
 </li>
 </ul>
 <p>This document should have a custom class applied to the TOC</p>
-<h1><a id="content-hello" href="#content-hello" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Hello</h1>
-<h2><a id="content-world" href="#content-world" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>World</h2>
+<h1><a id="content-hello" href="#content-hello" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Hello</h1>
+<h2><a id="content-world" href="#content-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>World</h2>

--- a/tests/functional/Extension/TableOfContents/md/headings-with-inlines.html
+++ b/tests/functional/Extension/TableOfContents/md/headings-with-inlines.html
@@ -4,6 +4,6 @@
 <li><a href="#content-i-love-using--characters-in-markdown">I love using * characters in Markdown!</a></li>
 </ul>
 <p>My Awesome Blog Post</p>
-<h2><a id="content-this-heading-has-a-link" href="#content-this-heading-has-a-link" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a><a href="https://example.com">This heading</a> has a link</h2>
-<h2><a id="content-20-reasons-why-marquee-tags-should-make-a-comeback" href="#content-20-reasons-why-marquee-tags-should-make-a-comeback" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>20 Reasons Why <code>&lt;marquee&gt;</code> Tags Should Make A Comeback</h2>
-<h2><a id="content-i-love-using--characters-in-markdown" href="#content-i-love-using--characters-in-markdown" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>I <strong>love</strong> using * characters in Markdown!</h2>
+<h2><a id="content-this-heading-has-a-link" href="#content-this-heading-has-a-link" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a><a href="https://example.com">This heading</a> has a link</h2>
+<h2><a id="content-20-reasons-why-marquee-tags-should-make-a-comeback" href="#content-20-reasons-why-marquee-tags-should-make-a-comeback" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>20 Reasons Why <code>&lt;marquee&gt;</code> Tags Should Make A Comeback</h2>
+<h2><a id="content-i-love-using--characters-in-markdown" href="#content-i-love-using--characters-in-markdown" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>I <strong>love</strong> using * characters in Markdown!</h2>

--- a/tests/functional/Extension/TableOfContents/md/html-in-headings.html
+++ b/tests/functional/Extension/TableOfContents/md/html-in-headings.html
@@ -2,5 +2,5 @@
 <li><a href="#content-hello-world">Hello World! </a></li>
 </ul>
 <p>Here's a sample Markdown document</p>
-<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Hello World! <i class="icon icon-waving-hand"></i></h1>
+<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Hello World! <i class="icon icon-waving-hand"></i></h1>
 <p>Hi there!</p>

--- a/tests/functional/Extension/TableOfContents/md/min-max.html
+++ b/tests/functional/Extension/TableOfContents/md/min-max.html
@@ -13,9 +13,9 @@
 </ul>
 </li>
 </ul>
-<h1><a id="content-level-1" href="#content-level-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 1</h1>
-<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 2</h2>
-<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 3</h3>
-<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 4</h4>
-<h5><a id="content-level-5" href="#content-level-5" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 5</h5>
-<h6><a id="content-level-6" href="#content-level-6" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 6</h6>
+<h1><a id="content-level-1" href="#content-level-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 1</h1>
+<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 2</h2>
+<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 3</h3>
+<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 4</h4>
+<h5><a id="content-level-5" href="#content-level-5" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 5</h5>
+<h6><a id="content-level-6" href="#content-level-6" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 6</h6>

--- a/tests/functional/Extension/TableOfContents/md/position-before-headings.html
+++ b/tests/functional/Extension/TableOfContents/md/position-before-headings.html
@@ -6,5 +6,5 @@
 </ul>
 </li>
 </ul>
-<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Hello World!</h1>
-<h2><a id="content-isnt-markdown-great" href="#content-isnt-markdown-great" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Isn't Markdown Great?</h2>
+<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Hello World!</h1>
+<h2><a id="content-isnt-markdown-great" href="#content-isnt-markdown-great" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Isn't Markdown Great?</h2>

--- a/tests/functional/Extension/TableOfContents/md/position-placeholder-missing.html
+++ b/tests/functional/Extension/TableOfContents/md/position-placeholder-missing.html
@@ -1,3 +1,3 @@
 <p>This is my document.</p>
-<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Hello World!</h1>
-<h2><a id="content-isnt-markdown-great" href="#content-isnt-markdown-great" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Isn't Markdown Great?</h2>
+<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Hello World!</h1>
+<h2><a id="content-isnt-markdown-great" href="#content-isnt-markdown-great" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Isn't Markdown Great?</h2>

--- a/tests/functional/Extension/TableOfContents/md/position-placeholder-multiple.html
+++ b/tests/functional/Extension/TableOfContents/md/position-placeholder-multiple.html
@@ -7,7 +7,7 @@
 </ul>
 </li>
 </ul>
-<h1><a id="content-another-copy-of-my-toc-is-here" href="#content-another-copy-of-my-toc-is-here" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Another copy of my TOC is here</h1>
+<h1><a id="content-another-copy-of-my-toc-is-here" href="#content-another-copy-of-my-toc-is-here" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Another copy of my TOC is here</h1>
 <ul class="table-of-contents">
 <li><a href="#content-another-copy-of-my-toc-is-here">Another copy of my TOC is here</a>
 <ul>
@@ -16,7 +16,7 @@
 </ul>
 </li>
 </ul>
-<h2><a id="content-this-contains-something-that-looks-like-a-placeholder-but-actually-isnt" href="#content-this-contains-something-that-looks-like-a-placeholder-but-actually-isnt" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>This contains something that looks like a placeholder but actually isn't</h2>
+<h2><a id="content-this-contains-something-that-looks-like-a-placeholder-but-actually-isnt" href="#content-this-contains-something-that-looks-like-a-placeholder-but-actually-isnt" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>This contains something that looks like a placeholder but actually isn't</h2>
 <p>This is not a placeholder, but a link reference: <a href="https://www.example.com" title="Link Reference">TOC</a></p>
 <p><a href="https://www.example.com" title="Link Reference">TOC</a> This should also be handled as a link reference</p>
-<h2><a id="content-just-a-link-reference-down-here" href="#content-just-a-link-reference-down-here" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Just a link reference down here</h2>
+<h2><a id="content-just-a-link-reference-down-here" href="#content-just-a-link-reference-down-here" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Just a link reference down here</h2>

--- a/tests/functional/Extension/TableOfContents/md/position-top.html
+++ b/tests/functional/Extension/TableOfContents/md/position-top.html
@@ -6,5 +6,5 @@
 </li>
 </ul>
 <p>This is my document.</p>
-<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Hello World!</h1>
-<h2><a id="content-isnt-markdown-great" href="#content-isnt-markdown-great" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Isn't Markdown Great?</h2>
+<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Hello World!</h1>
+<h2><a id="content-isnt-markdown-great" href="#content-isnt-markdown-great" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Isn't Markdown Great?</h2>

--- a/tests/functional/Extension/TableOfContents/md/sample.html
+++ b/tests/functional/Extension/TableOfContents/md/sample.html
@@ -49,21 +49,21 @@
 <li><a href="#content-section-title-with-quotes">Section title with &quot;quotes&quot;</a></li>
 </ul>
 <p>Here's a sample Markdown document with lots of headings</p>
-<h1><a id="content-section-1" href="#content-section-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1</h1>
-<h2><a id="content-section-11" href="#content-section-11" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1</h2>
-<h3><a id="content-section-111" href="#content-section-111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1</h3>
-<h4><a id="content-section-1111" href="#content-section-1111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1</h4>
-<h5><a id="content-section-11111" href="#content-section-11111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1.1</h5>
-<h6><a id="content-section-111111" href="#content-section-111111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1.1.1</h6>
-<h1><a id="content-section-2" href="#content-section-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2</h1>
-<h2><a id="content-section-21" href="#content-section-21" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.1</h2>
-<h2><a id="content-section-22" href="#content-section-22" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2</h2>
-<h3><a id="content-section-221" href="#content-section-221" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.1</h3>
-<h3><a id="content-section-222" href="#content-section-222" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2</h3>
-<h4><a id="content-section-2221" href="#content-section-2221" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2.1</h4>
-<h4><a id="content-section-2222" href="#content-section-2222" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2.2</h4>
-<h5><a id="content-section-22221" href="#content-section-22221" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2.2.1</h5>
-<h5><a id="content-section-22222" href="#content-section-22222" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2.2.2</h5>
-<h6><a id="content-section-222221" href="#content-section-222221" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2.2.2.1</h6>
-<h6><a id="content-section-222222" href="#content-section-222222" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2.2.2.2.2.2</h6>
-<h1><a id="content-section-title-with-quotes" href="#content-section-title-with-quotes" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section title with &quot;quotes&quot;</h1>
+<h1><a id="content-section-1" href="#content-section-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1</h1>
+<h2><a id="content-section-11" href="#content-section-11" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1</h2>
+<h3><a id="content-section-111" href="#content-section-111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1</h3>
+<h4><a id="content-section-1111" href="#content-section-1111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1</h4>
+<h5><a id="content-section-11111" href="#content-section-11111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1.1</h5>
+<h6><a id="content-section-111111" href="#content-section-111111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1.1.1</h6>
+<h1><a id="content-section-2" href="#content-section-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2</h1>
+<h2><a id="content-section-21" href="#content-section-21" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.1</h2>
+<h2><a id="content-section-22" href="#content-section-22" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2</h2>
+<h3><a id="content-section-221" href="#content-section-221" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.1</h3>
+<h3><a id="content-section-222" href="#content-section-222" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2</h3>
+<h4><a id="content-section-2221" href="#content-section-2221" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2.1</h4>
+<h4><a id="content-section-2222" href="#content-section-2222" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2.2</h4>
+<h5><a id="content-section-22221" href="#content-section-22221" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2.2.1</h5>
+<h5><a id="content-section-22222" href="#content-section-22222" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2.2.2</h5>
+<h6><a id="content-section-222221" href="#content-section-222221" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2.2.2.1</h6>
+<h6><a id="content-section-222222" href="#content-section-222222" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2.2.2.2.2.2</h6>
+<h1><a id="content-section-title-with-quotes" href="#content-section-title-with-quotes" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section title with &quot;quotes&quot;</h1>

--- a/tests/functional/Extension/TableOfContents/md/setext-headings.html
+++ b/tests/functional/Extension/TableOfContents/md/setext-headings.html
@@ -5,5 +5,5 @@
 </ul>
 </li>
 </ul>
-<h1><a id="content-this-is-a-top-level" href="#content-this-is-a-top-level" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>This is a top level</h1>
-<h2><a id="content-this-is-another-level" href="#content-this-is-another-level" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>This is another level</h2>
+<h1><a id="content-this-is-a-top-level" href="#content-this-is-a-top-level" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>This is a top level</h1>
+<h2><a id="content-this-is-another-level" href="#content-this-is-another-level" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>This is another level</h2>

--- a/tests/functional/Extension/TableOfContents/md/style-bullet.html
+++ b/tests/functional/Extension/TableOfContents/md/style-bullet.html
@@ -16,10 +16,10 @@
 </ul>
 </li>
 </ul>
-<h1><a id="content-these" href="#content-these" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>These</h1>
-<h2><a id="content-should" href="#content-should" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Should</h2>
-<h3><a id="content-be" href="#content-be" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Be</h3>
-<h2><a id="content-in" href="#content-in" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>In</h2>
-<h1><a id="content-an" href="#content-an" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>An</h1>
-<h1><a id="content-unordered" href="#content-unordered" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Unordered</h1>
-<h2><a id="content-list" href="#content-list" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>List</h2>
+<h1><a id="content-these" href="#content-these" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>These</h1>
+<h2><a id="content-should" href="#content-should" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Should</h2>
+<h3><a id="content-be" href="#content-be" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Be</h3>
+<h2><a id="content-in" href="#content-in" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>In</h2>
+<h1><a id="content-an" href="#content-an" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>An</h1>
+<h1><a id="content-unordered" href="#content-unordered" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Unordered</h1>
+<h2><a id="content-list" href="#content-list" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>List</h2>

--- a/tests/functional/Extension/TableOfContents/md/style-ordered.html
+++ b/tests/functional/Extension/TableOfContents/md/style-ordered.html
@@ -16,10 +16,10 @@
 </ol>
 </li>
 </ol>
-<h1><a id="content-these" href="#content-these" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>These</h1>
-<h2><a id="content-should" href="#content-should" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Should</h2>
-<h3><a id="content-be" href="#content-be" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Be</h3>
-<h2><a id="content-in" href="#content-in" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>In</h2>
-<h1><a id="content-an" href="#content-an" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>An</h1>
-<h1><a id="content-ordered" href="#content-ordered" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Ordered</h1>
-<h2><a id="content-list" href="#content-list" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>List</h2>
+<h1><a id="content-these" href="#content-these" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>These</h1>
+<h2><a id="content-should" href="#content-should" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Should</h2>
+<h3><a id="content-be" href="#content-be" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Be</h3>
+<h2><a id="content-in" href="#content-in" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>In</h2>
+<h1><a id="content-an" href="#content-an" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>An</h1>
+<h1><a id="content-ordered" href="#content-ordered" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Ordered</h1>
+<h2><a id="content-list" href="#content-list" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>List</h2>

--- a/tests/functional/Extension/TableOfContents/md/weird-as-is.html
+++ b/tests/functional/Extension/TableOfContents/md/weird-as-is.html
@@ -60,16 +60,16 @@
 <li><a href="#content-level-1">Level 1</a></li>
 </ul>
 <p>Here's a sample Markdown document with weird headings</p>
-<h2><a id="content-a-level-2-heading-to-start" href="#content-a-level-2-heading-to-start" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>A level 2 heading to start</h2>
-<h4><a id="content-followed-by-a-level-4" href="#content-followed-by-a-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Followed by a level 4</h4>
-<h1><a id="content-then-a-level-1" href="#content-then-a-level-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 1</h1>
-<h2><a id="content-and-another-level-2" href="#content-and-another-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>And another level 2</h2>
-<h5><a id="content-then-a-level-5" href="#content-then-a-level-5" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 5</h5>
-<h3><a id="content-and-then-a-level-3" href="#content-and-then-a-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>And then a level 3</h3>
-<h6><a id="content-followed-by-a-level-6" href="#content-followed-by-a-level-6" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Followed by a level 6</h6>
-<h3><a id="content-then-another-level-3" href="#content-then-another-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then another level 3</h3>
-<h4><a id="content-then-level-4" href="#content-then-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then level 4</h4>
-<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 3</h3>
-<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 2</h2>
-<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 4</h4>
-<h1><a id="content-level-1" href="#content-level-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 1</h1>
+<h2><a id="content-a-level-2-heading-to-start" href="#content-a-level-2-heading-to-start" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>A level 2 heading to start</h2>
+<h4><a id="content-followed-by-a-level-4" href="#content-followed-by-a-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Followed by a level 4</h4>
+<h1><a id="content-then-a-level-1" href="#content-then-a-level-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 1</h1>
+<h2><a id="content-and-another-level-2" href="#content-and-another-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>And another level 2</h2>
+<h5><a id="content-then-a-level-5" href="#content-then-a-level-5" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 5</h5>
+<h3><a id="content-and-then-a-level-3" href="#content-and-then-a-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>And then a level 3</h3>
+<h6><a id="content-followed-by-a-level-6" href="#content-followed-by-a-level-6" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Followed by a level 6</h6>
+<h3><a id="content-then-another-level-3" href="#content-then-another-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then another level 3</h3>
+<h4><a id="content-then-level-4" href="#content-then-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then level 4</h4>
+<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 3</h3>
+<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 2</h2>
+<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 4</h4>
+<h1><a id="content-level-1" href="#content-level-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 1</h1>

--- a/tests/functional/Extension/TableOfContents/md/weird-flattened.html
+++ b/tests/functional/Extension/TableOfContents/md/weird-flattened.html
@@ -14,16 +14,16 @@
 <li><a href="#content-level-1">Level 1</a></li>
 </ul>
 <p>Here's a sample Markdown document with weird headings</p>
-<h2><a id="content-a-level-2-heading-to-start" href="#content-a-level-2-heading-to-start" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>A level 2 heading to start</h2>
-<h4><a id="content-followed-by-a-level-4" href="#content-followed-by-a-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Followed by a level 4</h4>
-<h1><a id="content-then-a-level-1" href="#content-then-a-level-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 1</h1>
-<h2><a id="content-and-another-level-2" href="#content-and-another-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>And another level 2</h2>
-<h5><a id="content-then-a-level-5" href="#content-then-a-level-5" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 5</h5>
-<h3><a id="content-and-then-a-level-3" href="#content-and-then-a-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>And then a level 3</h3>
-<h6><a id="content-followed-by-a-level-6" href="#content-followed-by-a-level-6" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Followed by a level 6</h6>
-<h3><a id="content-then-another-level-3" href="#content-then-another-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then another level 3</h3>
-<h4><a id="content-then-level-4" href="#content-then-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then level 4</h4>
-<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 3</h3>
-<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 2</h2>
-<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 4</h4>
-<h1><a id="content-level-1" href="#content-level-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 1</h1>
+<h2><a id="content-a-level-2-heading-to-start" href="#content-a-level-2-heading-to-start" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>A level 2 heading to start</h2>
+<h4><a id="content-followed-by-a-level-4" href="#content-followed-by-a-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Followed by a level 4</h4>
+<h1><a id="content-then-a-level-1" href="#content-then-a-level-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 1</h1>
+<h2><a id="content-and-another-level-2" href="#content-and-another-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>And another level 2</h2>
+<h5><a id="content-then-a-level-5" href="#content-then-a-level-5" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 5</h5>
+<h3><a id="content-and-then-a-level-3" href="#content-and-then-a-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>And then a level 3</h3>
+<h6><a id="content-followed-by-a-level-6" href="#content-followed-by-a-level-6" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Followed by a level 6</h6>
+<h3><a id="content-then-another-level-3" href="#content-then-another-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then another level 3</h3>
+<h4><a id="content-then-level-4" href="#content-then-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then level 4</h4>
+<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 3</h3>
+<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 2</h2>
+<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 4</h4>
+<h1><a id="content-level-1" href="#content-level-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 1</h1>

--- a/tests/functional/Extension/TableOfContents/md/weird-relative.html
+++ b/tests/functional/Extension/TableOfContents/md/weird-relative.html
@@ -79,33 +79,33 @@
 <li><a href="#content-section-2">Section 2</a></li>
 </ul>
 <p>Here's a sample Markdown document with weird headings</p>
-<h2><a id="content-a-level-2-heading-to-start" href="#content-a-level-2-heading-to-start" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>A level 2 heading to start</h2>
-<h4><a id="content-followed-by-a-level-4" href="#content-followed-by-a-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Followed by a level 4</h4>
-<h1><a id="content-then-a-level-1" href="#content-then-a-level-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 1</h1>
-<h2><a id="content-and-another-level-2" href="#content-and-another-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>And another level 2</h2>
-<h5><a id="content-then-a-level-5" href="#content-then-a-level-5" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 5</h5>
-<h6><a id="content-then-a-level-6" href="#content-then-a-level-6" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 6</h6>
-<h5><a id="content-then-a-level-5-1" href="#content-then-a-level-5-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 5</h5>
-<h6><a id="content-then-a-level-6-1" href="#content-then-a-level-6-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 6</h6>
-<h3><a id="content-and-then-a-level-3" href="#content-and-then-a-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>And then a level 3</h3>
-<h5><a id="content-then-a-level-5-2" href="#content-then-a-level-5-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 5</h5>
-<h2><a id="content-then-a-level-2" href="#content-then-a-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then a level 2</h2>
-<h6><a id="content-followed-by-a-level-6" href="#content-followed-by-a-level-6" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Followed by a level 6</h6>
-<h3><a id="content-then-another-level-3" href="#content-then-another-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then another level 3</h3>
-<h5><a id="content-then-level-5" href="#content-then-level-5" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Then level 5</h5>
-<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 4</h4>
-<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 3</h3>
-<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 2</h2>
-<h4><a id="content-level-4-1" href="#content-level-4-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Level 4</h4>
-<h1><a id="content-now-for-some-normal-headings-to-test-going-up-and-down-the-stack" href="#content-now-for-some-normal-headings-to-test-going-up-and-down-the-stack" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Now for some &quot;normal&quot; headings to test going up and down the stack</h1>
-<h1><a id="content-section-1" href="#content-section-1" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1</h1>
-<h2><a id="content-section-11" href="#content-section-11" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1</h2>
-<h3><a id="content-section-111" href="#content-section-111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1</h3>
-<h4><a id="content-section-1111" href="#content-section-1111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1</h4>
-<h5><a id="content-section-11111" href="#content-section-11111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1.1</h5>
-<h6><a id="content-section-111111" href="#content-section-111111" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1.1.1</h6>
-<h5><a id="content-section-11112" href="#content-section-11112" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.1.2</h5>
-<h4><a id="content-section-1112" href="#content-section-1112" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.1.2</h4>
-<h3><a id="content-section-112" href="#content-section-112" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.1.2</h3>
-<h2><a id="content-section-12" href="#content-section-12" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 1.2</h2>
-<h1><a id="content-section-2" href="#content-section-2" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Section 2</h1>
+<h2><a id="content-a-level-2-heading-to-start" href="#content-a-level-2-heading-to-start" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>A level 2 heading to start</h2>
+<h4><a id="content-followed-by-a-level-4" href="#content-followed-by-a-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Followed by a level 4</h4>
+<h1><a id="content-then-a-level-1" href="#content-then-a-level-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 1</h1>
+<h2><a id="content-and-another-level-2" href="#content-and-another-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>And another level 2</h2>
+<h5><a id="content-then-a-level-5" href="#content-then-a-level-5" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 5</h5>
+<h6><a id="content-then-a-level-6" href="#content-then-a-level-6" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 6</h6>
+<h5><a id="content-then-a-level-5-1" href="#content-then-a-level-5-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 5</h5>
+<h6><a id="content-then-a-level-6-1" href="#content-then-a-level-6-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 6</h6>
+<h3><a id="content-and-then-a-level-3" href="#content-and-then-a-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>And then a level 3</h3>
+<h5><a id="content-then-a-level-5-2" href="#content-then-a-level-5-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 5</h5>
+<h2><a id="content-then-a-level-2" href="#content-then-a-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then a level 2</h2>
+<h6><a id="content-followed-by-a-level-6" href="#content-followed-by-a-level-6" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Followed by a level 6</h6>
+<h3><a id="content-then-another-level-3" href="#content-then-another-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then another level 3</h3>
+<h5><a id="content-then-level-5" href="#content-then-level-5" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Then level 5</h5>
+<h4><a id="content-level-4" href="#content-level-4" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 4</h4>
+<h3><a id="content-level-3" href="#content-level-3" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 3</h3>
+<h2><a id="content-level-2" href="#content-level-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 2</h2>
+<h4><a id="content-level-4-1" href="#content-level-4-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Level 4</h4>
+<h1><a id="content-now-for-some-normal-headings-to-test-going-up-and-down-the-stack" href="#content-now-for-some-normal-headings-to-test-going-up-and-down-the-stack" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Now for some &quot;normal&quot; headings to test going up and down the stack</h1>
+<h1><a id="content-section-1" href="#content-section-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1</h1>
+<h2><a id="content-section-11" href="#content-section-11" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1</h2>
+<h3><a id="content-section-111" href="#content-section-111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1</h3>
+<h4><a id="content-section-1111" href="#content-section-1111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1</h4>
+<h5><a id="content-section-11111" href="#content-section-11111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1.1</h5>
+<h6><a id="content-section-111111" href="#content-section-111111" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1.1.1</h6>
+<h5><a id="content-section-11112" href="#content-section-11112" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.1.2</h5>
+<h4><a id="content-section-1112" href="#content-section-1112" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.1.2</h4>
+<h3><a id="content-section-112" href="#content-section-112" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.1.2</h3>
+<h2><a id="content-section-12" href="#content-section-12" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 1.2</h2>
+<h1><a id="content-section-2" href="#content-section-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Section 2</h1>


### PR DESCRIPTION
When `heading_permalink/aria_hidden` is `true` (the default), the permalink is rendered as `<a href="#..." aria-hidden="true">`. That removes the link from the accessibility tree while leaving it in the keyboard tab order, so a keyboard user can focus an element that has nothing to announce — the `aria-hidden-focus` rule, and a WCAG 4.1.2 failure.

This adds `tabindex="-1"` alongside `aria-hidden="true"` so the two attributes always travel together. Mouse and touch users are unaffected; keyboard users could never usefully reach the link in the first place.

Output only changes for the `aria_hidden: true` path:

```diff
-<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Hello World!</h1>
+<h1><a id="content-hello-world" href="#content-hello-world" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">¶</a>Hello World!</h1>
```

Setting `aria_hidden: false` renders neither attribute, exactly as before.

### This does not close #1024

Worth being explicit: the reporter on #1024 is running `aria_hidden: false` with `insert: 'after'`, so their output is byte-identical before and after this PR. Their checker is flagging a different defect — the link's accessible name is a bare `¶`. That needs an accessible name derived from the heading text (e.g. a new `aria_label` option interpolating it), which is additive but a larger change and deliberately not bundled here.

### Notes

- Fixtures across `HeadingPermalink`, `NormalizeHeadings`, and `TableOfContents` move accordingly.
- Added `testAriaHiddenPermalinksAreNotFocusable` covering both `aria_hidden` values.
- The `aria-hidden` sample HTML in `docs/2.x/upgrading/*` is left alone — those are historical 1.x → 2.0 diffs.
- `composer test` passes (phpcs on 7.4, phpstan, psalm, phpunit, pathological); phpstan/psalm issue counts are unchanged from the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
