### PR TITLE
Fix Cursor::match() treating text before the cursor as part of the subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Optimized inline link destination parsing to scan the line in place, so its cost follows the length of the destination rather than the length of everything left in the block
 
 ### Fixed
+- Fixed `Cursor::match()` treating text before the cursor as part of the match subject. Since 2.9.0 patterns were matched against the whole line at an offset, which silently changed the meaning of `\b`, `\B`, `\A`, lookbehinds, a `^` anywhere other than the very start of the pattern, and a leading `^` combined with the `m` modifier. No built-in parser was affected, but extensions supplying such patterns could see missed, spurious, or shifted matches
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)
 - Fixed cloning a node breaking the link from the original node's children back to their parent, silently corrupting the document that node belonged to; detaching or inserting around those children afterwards could drop nodes from the tree
 - Fixed cloned nodes sharing their `data` with the node they were cloned from, so that setting an attribute on either one also set it on the other

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -28,6 +28,28 @@ class Cursor
      */
     private const BYTE_OFFSET_CHECKPOINT_INTERVAL = 16;
 
+    /**
+     * Matches one escape pair, or one character class including a leading "^" or "]".
+     * Removing both from a pattern leaves only its structural characters behind.
+     */
+    private const ESCAPES_AND_CHARACTER_CLASSES = '/\\\\.|\[\^?\]?(?:[^\]\\\\]|\\\\.)*\]/s';
+
+    /**
+     * Upper bound on the number of distinct patterns whose match() strategy is remembered.
+     * Far above any realistic parser registry (the built-in parsers contribute about sixteen
+     * patterns), so it exists only to bound the cache against a caller that interpolates
+     * variable text into a new pattern on every call.
+     */
+    private const MAX_MEMOIZED_PATTERNS = 1024;
+
+    /**
+     * Upper bound (in bytes) on the length of a pattern eligible for memoization. Cache keys
+     * are the pattern strings themselves, so together with MAX_MEMOIZED_PATTERNS this bounds
+     * the cache's worst-case memory at about 1MB. The longest built-in pattern is 174 bytes;
+     * an oversized pattern is still classified correctly on every call, just never cached.
+     */
+    private const MAX_MEMOIZED_PATTERN_LENGTH = 1024;
+
     /** @psalm-readonly */
     private string $line;
 
@@ -91,6 +113,13 @@ class Cursor
      * @var array<int, string>
      */
     private array $charCache = [];
