### PR TITLE
Keep the table of contents in the document in placeholder mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Optimized inline link destination parsing to scan the line in place, so its cost follows the length of the destination rather than the length of everything left in the block
 - Changed the `TableOfContents` extension to render the table of contents once and share it across all placeholders instead of cloning it into each one (#1134)
     - A custom renderer registered for the `TableOfContents` node is no longer called once per placeholder, so it must return the same markup each time it is called for a given document (#1134)
+    - The first placeholder receives the table of contents itself, so a document still contains a `TableOfContents` node for listeners which locate and reposition it (#1143)
 
 ### Fixed
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)

--- a/docs/2.x/extensions/table-of-contents.md
+++ b/docs/2.x/extensions/table-of-contents.md
@@ -98,7 +98,7 @@ This `string` controls where in the document your table of contents will be plac
 
 If you'd like to customize this further, you can implement a [custom event listener](/2.x/customization/event-dispatcher/#registering-listeners) to locate the `TableOfContents` node and reposition it somewhere else in the document prior to rendering.
 
-In `'placeholder'` mode the table of contents is rendered once and that result is reused for every placeholder, so a [custom renderer](/2.x/customization/rendering/) for the `TableOfContents` node is not called once per placeholder and must return the same markup each time it is called for a given document.
+In `'placeholder'` mode the document contains a single `TableOfContents` node, which is the one the listener above will find, and the remaining placeholders reuse the result of rendering it.  A [custom renderer](/2.x/customization/rendering/) for that node is therefore not called once per placeholder, and must return the same markup each time it is called for a given document.
 
 ### `placeholder`
 

--- a/src/Extension/TableOfContents/TableOfContentsBuilder.php
+++ b/src/Extension/TableOfContents/TableOfContentsBuilder.php
@@ -94,9 +94,10 @@ final class TableOfContentsBuilder implements ConfigurationAwareInterface
     {
         $maxEntries = $this->config->get('table_of_contents/max_placeholder_entries');
         \assert(\is_int($maxEntries) || $maxEntries === null);
-        $perCopy = $maxEntries === null ? 0 : self::countEntries($toc);
-        $cache   = new TableOfContentsRenderCache();
-        $entries = 0;
+        $perCopy  = $maxEntries === null ? 0 : self::countEntries($toc);
+        $cache    = new TableOfContentsRenderCache();
+        $entries  = 0;
+        $anchored = false;
 
         foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
             // Add the block once we find a placeholder
@@ -109,7 +110,15 @@ final class TableOfContentsBuilder implements ConfigurationAwareInterface
                 continue;
             }
 
-            $node->replaceWith(new TableOfContentsReference($toc, $cache));
+            // The first placeholder receives the table of contents itself, so that it remains
+            // part of the document; the rest share the single result of rendering it
+            if ($anchored) {
+                $node->replaceWith(new TableOfContentsReference($toc, $cache));
+            } else {
+                $node->replaceWith($toc);
+                $anchored = true;
+            }
+
             $entries += $perCopy;
         }
     }

--- a/tests/functional/Extension/TableOfContents/TableOfContentsExtensionTest.php
+++ b/tests/functional/Extension/TableOfContents/TableOfContentsExtensionTest.php
@@ -15,8 +15,11 @@ namespace League\CommonMark\Tests\Functional\Extension\TableOfContents;
 
 use League\CommonMark\ConverterInterface;
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Event\DocumentPreRenderEvent;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\TableOfContents\Node\TableOfContents;
 use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
 use League\CommonMark\MarkdownConverter;
 use League\CommonMark\Tests\Functional\AbstractLocalDataTestCase;
