### PR TITLE
Optimize inline link destination parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Improved performance of reading single characters from multibyte lines
 - Improved performance of locating the next non-space character on lines without tabs
 - Optimized `Cursor::advanceToNextNonSpaceOrNewline()` to scan the line in place instead of copying everything left in the block on every call
+- Optimized inline link destination parsing to scan the line in place, so its cost follows the length of the destination rather than the length of everything left in the block
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 ### Changed
 - Improved performance of reading single characters from multibyte lines
 - Improved performance of locating the next non-space character on lines without tabs
+- Optimized `Cursor::advanceToNextNonSpaceOrNewline()` to scan the line in place instead of copying everything left in the block on every call
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -469,13 +469,22 @@ class Cursor
             return 0;
         }
 
-        $matches = [];
-        \preg_match('/^ *(?:\n *)?/', $this->getRemainder(), $matches, \PREG_OFFSET_CAPTURE);
+        // A partially-consumed tab leaves the cursor sitting on the tab itself, which the check
+        // above has already returned on, so only real spaces and newlines reach this point and no
+        // tab expansion is needed.
+        //
+        // Spaces and newlines are single-byte ASCII characters which can never appear inside a
+        // multibyte UTF-8 sequence, so the run is measured at the byte level and each byte
+        // consumed is exactly one character. Scanning the line in place keeps the cost of each
+        // call proportional to the run it consumes, rather than to the length of everything left
+        // in the block, which is what building the remainder first charged for.
+        $byteOffset = $this->isMultibyte ? $this->byteOffset($this->currentPosition) : $this->currentPosition;
 
-        // [0][0] contains the matched text
-        // [0][1] contains the index of that match
-        \assert(isset($matches[0]));
-        $increment = $matches[0][1] + \strlen($matches[0][0]);
+        $increment = \strspn($this->line, ' ', $byteOffset);
+        if (($this->line[$byteOffset + $increment] ?? '') === "\n") {
+            $increment++;
+            $increment += \strspn($this->line, ' ', $byteOffset + $increment);
+        }
 
         $this->advanceBy($increment);
 

