### PR TITLE
Optimize Cursor character scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ### Changed
 - Improved performance of reading single characters from multibyte lines
+- Improved performance of locating the next non-space character on lines without tabs
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Changed
+- Improved performance of reading single characters from multibyte lines
+
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)
 

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -212,6 +212,15 @@ class Cursor
         // byte, the character index and byte offset advance together.
         $byteOffset = $this->isMultibyte ? $this->byteOffset($this->currentPosition) : $this->currentPosition;
 
+        // Past the last tab (or on a line with none) every whitespace character is a space worth
+        // exactly one column, so the run length is both the character count and the indent, and
+        // strspn() can measure it in one call instead of a per-character loop.
+        if ($this->lastTabPosition === false || $this->currentPosition > $this->lastTabPosition) {
+            $this->indent = \strspn($this->line, ' ', $byteOffset);
+
+            return $this->nextNonSpaceCache = $this->currentPosition + $this->indent;
+        }
+
         for ($i = $this->currentPosition; $i < $this->length; $i++, $byteOffset++) {
             $c = $this->line[$byteOffset];
 

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -179,7 +179,13 @@ class Cursor
 
         $startByte = $this->byteOffset($index);
 
-        return $this->charCache[$index] = \substr($this->line, $startByte, $this->byteOffset($index + 1) - $startByte);
+        // The line is known to be valid UTF-8 (the constructor rejects anything else), so the
+        // lead byte alone gives the character's width. Deriving it here avoids a second
+        // byteOffset() walk just to locate where the next character begins.
+        $lead  = \ord($this->line[$startByte]);
+        $width = $lead < 0x80 ? 1 : ($lead < 0xE0 ? 2 : ($lead < 0xF0 ? 3 : 4));
+
+        return $this->charCache[$index] = \substr($this->line, $startByte, $width);
     }
 
     /**

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -170,6 +170,10 @@ class Cursor
      * Return the single multibyte character at $index, caching the sliced string so
      * repeated reads of the same position (common during delimiter scanning) don't
      * re-slice. Callers must ensure 0 <= $index < $length.
+     *
+     * Only call this when $isMultibyte is true. On a single-byte line the character is
+     * already reachable as $this->line[$index], which costs less than the byte-offset
+     * translation below; every caller guards on that flag for exactly that reason.
      */
     private function charAt(int $index): string
     {


### PR DESCRIPTION
Two self-contained optimizations to `Cursor`'s hottest read paths. No behaviour changes and no new API — both are pure internal rewrites of existing logic.

### `charAt()` derives character width from the lead byte

It called `byteOffset()` twice per character: once for the character's own start, and once for the *next* character's start purely to work out how many bytes to slice. The constructor already rejects anything that isn't valid UTF-8, so the lead byte alone gives the width.

### `getNextNonSpacePosition()` uses `strspn()` when the line has no tabs

This is the most-called method on the cursor — `isBlank()` and `isIndented()` both funnel into it, and together they account for roughly 44% of all `Cursor` calls while parsing an ASCII document. Past the last tab (or on a line with no tab at all, which is nearly every line) every whitespace character is a space worth exactly one column, so the run length is simultaneously the character count *and* the indent, and `strspn()` measures it in one call instead of a per-character PHP loop. Lines that still have a tab ahead of the cursor keep the original loop, since those need real column arithmetic.

### Measurements

Converter built once outside the timing loop, 250 iterations, p10 per run. A/B is paired and interleaved — each round runs both arms back to back, alternating which goes first — reporting the median of per-round ratios. Measured noise floor with identical arms on both sides: ±0.25% median. (Sequential measurement drifts ~8% on this machine as it heats, which is enough to invent an effect this size, hence the pairing.)

| corpus | change |
| --- | --- |
| 44KB multibyte (Cyrillic/CJK/accented) | **-3.6%** |
| 27KB ASCII (`tests/benchmark/sample.md`) | -0.5% |
| tab-heavy document | neutral |

The multibyte gain is consistent across every round; the ASCII figure is at the edge of the noise floor.

### Testing

`phpunit`, `phpcs` (under PHP 7.4), and `tests/pathological/test.php` all pass on each commit individually.

No new tests: neither change alters observable behaviour, and both paths are already covered — the spec suite exercises the tab/column arithmetic, and the pathological suite covers the multibyte scanning cases.
