### PR TITLE
Stop cloning a node from mutating the node it was cloned from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)
+- Fixed cloning a node breaking the link from the original node's children back to their parent, silently corrupting the document that node belonged to; detaching or inserting around those children afterwards could drop nodes from the tree
+- Fixed cloned nodes sharing their `data` with the node they were cloned from, so that setting an attribute on either one also set it on the other
 
 ## [2.9.1] - 2026-08-09
 

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -21,7 +21,7 @@ use League\CommonMark\Exception\InvalidArgumentException;
 
 abstract class Node
 {
-    /** @psalm-readonly */
+    /** @psalm-readonly-allow-private-mutation */
     public Data $data;
 
     /** @psalm-readonly-allow-private-mutation */
@@ -243,14 +243,18 @@ abstract class Node
         $this->parent   = null;
         $this->previous = null;
         $this->next     = null;
-        // But save a copy of the children since we'll need that in a moment
-        $children = $this->children();
-        $this->detachChildren();
+        // But save a copy of the children since we'll need that in a moment.
+        // Those children still belong to the node being cloned, so only this copy's own links may be dropped.
+        $children         = $this->children();
+        $this->firstChild = $this->lastChild = null;
 
         // The original children get cloned and re-added
         foreach ($children as $child) {
             $this->appendChild(clone $child);
         }
+
+        // The data belongs to a single node, so the two nodes each need their own copy
+        $this->data = clone $this->data;
     }
 
     public static function assertInstanceOf(Node $node): void

--- a/tests/unit/Node/NodeTest.php
+++ b/tests/unit/Node/NodeTest.php
@@ -208,4 +208,45 @@ final class NodeTest extends TestCase
             $this->assertSame('original', $event->getNode()->value);
         }
     }
+
+    public function testCloneLeavesTheOriginalChildrenAttached(): void
+    {
+        $root = new SimpleNode();
+        $root->appendChild($child = new SimpleNode());
+        $child->appendChild($grandChild1 = new SimpleNode());
+        $child->appendChild($grandChild2 = new SimpleNode());
+
+        $copy = clone $child;
+
+        // The original keeps its children, which still point back to it
+        $this->assertSame($root, $child->parent());
+        $this->assertSame($child, $grandChild1->parent());
+        $this->assertSame($child, $grandChild2->parent());
+
+        // The copy has its own children, which point back to the copy
+        $copiedChildren = $copy->children();
+        $this->assertNull($copy->parent());
+        $this->assertCount(2, $copiedChildren);
+        $this->assertNotSame($grandChild1, $copiedChildren[0]);
+        $this->assertNotSame($grandChild2, $copiedChildren[1]);
+        $this->assertSame($copy, $copiedChildren[0]->parent());
+        $this->assertSame($copy, $copiedChildren[1]->parent());
+    }
+
+    public function testCloneGivesEveryNodeInTheSubtreeItsOwnData(): void
+    {
+        $node = new SimpleNode();
+        $node->appendChild($child = new SimpleNode());
+        $node->data->set('attributes/class', 'original');
+        $child->data->set('attributes/class', 'original-child');
+
+        $copy = clone $node;
+        $copy->data->set('attributes/class', 'copy');
+        $copy->firstChild()->data->set('attributes/class', 'copy-child');
+
+        $this->assertSame('original', $node->data->get('attributes/class'));
+        $this->assertSame('original-child', $child->data->get('attributes/class'));
+        $this->assertSame('copy', $copy->data->get('attributes/class'));
+        $this->assertSame('copy-child', $copy->firstChild()->data->get('attributes/class'));
+    }
 }


### PR DESCRIPTION
Cloning a node mutates the node it was cloned from, in two separate ways.

### The original's children lose their parent

`Node::__clone()` runs on the newly created copy, but PHP's shallow copy means that copy's `firstChild` and `lastChild` still point at the *original's* children. Calling `detachChildren()` on it therefore walks the original's child list and calls `setParent(null)` on every one of them.

The downward links survive, so `$original->children()` still returns everything and rendering is unaffected (renderers only ever walk downward). It is the upward links that break, and that asymmetry is what does the damage: `detach()` and `insertBefore()` repair sibling links via `$this->parent`, so once it is `null` they silently corrupt the tree.

```php
$p->appendChild($x);
$p->appendChild($y);

clone $p;      // the copy is never even used
$x->detach();

$p->children();   // [y] as expected once fixed; before, [x] - the detached node, and $y was lost
```

Inserting is worse, because the new node simply disappears:

```php
$p->appendChild($x);

clone $p;
$x->insertBefore($new);

$p->children();   // [$new, $x] once fixed; before, just [$x]
```

### Both nodes share one `Data` instance

`__clone` never copied `$data`, so a node and its copy shared a single `Data` object at every depth, and setting an attribute on either applied it to both.

This one is reachable through the library's own code. `TableOfContentsBuilder` clones the table of contents into each `[TOC]` placeholder, so a document with two placeholders yields two distinct nodes sharing one `Data`. Setting `attributes/id` on one of them emitted the id on **both** rendered `<ul>` elements: duplicate IDs, and invalid HTML, from touching a single node.

### The fix

Drop only the copy's own child pointers rather than detaching children which still belong to the node being cloned, and give the copy its own `Data`. Nothing about the resulting copy changes in either case.

### Notes

- Rendering output is byte-identical before and after, for both bugs, which is a large part of why they went unnoticed.
- `NodeTest::testClone()` was written to catch the first bug ("check the original to ensure nothing changed there") but could not: the corruption truncates the walker instead of altering any values, so the test simply visited fewer nodes and passed either way. Its assertion count rises with this applied. The tests added here assert the parent links and the data independence directly, and both fail without the corresponding fix.
- This behavior dates back to 2.0 and is present on every maintained branch, in case it is worth merging down further than 2.9.