+
+    /**
+     * Cached isRegexOffsetSafe() verdicts, keyed by pattern.
+     *
+     * @var array<string, bool>
+     */
+    private static array $regexOffsetSafetyCache = [];
 
     /**
      * @param string $line The line being parsed (ASCII or UTF-8)
@@ -548,9 +577,10 @@ class Cursor
     {
         // When a tab has been partially consumed the remainder is reconstructed with the
         // leftover tab expanded into spaces, so matching must run against that reconstructed
-        // string rather than the raw line. This is rare; use the copy-based path to preserve
-        // the exact column arithmetic.
-        if ($this->partiallyConsumedTab) {
+        // string rather than the raw line. Patterns that inspect what precedes the match start
+        // must also see a subject that begins at the cursor. Both are rare; use the copy-based
+        // path for them.
+        if ($this->partiallyConsumedTab || ! self::isRegexOffsetSafe($regex)) {
             return $this->matchViaRemainder($regex);
         }
 
@@ -589,9 +619,120 @@ class Cursor
     }
 
     /**
-     * Slow path for match() used only when a tab has been partially consumed: match against a
-     * freshly-built remainder whose leftover tab is expanded into spaces, advancing by columns
-     * across that expansion. Kept separate so the common case avoids the remainder allocation.
+     * Whether $regex means the same thing matched against the whole line at the cursor's byte
+     * offset as it does matched against a remainder that begins at the cursor.
+     *
+     * Matching at an offset leaves the text before the cursor visible to the pattern, so anything
+     * that inspects what precedes the match start would resolve against different context: "\b",
+     * "\B" and lookbehinds read the preceding character, "\A" and a "^" other than the leading
+     * anchor assert a subject start the cursor is not, and under "m" a leading "^" also matches at
+     * every later line start rather than only at the cursor.
+     *
+     * The test is conservative: a "\b" reachable only after the pattern has consumed input reads
+     * a character the two subjects share, and so is harmless, but proving that needs a real parse
+     * of the pattern. A pattern turned away simply keeps making the copy it always made.
+     *
+     * @psalm-param non-empty-string $regex
+     */
+    private static function isRegexOffsetSafe(string $regex): bool
+    {
+        // Patterns belong to parser classes rather than to the text being parsed, so this stays
+        // at a handful of entries; the count and length caps keep a caller that interpolates
+        // variable text into its patterns from growing it without bound.
+        if (isset(self::$regexOffsetSafetyCache[$regex])) {
+            return self::$regexOffsetSafetyCache[$regex];
+        }
+
+        $result = self::classifyRegexOffsetSafety($regex);
+
+        if (\strlen($regex) <= self::MAX_MEMOIZED_PATTERN_LENGTH && \count(self::$regexOffsetSafetyCache) < self::MAX_MEMOIZED_PATTERNS) {
+            self::$regexOffsetSafetyCache[$regex] = $result;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @see isRegexOffsetSafe()
+     *
+     * @psalm-param non-empty-string $regex
+     */
+    private static function classifyRegexOffsetSafety(string $regex): bool
+    {
+        // The scans below assume the closing delimiter equals the opener and that a "[" always
+        // opens a character class rather than delimiting the whole pattern. Bracket-style and
+        // "^" delimiters are rare enough to simply take the copy path.
+        $delimiter = $regex[0];
+        if ($delimiter === '(' || $delimiter === '{' || $delimiter === '[' || $delimiter === '<' || $delimiter === '^') {
+            return false;
+        }
+
+        // Extended (x) mode turns "#" into a comment opener, and a comment is zero-width yet may
+        // contain a "[" that the class stripper below would mistake for a real class opener,
+        // swallowing an anchor hidden inside the "class". Reject anything that could contain a
+        // comment: an x in the trailing modifiers, an "(?#...)" comment (legal in any mode), or
+        // an inline flag group enabling x mid-pattern.
+        $modifiers = self::regexModifiers($regex);
+        if ($modifiers === null || \strpos($modifiers, 'x') !== false) {
+            return false;
+        }
+
+        if ($regex[1] === '^' && \strpos($modifiers, 'm') !== false) {
+            return false;
+        }
+
+        if (
+            \strpos($regex, '\\b') !== false
+            || \strpos($regex, '\\B') !== false
+            || \strpos($regex, '\\A') !== false
+            || \strpos($regex, '(?<=') !== false
+            || \strpos($regex, '(?<!') !== false
+            || \strpos($regex, '(?#') !== false
+        ) {
+            return false;
+        }
+
+        // An inline flag group such as "(?x)", "(?imx:", or "(?^x)". A preg_match() failure is
+        // treated the same as a match: unanalyzable classifies as offset-sensitive.
+        if (\preg_match('/\(\?[a-zA-Z^-]*x/', $regex) !== 0) {
+            return false;
+        }
+
+        // Strip escape pairs and character classes, where a "^" is a literal rather than an
+        // anchor, then look for an anchor other than the leading one match() rewrites into "\G".
+        // A "^" that only becomes leading once something zero-width is stripped from in front of
+        // it (such as "\G") is still a real anchor, so only a "^" at the original position 1 is
+        // exempt from the scan. A null from the stripper means the pattern could not be analyzed,
+        // which must classify it as offset-sensitive rather than safe.
+        $anchorsOnly = \preg_replace(self::ESCAPES_AND_CHARACTER_CLASSES, '', $regex);
+        if ($anchorsOnly === null) {
+            return false;
+        }
+
+        return \strpos($anchorsOnly, '^', $regex[1] === '^' ? 2 : 1) === false;
+    }
+
+    /**
+     * Return the modifier characters trailing a delimited pattern, or null if the closing
+     * delimiter cannot be located. The delimiter must not be one of the bracket-style openers,
+     * whose closer differs from the opener.
+     *
+     * @psalm-param non-empty-string $regex
+     */
+    private static function regexModifiers(string $regex): ?string
+    {
+        $end = \strrpos($regex, $regex[0]);
+        if ($end === false) {
+            return null;
+        }
+
+        return \substr($regex, $end + 1);
+    }
+
+    /**
+     * Slow path for match(): build the remainder - with any partially-consumed tab expanded
+     * into spaces - and run the pattern against that copy, so the subject genuinely begins at
+     * the cursor. Kept separate so the common case avoids the remainder allocation.
      *
      * @psalm-param non-empty-string $regex
      */
@@ -613,17 +754,19 @@ class Cursor
 
         $advance = $offset + $matchLength;
 
-        // The remainder we matched against had the partially-consumed tab expanded into spaces,
+        // The remainder we matched against had any partially-consumed tab expanded into spaces,
         // so those columns must be advanced by column instead of by character.
-        $charsToTab = 4 - ($this->column % 4);
-        if ($advance < $charsToTab) {
-            $this->advanceBy($advance, true);
+        if ($this->partiallyConsumedTab) {
+            $charsToTab = 4 - ($this->column % 4);
+            if ($advance < $charsToTab) {
+                $this->advanceBy($advance, true);
 
-            return $matches[0][0];
+                return $matches[0][0];
+            }
+
+            $this->advanceBy($charsToTab, true);
+            $advance -= $charsToTab;
         }
-
-        $this->advanceBy($charsToTab, true);
-        $advance -= $charsToTab;
 
         $this->advanceBy($advance);
 

--- a/tests/pathological/test.php
+++ b/tests/pathological/test.php
@@ -214,6 +214,14 @@ $cases = [
         'sizes' => [500, 1_000, 2_000, 4_000],
         'input' => static fn($n) => \implode('', \array_map(static fn($i) => 'e' . \str_repeat('`', $i), \range(1, $n))),
     ],
+    'Unclosable backtick opener followed by many runs' => [
+        // The leading two-backtick run can never be closed by any of the one-backtick runs that
+        // follow, so locating its closer has to walk every one of them. Unlike 'Backticks' above,
+        // whose input size grows much faster than its run count and so cannot be scaled far, this
+        // one stays linear in size, which is what makes the per-run cost visible.
+        'sizes' => [25_000, 100_000, 400_000],
+        'input' => static fn($n) => '`` ' . \str_repeat('`a ', $n),
+    ],
     'Backtick fence with a backtick in the info string' => [
         'extension' => 'commonmark',
         'sizes' => [10_000, 40_000, 160_000],

--- a/tests/unit/Parser/CursorTest.php
+++ b/tests/unit/Parser/CursorTest.php
@@ -595,6 +595,60 @@ final class CursorTest extends TestCase
     }
 
     /**
+     * @dataProvider dataForTestMatchAnchoring
+     */
+    #[DataProvider('dataForTestMatchAnchoring')]
+    public function testMatchTreatsTheCursorAsTheStartOfTheSubject(string $string, string $regex, int $initialPosition, int $expectedPosition, ?string $expectedResult): void
+    {
+        $cursor = new Cursor($string);
+        $cursor->advanceBy($initialPosition);
+
+        $this->assertSame($expectedResult, $cursor->match($regex));
+        $this->assertSame($expectedPosition, $cursor->getPosition());
+    }
+
+    /**
+     * Patterns may be matched against the full line at the cursor's offset rather than against a
+     * copy of the remainder, so anything that inspects what precedes the match start has to keep
+     * seeing the cursor as the beginning of the subject. Every case below sits at a non-zero
+     * position; none of the in-tree patterns exercises these constructs, so nothing else would
+     * catch a divergence.
+     *
+     * @return iterable<array<mixed>>
+     */
+    public static function dataForTestMatchAnchoring(): iterable
+    {
+        return [
+            'leading caret'              => ['abcdef', '/^bc/', 1, 3, 'bc'],
+            'caret inside a group'       => ['abcdef', '/(?:^)bc/', 1, 3, 'bc'],
+            'caret after an inline flag' => ['abcdef', '/(?i)^bc/', 1, 3, 'bc'],
+            'caret in a character class' => ['abcdef', '/^[^x]c?/', 1, 3, 'bc'],
+            'caret in an alternation'    => ['abcdef', '/^zz|^bc/', 1, 3, 'bc'],
+            'caret after a zero-width escape' => ['abcdef', '/\G^bc/', 1, 3, 'bc'],
+            'bracket-style delimiters'   => ['abcdef', '[^bc]', 1, 3, 'bc'],
+            'anchor after an x-mode comment hiding a bracket' => ['xbarz', "/#[\n^bar|]/x", 1, 4, 'bar'],
+            'anchor after an inline comment hiding a bracket' => ['xbarz', '/(?#[)^bar|]/', 1, 4, 'bar'],
+            'anchor after an inline x flag and comment'       => ['xbarz', "/(?x)#[\n^bar|]/", 1, 4, 'bar'],
+            'word boundary'              => ['abcdef', '/\bbc/', 1, 3, 'bc'],
+            'word boundary after leading caret' => ['foobar', '/^\b\w+/', 3, 6, 'bar'],
+            'word non-boundary'          => ['abcdef', '/\Bbc/', 1, 1, null],
+            'word boundary mid-word'     => ['aaa bbb', '/\b\w+/', 2, 3, 'a'],
+            'negative lookbehind'        => ['abcdef', '/(?<![a-z])bc/', 1, 3, 'bc'],
+            'positive lookbehind'        => ['abcdef', '/(?<=a)bc/', 1, 1, null],
+            'subject anchor'             => ['abcdef', '/\Abc/', 1, 3, 'bc'],
+            'named group'                => ['abcdef', '/^(?<n>bc)/', 1, 3, 'bc'],
+            'leading caret, multiline'   => ["ab\ncd", '/^cd/m', 1, 5, 'cd'],
+            'leading caret, multiline, from position zero' => ["ab\ncd", '/^cd/m', 0, 5, 'cd'],
+            'unanchored, multiline'      => ['abcdef', '/c{1,3}/m', 1, 3, 'c'],
+            'multibyte leading caret'    => ['Это тест', '/^то/u', 1, 3, 'то'],
+            'multibyte word boundary'    => ['Это тест', '/\bтест/u', 1, 8, 'тест'],
+            'multibyte subject anchor'   => ['ёxyz', '/\Axyz/u', 1, 4, 'xyz'],
+            'match spanning a tab'       => ["a\tbcd", '/\A\tbc/', 1, 4, "\tbc"],
+            'tab mid-match'              => ["ab\tcd", '/\Ab\tc/', 1, 4, "b\tc"],
+        ];
+    }
+
+    /**
      * @dataProvider dataForTestGetSubstring
      */
     #[DataProvider('dataForTestGetSubstring')]


### PR DESCRIPTION
### What broke

Since 2.9.0, `Cursor::match()` runs the pattern against the whole persistent line at the cursor's byte offset, rewriting a leading `^` to `\G`. That rewrite covers the common case, but PCRE keeps the text *before* a start offset visible to the pattern, so any construct that inspects what precedes the match start silently changed meaning. With the cursor advanced by 1 on `"abcdef"` (`/m` case on `"ab\ncd"`):

| pattern | 2.8.3 | 2.9.0 / 2.9.1 |
| --- | --- | --- |
| `/(?:^)bc/`, `/(?i)^bc/` | `'bc'` | `null` |
| `/\bbc/` | `'bc'` | `null` |
| `/(?<![a-z])bc/` | `'bc'` | `null` |
| `/\Abc/` | `'bc'` | `null` |
| `/^cd/m` | `'cd'` | `null` |
| `/\Bbc/` | `null` | `'bc'` |
| `/(?<=a)bc/` | `null` | `'bc'` |

Note the last two rows: the change cuts both ways, producing spurious matches as well as missed ones, and `/\b\w+/` mid-word returns a different match with a different cursor advance. No built-in parser uses any of these constructs — every in-tree pattern is either leading-`^` or purely forward-looking, which is why the test suite never noticed — but `Cursor` is public API and extensions supply their own patterns.

### Why not just revert

The in-place path is what keeps repeated `match()` calls linear. Forcing every pattern back onto the old copy-the-remainder path, on a paragraph of backtick runs whose opener can never be closed:

| n | in place | copied remainder |
| --- | --- | --- |
| 100,000 | 373 ms | 837 ms |
| 400,000 | 1,605 ms | 10,376 ms |

The gap widens with each doubling — the copy path re-copies everything left in the block on every call.

### The fix

`match()` now classifies each pattern once (memoized) as offset-safe or not:

- **Rejected outright**: `\b`, `\B`, `\A`, lookbehinds, a leading `^` combined with the `m` modifier, bracket-style or `^` delimiters, and anything that could contain a comment — the `x` modifier (trailing or via an inline flag group) or an `(?#...)` group — since a comment is zero-width yet can hide a `[` that would make the anchor scan below swallow a real anchor.
- **Anchor scan**: escape pairs and character classes — where a `^` is a literal, not an anchor — are stripped, then any `^` other than the leading one `match()` rewrites into `\G` marks the pattern offset-sensitive. Only a `^` at the original position 1 is exempt, so a `^` that becomes leading after something zero-width is stripped (such as `\G`) still counts.

Offset-sensitive patterns take the pre-2.9 copy-based path, restoring exact 2.8.3 semantics (including its partially-consumed-tab column arithmetic, which is now conditional again since the copy path no longer implies a tab). The classifier is conservative by construction: any pattern it cannot analyze — unusual delimiter, stripper failure — falls back to the always-correct copy, so a misjudgment can only cost speed, never correctness.

All built-in patterns classify as offset-safe, so core parsing keeps the fast path; the classifier itself measured +0.4% on an ASCII document and +0.02% on a multibyte one, within noise. The memo is bounded (1,024 patterns, 1,024 bytes each, ~1MB worst case) so a caller interpolating variable text into its patterns cannot grow it without bound.

### Testing

- 26 new `Cursor::match()` unit cases covering every construct above plus tab-spanning matches, multibyte subjects, alternation anchors, bracket-delimited patterns, and anchors hidden behind comments — asserting both the returned match and the resulting cursor position. 19 of them fail against the current `2.9`.
- New pathological case, `Unclosable backtick opener followed by many runs`, which guards the other direction: it times out if `match()` ever goes back to copying the remainder per call. Unlike the existing `Backticks` case, its input stays linear in the number of runs, so it can be scaled far enough to make the per-run cost visible.
- `phpunit` (4,307 tests), `tests/pathological/test.php` (67 cases), and `phpcs` under PHP 7.4 all pass.
