### PR TITLE
Fix 2.9.0 regression: restore Cursor::match() remainder semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Optimized inline link destination parsing to scan the line in place, so its cost follows the length of the destination rather than the length of everything left in the block
 
 ### Fixed
+- Fixed a regression introduced in 2.9.0 where `Cursor::match()` treated text before the cursor as part of the match subject (#1145). Patterns were matched against the whole line at an offset, which silently changed the meaning of `\b`, `\B`, `\A`, lookbehinds, a `^` anywhere other than the very start of the pattern, and a leading `^` combined with the `m` modifier. `match()` once again matches against the remainder, exactly as it did in 2.8; the core parsers keep the optimized in-place matching via a new internal method with PCRE's native offset semantics, anchoring their patterns at the cursor with `\G`
 - Fixed heading permalinks rendered with `aria-hidden="true"` remaining in the keyboard tab order; they are now also given `tabindex="-1"`, as a focusable element removed from the accessibility tree has no accessible name to announce when focused (WCAG 4.1.2)
 - Fixed cloning a node breaking the link from the original node's children back to their parent, silently corrupting the document that node belonged to; detaching or inserting around those children afterwards could drop nodes from the tree
 - Fixed cloned nodes sharing their `data` with the node they were cloned from, so that setting an attribute on either one also set it on the other

--- a/src/Extension/Attributes/Util/AttributesHelper.php
+++ b/src/Extension/Attributes/Util/AttributesHelper.php
@@ -24,7 +24,7 @@ use League\CommonMark\Util\RegexHelper;
 final class AttributesHelper
 {
     private const SINGLE_ATTRIBUTE = '\s*([.]-?[_a-z][^\s.}]*|[#][^\s}]+|' . RegexHelper::PARTIAL_ATTRIBUTENAME . RegexHelper::PARTIAL_ATTRIBUTEVALUESPEC . ')\s*';
-    private const ATTRIBUTE_LIST   = '/^{:?(' . self::SINGLE_ATTRIBUTE . ')+}/i';
+    private const ATTRIBUTE_LIST   = '/\G{:?(' . self::SINGLE_ATTRIBUTE . ')+}/i';
 
     /**
      * PCRE's `\s` matches the form feed that PHP's default trim charlist omits, so the
@@ -53,7 +53,7 @@ final class AttributesHelper
         // matching individual attributes since they won't need to look ahead for the closing '}'
         // while dealing with the fact that attributes can technically contain curly braces.
         // So we'll just match the start and end braces up front.
-        $attributeExpression = $cursor->match(self::ATTRIBUTE_LIST);
+        $attributeExpression = $cursor->matchInPlace(self::ATTRIBUTE_LIST);
         if ($attributeExpression === null) {
             $cursor->restoreState($state);
 
@@ -66,7 +66,7 @@ final class AttributesHelper
 
         /** @var array<string, mixed> $attributes */
         $attributes = [];
-        while ($attribute = \trim((string) $attributeCursor->match('/^' . self::SINGLE_ATTRIBUTE . '/i'), self::WHITESPACE)) {
+        while ($attribute = \trim((string) $attributeCursor->matchInPlace('/\G' . self::SINGLE_ATTRIBUTE . '/i'), self::WHITESPACE)) {
             if ($attribute[0] === '#') {
                 $attributes['id'] = \substr($attribute, 1);
 

--- a/src/Extension/CommonMark/Parser/Block/FencedCodeStartParser.php
+++ b/src/Extension/CommonMark/Parser/Block/FencedCodeStartParser.php
@@ -27,7 +27,7 @@ final class FencedCodeStartParser implements BlockStartParserInterface
         }
 
         $indent = $cursor->getIndent();
-        $fence  = $cursor->match('/^[ \t]*(?:`{3,}+(?!.*`)|~{3,})/');
+        $fence  = $cursor->matchInPlace('/\G[ \t]*(?:`{3,}+(?!.*`)|~{3,})/');
         if ($fence === null) {
             return BlockStart::none();
         }

--- a/src/Extension/CommonMark/Parser/Inline/BacktickParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/BacktickParser.php
@@ -110,7 +110,7 @@ final class BacktickParser implements InlineParserInterface
             return false;
         }
 
-        while ($ticks = $cursor->match('/`{1,' . self::MAX_BACKTICKS . '}/m')) {
+        while ($ticks = $cursor->matchInPlace('/`{1,' . self::MAX_BACKTICKS . '}/m')) {
             $numTicks = \strlen($ticks);
 
             // Did we find the closer?

--- a/src/Extension/CommonMark/Parser/Inline/BacktickParser.php
+++ b/src/Extension/CommonMark/Parser/Inline/BacktickParser.php
@@ -56,7 +56,7 @@ final class BacktickParser implements InlineParserInterface
         if ($this->findMatchingTicks(\strlen($ticks), $cursor)) {
             $code = $cursor->getSubstring($currentPosition, $cursor->getPosition() - $currentPosition - \strlen($ticks));
 
-            $c = \preg_replace('/\n/m', ' ', $code) ?? '';
+            $c = \preg_replace('/\n/', ' ', $code) ?? '';
 
             if (
                 $c !== '' &&
@@ -110,7 +110,7 @@ final class BacktickParser implements InlineParserInterface
             return false;
         }
 
-        while ($ticks = $cursor->matchInPlace('/`{1,' . self::MAX_BACKTICKS . '}/m')) {
+        while ($ticks = $cursor->matchInPlace('/`{1,' . self::MAX_BACKTICKS . '}/')) {
             $numTicks = \strlen($ticks);
 
             // Did we find the closer?

--- a/src/Extension/DescriptionList/Parser/DescriptionStartParser.php
+++ b/src/Extension/DescriptionList/Parser/DescriptionStartParser.php
@@ -29,7 +29,7 @@ final class DescriptionStartParser implements BlockStartParserInterface
         }
 
         $cursor->advanceToNextNonSpaceOrTab();
-        if ($cursor->match('/^:[ \t]+/') === null) {
+        if ($cursor->matchInPlace('/\G:[ \t]+/') === null) {
             return BlockStart::none();
         }
 

--- a/src/Extension/FrontMatter/FrontMatterParser.php
+++ b/src/Extension/FrontMatter/FrontMatterParser.php
@@ -23,7 +23,7 @@ final class FrontMatterParser implements FrontMatterParserInterface
     /** @psalm-readonly */
     private FrontMatterDataParserInterface $frontMatterParser;
 
-    private const REGEX_FRONT_MATTER = '/^---\\R.*?\\R---\\R/s';
+    private const REGEX_FRONT_MATTER = '/\G---\\R.*?\\R---\\R/s';
 
     public function __construct(FrontMatterDataParserInterface $frontMatterParser)
     {
@@ -38,7 +38,7 @@ final class FrontMatterParser implements FrontMatterParserInterface
         $cursor = new Cursor($markdownContent);
 
         // Locate the front matter
-        $frontMatter = $cursor->match(self::REGEX_FRONT_MATTER);
+        $frontMatter = $cursor->matchInPlace(self::REGEX_FRONT_MATTER);
         if ($frontMatter === null) {
             return new MarkdownInputWithFrontMatter($markdownContent);
         }
@@ -53,7 +53,7 @@ final class FrontMatterParser implements FrontMatterParserInterface
         $data = $this->frontMatterParser->parse($frontMatter);
 
         // Advance through any remaining newlines which separated the front matter from the Markdown text
-        $trailingNewlines = $cursor->match('/^\R+/');
+        $trailingNewlines = $cursor->matchInPlace('/\G\R+/');
 
         // Calculate how many lines the Markdown is offset from the front matter by counting the number of newlines
         // Don't forget to add 1 because we stripped one out when trimming the trailing delims

--- a/src/Extension/Table/TableStartParser.php
+++ b/src/Extension/Table/TableStartParser.php
@@ -107,7 +107,7 @@ final class TableStartParser implements BlockStartParserInterface
                         $cursor->advanceBy(1);
                     }
 
-                    if ($cursor->match('/^-+/') === null) {
+                    if ($cursor->matchInPlace('/\G-+/') === null) {
                         // Need at least one dash
                         return [];
                     }

--- a/src/Extension/TableOfContents/TableOfContentsPlaceholderParser.php
+++ b/src/Extension/TableOfContents/TableOfContentsPlaceholderParser.php
@@ -58,7 +58,7 @@ final class TableOfContentsPlaceholderParser extends AbstractBlockContinueParser
                 }
 
                 // The placeholder must be the only thing on the line
-                if ($cursor->match('/^' . \preg_quote($placeholder, '/') . '$/') === null) {
+                if ($cursor->matchInPlace('/\G' . \preg_quote($placeholder, '/') . '$/') === null) {
                     return BlockStart::none();
                 }
 

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -538,7 +538,12 @@ class Cursor
     }
 
     /**
-     * Try to match a regular expression
+     * Try to match a regular expression against the remainder of the line
+     *
+     * The subject begins at the cursor: text before the cursor is invisible to the pattern,
+     * so "^" and "\A" anchor at the cursor, and constructs which examine what precedes the
+     * match position (lookbehinds, "\b", "\B") see the start of a subject there rather than
+     * the characters actually preceding the cursor.
      *
      * Returns the matching text and advances to the end of that match
      *
@@ -546,23 +551,73 @@ class Cursor
      */
     public function match(string $regex): ?string
     {
-        // When a tab has been partially consumed the remainder is reconstructed with the
-        // leftover tab expanded into spaces, so matching must run against that reconstructed
-        // string rather than the raw line. This is rare; use the copy-based path to preserve
-        // the exact column arithmetic.
-        if ($this->partiallyConsumedTab) {
-            return $this->matchViaRemainder($regex);
+        $subject = $this->getRemainder();
+
+        if (! \preg_match($regex, $subject, $matches, \PREG_OFFSET_CAPTURE)) {
+            return null;
         }
 
-        // Match against the persistent line at the current byte offset instead of allocating a
-        // fresh copy of the remainder on every call. A leading "^" is rewritten to "\G" so the
-        // pattern still anchors to the cursor - a bare "^" only matches at the true start of the
-        // subject when a non-zero offset is supplied. Patterns that intentionally scan ahead
-        // (e.g. the backtick closer search) carry no leading "^" and are left untouched. This
-        // keeps repeated match() calls - such as that backtick scan - linear rather than O(n^2),
-        // since each call no longer copies the entire remaining line.
-        if ($regex[1] === '^') {
-            $regex = $regex[0] . '\\G' . \substr($regex, 2);
+        // $matches[0][0] contains the matched text; $matches[0][1] is its byte offset in the subject.
+        if ($this->isMultibyte) {
+            $offset      = \mb_strlen(\substr($subject, 0, $matches[0][1]), 'UTF-8');
+            $matchLength = \mb_strlen($matches[0][0], 'UTF-8');
+        } else {
+            $offset      = $matches[0][1];
+            $matchLength = \strlen($matches[0][0]);
+        }
+
+        $advance = $offset + $matchLength;
+
+        // The remainder we matched against had any partially-consumed tab expanded into spaces,
+        // so those columns must be advanced by column instead of by character.
+        if ($this->partiallyConsumedTab) {
+            $charsToTab = 4 - ($this->column % 4);
+            if ($advance < $charsToTab) {
+                $this->advanceBy($advance, true);
+
+                return $matches[0][0];
+            }
+
+            $this->advanceBy($charsToTab, true);
+            $advance -= $charsToTab;
+        }
+
+        $this->advanceBy($advance);
+
+        return $matches[0][0];
+    }
+
+    /**
+     * Try to match a regular expression at the cursor's position within the line, without
+     * copying the remainder
+     *
+     * Matches with PCRE's native offset semantics: the whole line is the subject, and matching
+     * starts at the cursor. "\G" anchors at the cursor; "^" anchors at the true start of the
+     * line (or after newlines under the "m" modifier); lookbehinds, "\b", and "\B" see the
+     * characters actually preceding the cursor. This differs from match(), whose subject begins
+     * at the cursor - a pattern written for match() migrates by replacing its leading "^" (or
+     * "\A") with "\G".
+     *
+     * Because no copy of the remainder is made, repeated calls stay linear: match() copies
+     * everything left in the line on every call, so scanning loops (such as the backtick closer
+     * search) would otherwise cost O(n^2).
+     *
+     * When a tab has been partially consumed, no position within the line can represent the
+     * cursor, so this falls back to matching the remainder with the leftover tab expanded into
+     * spaces; "\G" still anchors at the cursor there, but the line content before it is not
+     * visible in that case.
+     *
+     * @internal Planned to become public API in 2.10; until then the name and contract may
+     *           change without notice.
+     *
+     * @psalm-param non-empty-string $regex
+     */
+    public function matchInPlace(string $regex): ?string
+    {
+        // A partially-consumed tab means the remainder differs from the underlying line (the
+        // leftover tab expands into spaces), so no byte offset can represent the cursor.
+        if ($this->partiallyConsumedTab) {
+            return $this->match($regex);
         }
 
         $bytePosition = $this->isMultibyte ? $this->byteOffset($this->currentPosition) : $this->currentPosition;
@@ -584,48 +639,6 @@ class Cursor
         }
 
         $this->advanceBy($offset + $matchLength);
-
-        return $matches[0][0];
-    }
-
-    /**
-     * Slow path for match() used only when a tab has been partially consumed: match against a
-     * freshly-built remainder whose leftover tab is expanded into spaces, advancing by columns
-     * across that expansion. Kept separate so the common case avoids the remainder allocation.
-     *
-     * @psalm-param non-empty-string $regex
-     */
-    private function matchViaRemainder(string $regex): ?string
-    {
-        $subject = $this->getRemainder();
-
-        if (! \preg_match($regex, $subject, $matches, \PREG_OFFSET_CAPTURE)) {
-            return null;
-        }
-
-        if ($this->isMultibyte) {
-            $offset      = \mb_strlen(\substr($subject, 0, $matches[0][1]), 'UTF-8');
-            $matchLength = \mb_strlen($matches[0][0], 'UTF-8');
-        } else {
-            $offset      = $matches[0][1];
-            $matchLength = \strlen($matches[0][0]);
-        }
-
-        $advance = $offset + $matchLength;
-
-        // The remainder we matched against had the partially-consumed tab expanded into spaces,
-        // so those columns must be advanced by column instead of by character.
-        $charsToTab = 4 - ($this->column % 4);
-        if ($advance < $charsToTab) {
-            $this->advanceBy($advance, true);
-
-            return $matches[0][0];
-        }
-
-        $this->advanceBy($charsToTab, true);
-        $advance -= $charsToTab;
-
-        $this->advanceBy($advance);
 
         return $matches[0][0];
     }

--- a/src/Util/LinkParserHelper.php
+++ b/src/Util/LinkParserHelper.php
@@ -46,7 +46,7 @@ final class LinkParserHelper
 
     public static function parseLinkLabel(Cursor $cursor): int
     {
-        $match = $cursor->match('/^\[(?:[^\\\\\[\]]|\\\\.){0,1000}\]/');
+        $match = $cursor->matchInPlace('/\G\[(?:[^\\\\\[\]]|\\\\.){0,1000}\]/');
         if ($match === null) {
             return 0;
         }
@@ -62,7 +62,7 @@ final class LinkParserHelper
 
     public static function parsePartialLinkLabel(Cursor $cursor): ?string
     {
-        return $cursor->match('/^(?:[^\\\\\[\]]++|\\\\.?)*+/');
+        return $cursor->matchInPlace('/\G(?:[^\\\\\[\]]++|\\\\.?)*+/');
     }
 
     /**
@@ -72,7 +72,7 @@ final class LinkParserHelper
      */
     public static function parseLinkTitle(Cursor $cursor): ?string
     {
-        if ($title = $cursor->match('/' . RegexHelper::PARTIAL_LINK_TITLE . '/')) {
+        if ($title = $cursor->matchInPlace('/\G' . RegexHelper::PARTIAL_LINK_TITLE_UNANCHORED . '/')) {
             // Chop off quotes from title and unescape
             return RegexHelper::unescape(\substr($title, 1, -1));
         }
@@ -84,7 +84,7 @@ final class LinkParserHelper
     {
         $endDelimiter = \preg_quote($endDelimiter, '/');
         $regex        = \sprintf('/(%s|[^%s\x00])*(?:%s)?/', RegexHelper::PARTIAL_ESCAPED_CHAR, $endDelimiter, $endDelimiter);
-        if (($partialTitle = $cursor->match($regex)) === null) {
+        if (($partialTitle = $cursor->matchInPlace($regex)) === null) {
             return null;
         }
 
@@ -156,7 +156,7 @@ final class LinkParserHelper
             self::$lastCursor = \WeakReference::create($cursor);
         }
 
-        if ($res = $cursor->match(RegexHelper::REGEX_LINK_DESTINATION_BRACES)) {
+        if ($res = $cursor->matchInPlace('/\G' . RegexHelper::PARTIAL_LINK_DESTINATION_BRACES . '/')) {
             self::$lastCursorLacksClosingBrace = false;
 
             // Chop off surrounding <..>:

--- a/src/Util/RegexHelper.php
+++ b/src/Util/RegexHelper.php
@@ -61,9 +61,15 @@ final class RegexHelper
         self::PARTIAL_PROCESSINGINSTRUCTION . '|' . self::PARTIAL_DECLARATION . '|' . self::PARTIAL_CDATA . ')';
     public const PARTIAL_HTMLBLOCKOPEN         = '<(?:' . self::PARTIAL_BLOCKTAGNAME . '(?:[\s\/>]|$)' . '|' .
         '\/' . self::PARTIAL_BLOCKTAGNAME . '(?:[\s>]|$)' . '|' . '[?!])';
-    public const PARTIAL_LINK_TITLE            = '^(?:"(' . self::PARTIAL_ESCAPED_CHAR . '|[^"\x00])*+"' .
+    /**
+     * @internal Unanchored so each call site can supply its own anchor ("^" against a detached
+     *           string, "\G" at a cursor position). PARTIAL_LINK_TITLE is composed from this
+     *           and must keep its value, so only this fragment should be used in new code.
+     */
+    public const PARTIAL_LINK_TITLE_UNANCHORED = '(?:"(' . self::PARTIAL_ESCAPED_CHAR . '|[^"\x00])*+"' .
         '|' . '\'(' . self::PARTIAL_ESCAPED_CHAR . '|[^\'\x00])*+\'' .
         '|' . '\((' . self::PARTIAL_ESCAPED_CHAR . '|[^()\x00])*+\))';
+    public const PARTIAL_LINK_TITLE            = '^' . self::PARTIAL_LINK_TITLE_UNANCHORED;
 
     public const REGEX_PUNCTUATION        = '/^[\p{P}\p{S}]/u';
     public const REGEX_UNSAFE_PROTOCOL    = '/^(?:javascript|vbscript|file|data):/i';
@@ -73,7 +79,14 @@ final class RegexHelper
     public const REGEX_WHITESPACE_CHAR         = '/^[ \t\n\x0b\x0c\x0d]/';
     public const REGEX_UNICODE_WHITESPACE_CHAR = '/^\pZ|\s/u';
     public const REGEX_THEMATIC_BREAK          = '/^(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})$/';
-    public const REGEX_LINK_DESTINATION_BRACES = '/^(?:<(?:[^<>\\n\\\\\\x00]|\\\\.)*>)/';
+    /**
+     * @internal Unanchored so each call site can supply its own anchor ("^" against a detached
+     *           string, "\G" at a cursor position). REGEX_LINK_DESTINATION_BRACES is composed
+     *           from this and must keep its value, so only this fragment should be used in new
+     *           code.
+     */
+    public const PARTIAL_LINK_DESTINATION_BRACES = '(?:<(?:[^<>\\n\\\\\\x00]|\\\\.)*>)';
+    public const REGEX_LINK_DESTINATION_BRACES   = '/^' . self::PARTIAL_LINK_DESTINATION_BRACES . '/';
 
     /**
      * @psalm-pure

--- a/tests/pathological/test.php
+++ b/tests/pathological/test.php
@@ -214,6 +214,15 @@ $cases = [
         'sizes' => [500, 1_000, 2_000, 4_000],
         'input' => static fn($n) => \implode('', \array_map(static fn($i) => 'e' . \str_repeat('`', $i), \range(1, $n))),
     ],
+    'Unclosable backtick opener followed by many runs' => [
+        // The leading two-backtick run can never be closed by any of the one-backtick runs that
+        // follow, so locating its closer has to walk every one of them. Unlike 'Backticks' above,
+        // whose input size grows much faster than its run count and so cannot be scaled far, this
+        // one stays linear in size, which is what makes the per-run cost visible: it times out if
+        // the closer scan ever copies the remainder per call instead of matching in place.
+        'sizes' => [25_000, 100_000, 400_000],
+        'input' => static fn($n) => '`` ' . \str_repeat('`a ', $n),
+    ],
     'Backtick fence with a backtick in the info string' => [
         'extension' => 'commonmark',
         'sizes' => [10_000, 40_000, 160_000],

--- a/tests/pathological/test.php
+++ b/tests/pathological/test.php
@@ -441,6 +441,20 @@ $cases = [
         'input' => static fn($n) => \str_repeat(\str_repeat('a', 63) . '" ', $n),
         'expected' => static fn($n) => '<p>' . \str_repeat(\str_repeat('a', 63) . "\u{201C} ", $n - 1) . \str_repeat('a', 63) . "\u{201C}</p>",
     ],
+    'Many attributes in one list' => [
+        // Sized just below the ~2,400-attribute boundary where the list exhausts pcre.backtrack_limit.
+        'extension' => 'attributes',
+        'sizes' => [500, 1_000, 2_000],
+        'input' => static fn($n) => '{' . \str_repeat('#a ', $n) . "}\nx",
+        'expected' => static fn($n) => '<p id="a">x</p>',
+    ],
+    'Oversized attribute list' => [
+        // Beyond that boundary the list must degrade quickly into a literal paragraph.
+        'extension' => 'attributes',
+        'sizes' => [20_000, 80_000],
+        'input' => static fn($n) => '{' . \str_repeat('#a ', $n) . "}\nx",
+        'expected' => static fn($n) => '<p>{' . \str_repeat('#a ', $n - 1) . "#a }\nx</p>",
+    ],
     'Adjacent inline attributes at start of block' => [
         'extension' => 'attributes',
         'sizes' => [1_000, 4_000, 16_000],

--- a/tests/unit/Parser/CursorTest.php
+++ b/tests/unit/Parser/CursorTest.php
@@ -595,6 +595,148 @@ final class CursorTest extends TestCase
     }
 
     /**
+     * @dataProvider dataForTestMatchAnchoring
+     */
+    #[DataProvider('dataForTestMatchAnchoring')]
+    public function testMatchTreatsTheCursorAsTheStartOfTheSubject(string $string, string $regex, int $initialPosition, int $expectedPosition, ?string $expectedResult): void
+    {
+        $cursor = new Cursor($string);
+        $cursor->advanceBy($initialPosition);
+
+        $this->assertSame($expectedResult, $cursor->match($regex));
+        $this->assertSame($expectedPosition, $cursor->getPosition());
+    }
+
+    /**
+     * match()'s subject begins at the cursor, so anything that inspects what precedes the match
+     * start must see the start of a subject there - never the actual preceding characters - and
+     * every flavor of subject-start anchor must anchor at the cursor. Every case below sits at a
+     * non-zero position; none of the in-tree patterns exercises these constructs, so nothing
+     * else would catch a divergence.
+     *
+     * @return iterable<array<mixed>>
+     */
+    public static function dataForTestMatchAnchoring(): iterable
+    {
+        return [
+            'leading caret'              => ['abcdef', '/^bc/', 1, 3, 'bc'],
+            'caret inside a group'       => ['abcdef', '/(?:^)bc/', 1, 3, 'bc'],
+            'caret after an inline flag' => ['abcdef', '/(?i)^bc/', 1, 3, 'bc'],
+            'caret in a character class' => ['abcdef', '/^[^x]c?/', 1, 3, 'bc'],
+            'caret in an alternation'    => ['abcdef', '/^zz|^bc/', 1, 3, 'bc'],
+            'caret after a zero-width escape' => ['abcdef', '/\G^bc/', 1, 3, 'bc'],
+            'bracket-style delimiters'   => ['abcdef', '[^bc]', 1, 3, 'bc'],
+            'word boundary'              => ['abcdef', '/\bbc/', 1, 3, 'bc'],
+            'word boundary after leading caret' => ['foobar', '/^\b\w+/', 3, 6, 'bar'],
+            'word non-boundary'          => ['abcdef', '/\Bbc/', 1, 1, null],
+            'word boundary mid-word'     => ['aaa bbb', '/\b\w+/', 2, 3, 'a'],
+            'negative lookbehind'        => ['abcdef', '/(?<![a-z])bc/', 1, 3, 'bc'],
+            'positive lookbehind'        => ['abcdef', '/(?<=a)bc/', 1, 1, null],
+            'subject anchor'             => ['abcdef', '/\Abc/', 1, 3, 'bc'],
+            'named group'                => ['abcdef', '/^(?<n>bc)/', 1, 3, 'bc'],
+            'leading caret, multiline'   => ["ab\ncd", '/^cd/m', 1, 5, 'cd'],
+            'leading caret, multiline, from position zero' => ["ab\ncd", '/^cd/m', 0, 5, 'cd'],
+            'unanchored, multiline'      => ['abcdef', '/c{1,3}/m', 1, 3, 'c'],
+            'multibyte leading caret'    => ['Это тест', '/^то/u', 1, 3, 'то'],
+            'multibyte word boundary'    => ['Это тест', '/\bтест/u', 1, 8, 'тест'],
+            'multibyte subject anchor'   => ['ёxyz', '/\Axyz/u', 1, 4, 'xyz'],
+            'match spanning a tab'       => ["a\tbcd", '/\A\tbc/', 1, 4, "\tbc"],
+            'tab mid-match'              => ["ab\tcd", '/\Ab\tc/', 1, 4, "b\tc"],
+            'x-mode comment hiding a bracket'   => ['xbarz', "/#[\n^bar|]/x", 1, 4, 'bar'],
+            'inline comment hiding a bracket'   => ['xbarz', '/(?#[)^bar|]/', 1, 4, 'bar'],
+            'quoted text resembling a class'    => ['xbc]', '/\Q[\E|^bc]/', 1, 4, 'bc]'],
+        ];
+    }
+
+    /**
+     * "\G" anchors at the cursor under both contracts - match()'s detached subject and
+     * matchInPlace()'s in-place matching - so cursor-anchored (and purely forward-looking)
+     * patterns must behave identically through either method.
+     *
+     * @dataProvider dataForTestMatchInPlace
+     */
+    #[DataProvider('dataForTestMatchInPlace')]
+    public function testMatchInPlaceMatchesLikeMatchForCursorAnchoredPatterns(string $string, string $regex, int $initialPosition, int $expectedPosition, ?string $expectedResult): void
+    {
+        $cursor = new Cursor($string);
+        $cursor->advanceBy($initialPosition);
+
+        $this->assertSame($expectedResult, $cursor->matchInPlace($regex));
+        $this->assertSame($expectedPosition, $cursor->getPosition());
+
+        $viaRemainder = new Cursor($string);
+        $viaRemainder->advanceBy($initialPosition);
+
+        $this->assertSame($expectedResult, $viaRemainder->match($regex));
+        $this->assertSame($expectedPosition, $viaRemainder->getPosition());
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public static function dataForTestMatchInPlace(): iterable
+    {
+        return [
+            'cursor anchor'             => ['abcdef', '/\Gbc/', 1, 3, 'bc'],
+            'cursor anchor, no match'   => ['abcdef', '/\Gzz/', 1, 1, null],
+            'caret in a character class' => ['x[foo]', '/\G\[(?:[^\\\\\[\]]|\\\\.){0,1000}\]/', 1, 6, '[foo]'],
+            'class ] and ^ literals'    => ['xa^b', '/\G[\]^_]/', 2, 3, '^'],
+            'end anchor'                => ['ab***', '/\G(?:\*[ \t]*){3,}$/', 2, 5, '***'],
+            'lookahead'                 => ['  ```php', '/\G[ \t]*(?:`{3,}+(?!.*`)|~{3,})/', 0, 5, '  ```'],
+            'unanchored scan ahead'     => ['a `` b', '/`{1,40}/m', 1, 4, '``'],
+            'unanchored, empty match'   => ['abc', '/z?/', 1, 1, ''],
+            'multibyte cursor anchor'   => ['Это тест', '/\Gто/u', 1, 3, 'то'],
+            'multibyte scan ahead'      => ['и `` б', '/`{1,40}/m', 1, 4, '``'],
+        ];
+    }
+
+    /**
+     * matchInPlace() uses PCRE's native offset semantics: the whole line is the subject and
+     * matching starts at the cursor, so "^" and "\A" anchor at the true start of the line and
+     * lookbehinds and "\b" see the characters actually preceding the cursor. (These are the very
+     * constructs whose meaning differs from match() - compare dataForTestMatchAnchoring.)
+     *
+     * @dataProvider dataForTestMatchInPlaceEngineNativeSemantics
+     */
+    #[DataProvider('dataForTestMatchInPlaceEngineNativeSemantics')]
+    public function testMatchInPlaceTreatsTheCursorAsAPositionWithinTheLine(string $string, string $regex, int $initialPosition, int $expectedPosition, ?string $expectedResult): void
+    {
+        $cursor = new Cursor($string);
+        $cursor->advanceBy($initialPosition);
+
+        $this->assertSame($expectedResult, $cursor->matchInPlace($regex));
+        $this->assertSame($expectedPosition, $cursor->getPosition());
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public static function dataForTestMatchInPlaceEngineNativeSemantics(): iterable
+    {
+        return [
+            'caret means start of line'          => ['abcdef', '/^bc/', 1, 1, null],
+            'subject anchor means start of line' => ['abcdef', '/\Abc/', 1, 1, null],
+            'caret under /m matches line starts' => ["ab\ncd", '/^cd/m', 1, 5, 'cd'],
+            'word boundary sees preceding char'  => ['foobar', '/\G\b\w+/', 3, 3, null],
+            'lookbehind sees preceding char'     => ['abcdef', '/(?<=a)bc/', 1, 3, 'bc'],
+        ];
+    }
+
+    /**
+     * A partially-consumed tab has no byte-offset representation, so matchInPlace() must fall
+     * back to remainder matching, where the leftover tab appears as its expanded spaces and
+     * "\G" still anchors at the cursor.
+     */
+    public function testMatchInPlaceWithPartiallyConsumedTab(): void
+    {
+        $cursor = new Cursor("\tfoo");
+        $cursor->advanceBy(1, true);
+
+        $this->assertSame('   f', $cursor->matchInPlace('/\G +f/'));
+        $this->assertSame(2, $cursor->getPosition());
+    }
+
+    /**
      * @dataProvider dataForTestGetSubstring
      */
     #[DataProvider('dataForTestGetSubstring')]

--- a/tests/unit/Util/RegexHelperTest.php
+++ b/tests/unit/Util/RegexHelperTest.php
@@ -455,6 +455,20 @@ final class RegexHelperTest extends TestCase
         ];
     }
 
+    /**
+     * These public constants are now composed from internal unanchored fragments (which the
+     * cursor-based call sites anchor with "\G" instead). The public values are part of the BC
+     * surface and must not change before 3.0, so pin them to their exact historical values.
+     */
+    public function testAnchoredConstantsKeepTheirHistoricalValues(): void
+    {
+        $this->assertSame(
+            '^(?:"(\\\\[!"#$%&\'()*+,.\\/:;<=>?@[\\\\\\]^_`{|}~-]|[^"\\x00])*+"|\'(\\\\[!"#$%&\'()*+,.\\/:;<=>?@[\\\\\\]^_`{|}~-]|[^\'\\x00])*+\'|\\((\\\\[!"#$%&\'()*+,.\\/:;<=>?@[\\\\\\]^_`{|}~-]|[^()\\x00])*+\\))',
+            RegexHelper::PARTIAL_LINK_TITLE
+        );
+        $this->assertSame('/^(?:<(?:[^<>\\n\\\\\\x00]|\\\\.)*>)/', RegexHelper::REGEX_LINK_DESTINATION_BRACES);
+    }
+
     private function assertRegexMatches(string $pattern, string $string, string $message = ''): void
     {
         if (\method_exists($this, 'assertMatchesRegularExpression')) {


### PR DESCRIPTION
Closes #1145. Supersedes #1144.

### What this does

**Fixes a regression introduced in 2.9.0** by restoring `Cursor::match()` to the exact 2.8.3 contract: **the subject begins at the cursor.** Text before the cursor is invisible to the pattern, `^`/`\A` anchor at the cursor, and `\b`/lookbehinds see a subject boundary there — for every pattern, on every PCRE version, with no runtime classification anywhere. See #1145 for the full background on the two contracts and why the classification approach from #1144 was abandoned.

The in-place fast path from 2.9.0 doesn't go away — it moves to a new `@internal` method, `Cursor::matchInPlace()`, with **PCRE's native offset semantics, verbatim**: the whole line is the subject, matching starts at the cursor, `\G` anchors at the cursor, `^` means start of line, and lookbehinds/`\b` see the characters actually preceding the cursor. No pattern rewriting happens anywhere — the 14 core call sites switch to it with their patterns re-anchored from `^` to `\G` (byte-for-byte the same regex the old rewrite produced, so behavior is unchanged). Two call sites previously used public `^`-anchored `RegexHelper` constants, whose values can't change before 3.0. Those constants are now composed from new `@internal` *unanchored* fragment constants (`PARTIAL_LINK_TITLE_UNANCHORED`, `PARTIAL_LINK_DESTINATION_BRACES`) — the public values stay byte-identical by construction (pinned by a new BC test), and the call sites anchor the fragments with `\G` directly. In 2.10 the fragments can drop `@internal` and the anchored originals can be deprecated, aligning the whole `PARTIAL_` family on "fragments are unanchored; call sites choose the anchor." When a partially-consumed tab makes the remainder differ from the underlying line, `matchInPlace()` falls back to `match()` — where `\G` still anchors at the cursor, since it means "at the cursor" under both contracts.

This shape is deliberate: `matchInPlace()` is the engine-native "contract B" method discussed in #1145, planned to become public API in 2.10 by removing the `@internal` tag. Nothing about it requires callers to certify anything — it does exactly what PCRE documents. (It keeps the `matchInPlace` name rather than `matchAt` because `RegexHelper::matchAt()` already exists with detached-substring semantics — reusing that name for the opposite contract would invite confusion.)

### Security posture

- The multibyte quadratic-parsing fix from 2.9.0 (GHSA-2q4p-g7hv-5rgv) is unaffected: it lives in the byte-offset checkpoint map, which the restored remainder path also uses — remainder construction remains cheaper than it ever was in 2.8.x.
- The only two `match()`-in-a-loop sites in the tree (the backtick closer scan and the attribute list parser) are core call sites now on `matchInPlace()`, so pathological inputs keep their linear cost. A new pathological case (`Unclosable backtick opener followed by many runs`) times out if either ever regresses to copying the remainder per call.
- Third-party `match()` calls return to the pre-2.9 cost profile — one remainder copy per call, the status quo of every release before 2.9.0.

### Testing

- 26 new `match()` unit cases pinning contract-A semantics for every construct family the 2.9.0 regression affected — lookbehinds, `\b`/`\B`, `\A`, mid-pattern `^` (alternations, groups, inline flags), leading `^` with `/m`, plus the scanner-hostile shapes found during review of #1144 (`(?#…)` and `/x`-mode comments, `\Q…\E` quoting) — asserting both the returned match and the resulting cursor position.
- New `matchInPlace()` tests: a parity table proving `\G`-anchored and forward-looking patterns behave identically through `match()` and `matchInPlace()`; an engine-native semantics table pinning contract B (`^`/`\A` anchor to the line, `^` under `/m` matches later line starts, lookbehinds and `\b` see real preceding text); and the partially-consumed-tab fallback.
- A BC-pin test asserting the recomposed public `RegexHelper` constants keep their exact historical values.
- `phpunit` (4,327 tests), `tests/pathological/test.php` (67 cases), PHPStan/Psalm at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