--- a/src/Util/LinkParserHelper.php
+++ b/src/Util/LinkParserHelper.php
@@ -93,12 +93,19 @@ final class LinkParserHelper
 
     private static function manuallyParseLinkDestination(Cursor $cursor): ?string
     {
-        $remainder  = $cursor->getRemainder();
+        // The destination always ends at the first whitespace or unbalanced ")", so scan the line
+        // in place from the cursor rather than materializing the remainder: the cost of finding it
+        // should follow the length of the destination, not the length of everything left in the
+        // block. A partially-consumed tab needs no special handling - getRemainder() would expand
+        // it into leading spaces and the scan would stop on the first one, exactly as it stops on
+        // the tab itself here.
+        $line       = $cursor->getLine();
+        $start      = $cursor->getBytePosition();
         $openParens = 0;
-        $len        = \strlen($remainder);
+        $len        = \strlen($line) - $start;
         for ($i = 0; $i < $len; $i++) {
-            $c = $remainder[$i];
-            if ($c === '\\' && $i + 1 < $len && RegexHelper::isEscapable($remainder[$i + 1])) {
+            $c = $line[$start + $i];
+            if ($c === '\\' && $i + 1 < $len && RegexHelper::isEscapable($line[$start + $i + 1])) {
                 $i++;
             } elseif ($c === '(') {
                 $openParens++;
@@ -125,7 +132,7 @@ final class LinkParserHelper
             return null;
         }
 
-        $destination = \substr($remainder, 0, $i);
+        $destination = \substr($line, $start, $i);
         $cursor->advanceBy(\mb_strlen($destination, 'UTF-8'));
 
         return $destination;

--- a/tests/pathological/test.php
+++ b/tests/pathological/test.php
@@ -188,6 +188,15 @@ $cases = [
         'input' => static fn($n) => \str_repeat('[a](b', $n),
         'expected' => static fn($n) => '<p>' . \str_repeat('[a](b', $n) . '</p>',
     ],
+    'Unclosed inline links with whitespace after the paren' => [
+        // The space is load-bearing: it routes each "(" through the whitespace skip in
+        // Cursor::advanceToNextNonSpaceOrNewline() as well as the destination scan in
+        // LinkParserHelper. Every other case here puts a non-space directly after the "(", so the
+        // destination scan is the only one they cover.
+        'sizes' => [10_000, 50_000, 200_000],
+        'input' => static fn($n) => \str_repeat('[a]( b', $n),
+        'expected' => static fn($n) => '<p>' . \str_repeat('[a]( b', $n) . '</p>',
+    ],
     'Unclosed inline links (3)' => [
         'ref' => 'https://github.com/commonmark/commonmark.js/issues/129',
         'sizes' => [1_000, 10_000, 100_000],


### PR DESCRIPTION
Follow-up to #1139. Two more places that built a copy of everything left in the block in order to read a handful of bytes from the front of it.

### `Cursor::advanceToNextNonSpaceOrNewline()`

It called `getRemainder()` and ran `/^ *(?:\n *)?/` against the copy, to consume a run that is usually one or two characters long. Spaces and newlines are single-byte ASCII and can never appear inside a multibyte UTF-8 sequence, so the run can be measured directly against the line with `strspn()` — each byte consumed is exactly one character.

A partially-consumed tab needs no special case: that state leaves the cursor sitting on the tab itself, which the existing early return already rejects before this point.

### `LinkParserHelper::manuallyParseLinkDestination()`

Same shape: it materialized the remainder, then scanned forward only as far as the first whitespace or unbalanced `)`. It now scans the line in place from `getBytePosition()`, so the work follows the length of the destination rather than the length of the rest of the block.

A partially-consumed tab needs no special handling here either — `getRemainder()` would have expanded it into leading spaces and the scan would stop on the first one, exactly as it now stops on the tab itself.

### Effect

`manuallyParseLinkDestination()` runs for every destination that doesn't open with `<`, so any `[a](…` shape gains from that half. Putting a space after the `(` adds `advanceToNextNonSpaceOrNewline()` on top, so that shape pays the copy twice per bracket and gains correspondingly more:

| input | bytes | before | after |
| --- | --- | --- | --- |
| `[a]( b` × 32,000 | 192KB | 396 ms | 249 ms |
| `[a]( b` × 64,000 | 384KB | 1030 ms (2.60x) | 516 ms (2.07x) |
| `[a]( b` × 128,000 | 768KB | 2996 ms (2.91x) | 1078 ms (2.09x) |
| `[a](b` × 32,000 | 160KB | 515 ms | 465 ms |
| `[a](b` × 64,000 | 320KB | 1199 ms (2.33x) | 1005 ms (2.16x) |
| `[a](b` × 128,000 | 640KB | 2910 ms (2.43x) | 2053 ms (2.04x) |

The bracketed figure is the growth factor per doubling of input. Before, it climbs with size; after, it settles at ~2.05.

Ordinary documents are unaffected — -0.30% on a 27KB ASCII document and -0.13% on a 44KB multibyte one, both inside the measurement noise. This is a worst-case improvement, not a throughput one.

### Testing

New pathological case, `Unclosed inline links with whitespace after the paren`. The space is what makes it new coverage rather than a duplicate of `Unclosed inline links (2)`: that case already drives `manuallyParseLinkDestination()`, but nothing in the file put whitespace after the `(`, so `advanceToNextNonSpaceOrNewline()`'s copy of the remainder was never on a hot path. Verified the new case blows the harness's growth budget against the current `2.9` (6.8s at n=200,000) and passes in ~1.8s with these changes.

`phpunit`, `phpcs` (under PHP 7.4) and `tests/pathological/test.php` all pass.