@@ -42,5 +45,62 @@ final class TableOfContentsExtensionTest extends AbstractLocalDataTestCase
     public static function dataProvider(): iterable
     {
         yield from self::loadTests(__DIR__ . '/md');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function placeholderConfig(): array
+    {
+        return ['table_of_contents' => ['position' => 'placeholder', 'placeholder' => '[TOC]']];
+    }
+
+    public function testDocumentContainsOneTableOfContentsRegardlessOfPlaceholderCount(): void
+    {
+        $environment = new Environment(self::placeholderConfig());
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+        $environment->addExtension(new TableOfContentsExtension());
+
+        $found = 0;
+        $environment->addEventListener(DocumentParsedEvent::class, static function (DocumentParsedEvent $event) use (&$found): void {
+            foreach ($event->getDocument()->iterator() as $node) {
+                if ($node instanceof TableOfContents) {
+                    $found++;
+                }
+            }
+        }, -200);
+
+        $html = (new MarkdownConverter($environment))->convert("[TOC]\n\n# Alpha\n\n[TOC]\n\n# Bravo\n\n[TOC]\n")->getContent();
+
+        $this->assertSame(1, $found);
+        $this->assertSame(3, \substr_count($html, 'class="table-of-contents"'));
+    }
+
+    public function testTableOfContentsCanBeRepositionedBeforeRendering(): void
+    {
+        $environment = new Environment(self::placeholderConfig());
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+        $environment->addExtension(new TableOfContentsExtension());
+
+        $environment->addEventListener(DocumentPreRenderEvent::class, static function (DocumentPreRenderEvent $event): void {
+            foreach ($event->getDocument()->iterator() as $node) {
+                if ($node instanceof TableOfContents) {
+                    $node->detach();
+                    $event->getDocument()->prependChild($node);
+
+                    return;
+                }
+            }
+        });
+
+        $html = (new MarkdownConverter($environment))->convert("Intro.\n\n[TOC]\n\n# Alpha\n")->getContent();
+
+        $this->assertLessThan(
+            \strpos($html, '<p>Intro.</p>'),
+            \strpos($html, 'class="table-of-contents"'),
+            'The listener should have moved the table of contents above the intro paragraph',
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #1134.

That change replaced every `[TOC]` placeholder with a lightweight reference to a single shared table of contents, which is rendered once and reused. The shared node is never inserted anywhere, so in `'placeholder'` mode a document ends up containing **no** `TableOfContents` node at all.

That quietly breaks the customization the docs describe two paragraphs earlier:

> If you'd like to customize this further, you can implement a custom event listener to locate the `TableOfContents` node and reposition it somewhere else in the document prior to rendering.

There is nothing to locate, so such a listener finds nothing and silently does nothing. A `DocumentParsedEvent` listener that used to see one `TableOfContents` node per placeholder now sees zero.

### The change

The first placeholder receives the table of contents itself instead of a reference to it; the remaining placeholders keep their references to it. The rendered result is still cached on those references, so the table of contents is rendered at most twice no matter how many placeholders a document has, rather than once per placeholder.

That is the whole change - nine lines in `replacePlaceholders()`. No new classes, no new public API, and neither renderer nor the node class is touched.

### Why the cache stays on the references

Moving the cache onto the `TableOfContents` node so it could be filled by the first in-tree render would save the second render, but `TableOfContentsRenderer` is displaceable: registering your own renderer for `TableOfContents::class` at a higher priority replaces it, and with it the cache. I measured that alternative at 8 renders for 8 placeholders, exactly the behavior #1134 set out to remove. Keeping the cache on the reference renderer keeps the optimization intact whatever else is registered.

The second render costs about 0.7ms at 100 placeholders over 200 headings, against roughly 85ms saved by #1134.

### Verification

- HTML and XML output are byte-identical to #1134 for every existing fixture.
- Two new tests: one asserts the document contains exactly one `TableOfContents` node for three placeholders while still rendering three of them, the other asserts a pre-render listener can actually reposition it. Both fail against `2.9` as it stands (0 nodes found; the reposition is a no-op).
- Full suite passes; PHPStan and Psalm unchanged from the branch baseline.

### Note

This restores one `TableOfContents` node per document, not the one-per-placeholder of the pre-#1134 behavior. A listener looking for a single node works again; one expecting to iterate every copy still sees one. The docs paragraph has been updated to say so.
