### PR TITLE
Treat string and array default attribute values as literals behind an opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,22 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Added `Cursor::matchInPlace()`, which matches a regular expression at the cursor's position within the line using PCRE's native offset semantics instead of copying the remainder (#1145)
     - `\G` anchors at the cursor, `^` anchors at the start of the line, and lookbehinds and `\b` see the characters actually preceding the cursor; this keeps scanning loops linear and enables left-context assertions that `match()` cannot express
 - Added `RegexHelper::PARTIAL_LINK_TITLE_UNANCHORED` and `RegexHelper::PARTIAL_LINK_DESTINATION_BRACES`, unanchored fragments so each call site can supply its own anchor
+- Added a `default_attributes` configuration format which pairs the node attribute map with a new `strict_callables` option:  `['default_attributes' => ['attributes' => [...], 'strict_callables' => true]]`.  With `strict_callables` enabled, only closures and invokable objects are treated as callbacks, so strings and arrays are always used as literal attribute values.  Callbacks written as string or array callables can be wrapped with `Closure::fromCallable()`.  The original format - passing the node map directly - is still accepted, and defaults `strict_callables` to `false`.
 
 ### Changed
 - Changed the `TableOfContents` extension to render the table of contents once and share it across all placeholders instead of cloning it into each one (#1134)
     - A custom renderer registered for the `TableOfContents` node is no longer called once per placeholder, so it must return the same markup each time it is called for a given document (#1134)
     - The first placeholder receives the table of contents itself, so a document still contains a `TableOfContents` node for listeners which locate and reposition it (#1143)
+- `$environment->getConfiguration()->get('default_attributes')` now returns the normalized structure with `attributes` and `strict_callables` keys instead of the node map; read `default_attributes/attributes` to get the map.  Configuration written in either format continues to work unchanged.
 
 ### Deprecated
 - Deprecated `RegexHelper::PARTIAL_LINK_TITLE` and `RegexHelper::REGEX_LINK_DESTINATION_BRACES`; use the unanchored variants with an explicit anchor instead
+- Deprecated the `default_attributes` `strict_callables` option, which will be removed in 3.0 when only closures and invokable objects will ever be treated as callbacks.
+
+### Fixed
+- Fixed `default_attributes` values which happen to match the name of a PHP function - such as `'class' => 'link'`, `'header'`, `'key'`, `'range'`, or `'current'` - being invoked as callbacks, producing errors like `link() expects exactly 2 arguments, 1 given`.  Enable `strict_callables` to treat strings and arrays as literal attribute values (#1123)
+- Fixed the `DefaultAttributesExtension` re-testing every configured value with `is_callable()` once per matching node, which asked the autoloader whether the first element of each array value named a real class every single time
+- Fixed a `default_attributes` value which PHP treats as callable reporting its failure from inside whichever function it collided with; the error now names the attribute and node class responsible, and keeps the original error as its previous exception
 
 ## [2.9.2] - 2026-08-10
 

--- a/docs/2.x/extensions/default-attributes.md
+++ b/docs/2.x/extensions/default-attributes.md
@@ -50,24 +50,26 @@ use League\CommonMark\Node\Block\Paragraph;
 // If you're happy with the defaults, feel free to remove them from this array
 $config = [
     'default_attributes' => [
-        Heading::class => [
-            'class' => static function (Heading $node) {
-                if ($node->getLevel() === 1) {
-                    return 'title-main';
-                } else {
-                    return null;
-                }
-            },
-        ],
-        Table::class => [
-            'class' => 'table',
-        ],
-        Paragraph::class => [
-            'class' => ['text-center', 'font-comic-sans'],
-        ],
-        Link::class => [
-            'class' => 'btn btn-link',
-            'target' => '_blank',
+        'attributes' => [
+            Heading::class => [
+                'class' => static function (Heading $node) {
+                    if ($node->getLevel() === 1) {
+                        return 'title-main';
+                    } else {
+                        return null;
+                    }
+                },
+            ],
+            Table::class => [
+                'class' => 'table',
+            ],
+            Paragraph::class => [
+                'class' => ['text-center', 'font-comic-sans'],
+            ],
+            Link::class => [
+                'class' => 'btn btn-link',
+                'target' => '_blank',
+            ],
         ],
     ],
 ];
@@ -84,16 +86,92 @@ $converter = new MarkdownConverter($environment);
 echo $converter->convert('# Hello World!');
 ```
 
+The configuration above uses the format introduced in 2.10.  If you already have `default_attributes` configured from an earlier version, see [upgrading from the older format](#upgrading-from-the-older-format).
+
 ## Configuration
 
-This extension can be configured by providing a `default_attributes` array.  Each key in the array should be a FQCN for the node class you wish to apply the default attribute to, and the values should be a map of attribute names to attribute values.
+Provide a `default_attributes` array with an `attributes` key (available since 2.10).  Each key inside it should be a FQCN for the node class you wish to apply the default attribute to, and the values should be a map of attribute names to attribute values:
+
+```php
+$config = [
+    'default_attributes' => [
+        'attributes' => [
+            Table::class => [
+                'class' => 'table',
+            ],
+        ],
+    ],
+];
+```
 
 Attribute values may be any of the following types:
 
 - `string`
 - `string[]`
 - `bool`
-- `callable` (parameter is the `Node`, return value may be `string|string[]|bool`)
+- `Closure` or invokable object (parameter is the `Node`, return value may be `string|string[]|bool`, or `null` to make no changes)
+
+### Strings that are also PHP function names
+
+PHP considers a string to be `callable` whenever it happens to match the name of a defined function, and there are quite a few short function names which also make perfectly reasonable CSS classes - `link`, `header`, `key`, `range`, and `current` among them.
+
+Only a `Closure` or an invokable object is therefore treated as a callback.  Strings and arrays are always used as literal attribute values, so `'class' => 'link'` produces `class="link"` instead of calling PHP's [`link()`](https://www.php.net/manual/en/function.link.php) function.
+
+If you have a callback written as a string or an array, wrap it with `Closure::fromCallable()`:
+
+```php
+$config = [
+    'default_attributes' => [
+        'attributes' => [
+            Heading::class => [
+                'class' => Closure::fromCallable([MyThemeHelper::class, 'headingClass']),
+            ],
+        ],
+    ],
+];
+```
+
+This is controlled by a `strict_callables` option, which is enabled by default in the format shown above.  You only need to set it yourself when using the older format below.
+
+### Upgrading from the older format
+
+This section only matters if you already have `default_attributes` configured - there's nothing here you need for new configuration.
+
+Before 2.10, `default_attributes` was the node map on its own, without the surrounding `attributes` key.  That format still works throughout the rest of 2.x:
+
+```php
+$config = [
+    'default_attributes' => [
+        Table::class => [
+            'class' => 'table',
+        ],
+    ],
+];
+```
+
+The two formats behave identically except for the default value of `strict_callables`:
+
+| Format | `strict_callables` defaults to |
+| ------ | ------------------------------ |
+| Structure with an `attributes` key (2.10 and later) | `true` |
+| Node map on its own (any version) | `false` |
+
+When it is disabled, any string or array which names a callable is invoked with the `Node` and its return value used as the attribute value - which is exactly what makes `'class' => 'link'` fail.  Configuration written before the option existed keeps that behavior so it continues working as it always has, and plain `callable` values remain allowed alongside the types listed above.
+
+You can opt in without restructuring anything else:
+
+```php
+$config = [
+    'default_attributes' => [
+        Table::class => [
+            'class' => 'table',
+        ],
+        'strict_callables' => true,
+    ],
+];
+```
+
+> Note: `strict_callables` will be removed in 3.0, when only closures and invokable objects will ever be treated as callbacks.  Enabling it now means no changes will be needed then.
 
 ## Examples
 
@@ -102,29 +180,33 @@ Here's an example that will apply Bootstrap 4 classes and attributes:
 ```php
 $config = [
     'default_attributes' => [
-        Table::class => [
-            'class' => ['table', 'table-responsive'],
-        ],
-        BlockQuote::class => [
-            'class' => 'blockquote',
+        'attributes' => [
+            Table::class => [
+                'class' => ['table', 'table-responsive'],
+            ],
+            BlockQuote::class => [
+                'class' => 'blockquote',
+            ],
         ],
     ],
 ];
 ```
 
-Here's a more complex example that uses a `callable` to add a class only if the paragraph immediately follows an `<h1>` heading:
+Here's a more complex example that uses a `Closure` to add a class only if the paragraph immediately follows an `<h1>` heading:
 
 ```php
 $config = [
     'default_attributes' => [
-        Paragraph::class => [
-            'class' => static function (Paragraph $paragraph) {
-                if ($paragraph->previous() instanceof Heading && $paragraph->previous()->getLevel() === 1) {
-                    return 'lead';
-                }
+        'attributes' => [
+            Paragraph::class => [
+                'class' => static function (Paragraph $paragraph) {
+                    if ($paragraph->previous() instanceof Heading && $paragraph->previous()->getLevel() === 1) {
+                        return 'lead';
+                    }
 
-                return null;
-            },
+                    return null;
+                },
+            ],
         ],
     ],
 ];

--- a/src/Extension/DefaultAttributes/ApplyDefaultAttributesProcessor.php
+++ b/src/Extension/DefaultAttributes/ApplyDefaultAttributesProcessor.php
@@ -15,17 +15,29 @@ namespace League\CommonMark\Extension\DefaultAttributes;
 
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Attributes\Util\AttributesHelper;
+use League\CommonMark\Node\Node;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
+use League\Config\Exception\InvalidConfigurationException;
 
 final class ApplyDefaultAttributesProcessor implements ConfigurationAwareInterface
 {
     private ConfigurationInterface $config;
 
+    /**
+     * Configured attributes with every callback already resolved to a `Closure`, keyed by node FQCN.
+     *
+     * @var array<string, array<string, mixed>>|null
+     */
+    private ?array $resolved = null;
+
     public function onDocumentParsed(DocumentParsedEvent $event): void
     {
-        /** @var array<string, array<string, mixed>> $map */
-        $map = $this->config->get('default_attributes');
+        if ($this->resolved === null) {
+            $this->resolved = $this->resolveConfiguredAttributes();
+        }
+
+        $map = $this->resolved;
 
         // Don't bother iterating if no default attributes are configured
         if (! $map) {
@@ -40,7 +52,7 @@ final class ApplyDefaultAttributesProcessor implements ConfigurationAwareInterfa
 
             $newAttributes = [];
             foreach ($attributesToApply as $name => $value) {
-                if (\is_callable($value)) {
+                if ($value instanceof \Closure) {
                     $value = $value($node);
                     // Callables are allowed to return `null` indicating that no changes should be made
                     if ($value !== null) {
@@ -61,5 +73,79 @@ final class ApplyDefaultAttributesProcessor implements ConfigurationAwareInterfa
     public function setConfiguration(ConfigurationInterface $configuration): void
     {
         $this->config = $configuration;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function resolveConfiguredAttributes(): array
+    {
+        /** @var array<string, array<string, mixed>> $map */
+        $map    = $this->config->get('default_attributes/attributes');
+        $strict = (bool) $this->config->get('default_attributes/strict_callables');
+
+        $resolved = [];
+        foreach ($map as $class => $attributes) {
+            foreach ($attributes as $name => $value) {
+                $resolved[$class][$name] = self::resolveValue($class, $name, $value, $strict);
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed A `Closure` if the value is a callback, otherwise the literal attribute value
+     */
+    private static function resolveValue(string $class, string $name, $value, bool $strict)
+    {
+        if ($value instanceof \Closure) {
+            return $value;
+        }
+
+        if (\is_string($value) || \is_array($value)) {
+            // Strings and arrays are how literal attribute values are written, and plenty of them also
+            // name a real function - PHP has a global `link()`, for example
+            if ($strict) {
+                return $value;
+            }
+
+            if (! \is_callable($value)) {
+                return $value;
+            }
+
+            return self::wrapCallable($class, $name, $value, \Closure::fromCallable($value));
+        }
+
+        return \is_callable($value) ? \Closure::fromCallable($value) : $value;
+    }
+
+    /**
+     * Invoke the callable, replacing a failure with one which names the configuration responsible.
+     *
+     * A value like `'link'` is otherwise invoked and fails deep inside whichever function it collided
+     * with, reporting an argument count the user never wrote.
+     *
+     * @param string|mixed[] $value The callable as it was written in the configuration
+     */
+    private static function wrapCallable(string $class, string $name, $value, \Closure $callback): \Closure
+    {
+        return static function (Node $node) use ($callback, $class, $name, $value) {
+            try {
+                return $callback($node);
+            } catch (\TypeError $e) {
+                throw new InvalidConfigurationException(\sprintf(
+                    'The "%s" attribute configured for %s is %s, which PHP also treats as a callable, so it was '
+                    . 'called with the node and failed: %s. If it was meant to be a literal attribute value instead, '
+                    . 'set "default_attributes/strict_callables" to true.',
+                    $name,
+                    $class,
+                    \is_string($value) ? \sprintf('the string "%s"', $value) : 'an array',
+                    $e->getMessage()
+                ), 0, $e);
+            }
+        };
     }
 }

--- a/src/Extension/DefaultAttributes/DefaultAttributesExtension.php
+++ b/src/Extension/DefaultAttributes/DefaultAttributesExtension.php
@@ -21,15 +21,52 @@ use Nette\Schema\Expect;
 
 final class DefaultAttributesExtension implements ConfigurableExtensionInterface
 {
+    /**
+     * Keys belonging to this extension's own settings rather than to a node class
+     */
+    private const RESERVED_KEYS = ['attributes' => 0, 'strict_callables' => 0];
+
     public function configureSchema(ConfigurationBuilderInterface $builder): void
     {
-        $builder->addSchema('default_attributes', Expect::arrayOf(
-            Expect::arrayOf(
-                Expect::type('string|string[]|bool|callable'), // attribute value(s)
-                'string' // attribute name
-            ),
-            'string' // node FQCN
-        )->default([]));
+        $builder->addSchema('default_attributes', Expect::structure([
+            'attributes' => Expect::arrayOf(
+                Expect::arrayOf(
+                    Expect::type('string|string[]|bool|callable'), // attribute value(s)
+                    'string' // attribute name
+                ),
+                'string' // node FQCN
+            )->default([]),
+            // @deprecated This option will be removed in 3.0, when only closures and invokable objects
+            // will ever be treated as callbacks.
+            'strict_callables' => Expect::bool()->default(true),
+        ])->before(static function ($value) {
+            if (! \is_array($value)) {
+                return $value;
+            }
+
+            $canonical = \array_intersect_key($value, self::RESERVED_KEYS);
+            $legacy    = \array_diff_key($value, self::RESERVED_KEYS);
+
+            if ($legacy === []) {
+                return $value;
+            }
+
+            // Nothing can be merged into an `attributes` which isn't an array; hand it to the schema
+            // as-is so it reports the same validation error it would without the node classes present
+            if (isset($canonical['attributes']) && ! \is_array($canonical['attributes'])) {
+                return $canonical;
+            }
+
+            $canonical['attributes'] = \array_merge($legacy, $canonical['attributes'] ?? []);
+
+            // The flat shape predates this option, so it stays on the legacy callable handling
+            // unless it opts in explicitly.
+            if (! \array_key_exists('strict_callables', $canonical)) {
+                $canonical['strict_callables'] = false;
+            }
+
+            return $canonical;
+        }));
     }
 
     public function register(EnvironmentBuilderInterface $environment): void

--- a/tests/functional/Extension/DefaultAttributes/AttributeCallbacks.php
+++ b/tests/functional/Extension/DefaultAttributes/AttributeCallbacks.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Functional\Extension\DefaultAttributes;
+
+use League\CommonMark\Node\Node;
+use League\CommonMark\Node\StringContainerInterface;
+
+final class AttributeCallbacks
+{
+    public static function cssClass(Node $node): string
+    {
+        return 'from-static-method';
+    }
+
+    /**
+     * Typed against an interface rather than against `Node` itself
+     */
+    public static function stringContainerClass(StringContainerInterface $node): string
+    {
+        return 'from-interface-typed';
+    }
+
+    public function __invoke(Node $node): string
+    {
+        return 'from-invokable';
+    }
+}

--- a/tests/functional/Extension/DefaultAttributes/DefaultAttributesConfigurationTest.php
+++ b/tests/functional/Extension/DefaultAttributes/DefaultAttributesConfigurationTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the league/commonmark package.
+ *
+ * (c) Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\CommonMark\Tests\Functional\Extension\DefaultAttributes;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
+use League\CommonMark\Node\Block\Paragraph;
+use League\Config\Configuration;
+use League\Config\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `default_attributes` option accepts both a flat map of node class => attributes and a structure
+ * which pairs that map with the `strict_callables` toggle. Both are normalized to the structure.
+ */
+final class DefaultAttributesConfigurationTest extends TestCase
+{
+    /**
+     * @dataProvider provideShapes
+     *
+     * @param array<int, array<string, mixed>>    $merges
+     * @param array<string, array<string, mixed>> $expectedAttributes
+     */
+    #[DataProvider('provideShapes')]
+    public function testShapeIsNormalized(array $merges, array $expectedAttributes, bool $expectedStrictCallables): void
+    {
+        $config = $this->buildConfiguration($merges);
+
+        $this->assertSame($expectedAttributes, $config->get('default_attributes/attributes'));
+        $this->assertSame($expectedStrictCallables, $config->get('default_attributes/strict_callables'));
+    }
+
+    /**
+     * @return iterable<string, array{array<int, array<string, mixed>>, array<string, array<string, mixed>>, bool}>
+     */
+    public static function provideShapes(): iterable
+    {
+        $link      = [Link::class => ['class' => 'btn']];
+        $paragraph = [Paragraph::class => ['class' => 'lead']];
+
+        yield 'option absent' => [[], [], true];
+
+        yield 'flat map' => [
+            [['default_attributes' => $link]],
+            $link,
+            false,
+        ];
+
+        yield 'structure with toggle' => [
+            [['default_attributes' => ['attributes' => $link, 'strict_callables' => true]]],
+            $link,
+            true,
+        ];
+
+        yield 'structure without toggle' => [
+            [['default_attributes' => ['attributes' => $link]]],
+            $link,
+            true,
+        ];
+
+        yield 'empty array' => [
+            [['default_attributes' => []]],
+            [],
+            true,
+        ];
+
+        yield 'toggle without attributes' => [
+            [['default_attributes' => ['strict_callables' => true]]],
+            [],
+            true,
+        ];
+
+        // The raw config is accumulated across merges and only validated on read, so both shapes can
+        // arrive at the normalizer as a single array holding node classes alongside reserved keys
+        yield 'flat map merged with toggle' => [
+            [
+                ['default_attributes' => $link],
+                ['default_attributes' => ['strict_callables' => true]],
+            ],
+            $link,
+            true,
+        ];
+
+        yield 'flat map and toggle in one array' => [
+            [['default_attributes' => $link + ['strict_callables' => true]]],
+            $link,
+            true,
+        ];
+
+        yield 'two flat maps' => [
+            [
+                ['default_attributes' => $link],
+                ['default_attributes' => $paragraph],
+            ],
+            $link + $paragraph,
+            false,
+        ];
+
+        yield 'flat map merged with structure' => [
+            [
+                ['default_attributes' => $link],
+                ['default_attributes' => ['attributes' => $paragraph]],
+            ],
+            $link + $paragraph,
+            false,
+        ];
+    }
+
+    public function testExplicitAttributesWinOverStrayFlatKeys(): void
+    {
+        $config = $this->buildConfiguration([
+            ['default_attributes' => [Link::class => ['class' => 'from-flat']]],
+            ['default_attributes' => ['attributes' => [Link::class => ['class' => 'from-structure']]]],
+        ]);
+
+        $this->assertSame(
+            [Link::class => ['class' => 'from-structure']],
+            $config->get('default_attributes/attributes')
+        );
+    }
+
+    public function testInvalidAttributeMapIsRejected(): void
+    {
+        $config = $this->buildConfiguration([
+            ['default_attributes' => [Link::class => 'not-an-array']],
+        ]);
+
+        $this->expectException(ValidationException::class);
+        // The path separators are surrounded by non-breaking spaces
+        $this->expectExceptionMessageMatches(
+            '/default_attributes\W+attributes\W+' . \preg_quote(Link::class, '/') . "' expects to be array/"
+        );
+
+        $config->get('default_attributes');
+    }
+
+    /**
+     * An `attributes` which isn't an array has nothing to merge node classes into, and must still be
+     * reported by the configuration layer rather than failing inside the normalizer.
+     *
+     * @dataProvider provideInvalidAttributesValues
+     *
+     * @param array<string, mixed> $merge
+     */
+    #[DataProvider('provideInvalidAttributesValues')]
+    public function testInvalidAttributesValueIsRejected(array $merge): void
+    {
+        $config = $this->buildConfiguration([['default_attributes' => $merge]]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/default_attributes\W+attributes\' expects to be array/');
+
+        $config->get('default_attributes');
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function provideInvalidAttributesValues(): iterable
+    {
+        yield 'on its own'              => [['attributes' => 'not-an-array']];
+        yield 'alongside a node class'  => [['attributes' => 'not-an-array', Link::class => ['class' => 'btn']]];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $merges
+     */
+    private function buildConfiguration(array $merges): Configuration
+    {
+        $config = new Configuration();
+        (new DefaultAttributesExtension())->configureSchema($config);
+
+        foreach ($merges as $merge) {
+            $config->merge($merge);
+        }
+
+        return $config;
+    }
+}

--- a/tests/functional/Extension/DefaultAttributes/DefaultAttributesExtensionTest.php
+++ b/tests/functional/Extension/DefaultAttributes/DefaultAttributesExtensionTest.php
@@ -16,6 +16,7 @@ namespace League\CommonMark\Tests\Functional\Extension\DefaultAttributes;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
@@ -23,11 +24,15 @@ use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 use League\CommonMark\Node\Block\Paragraph;
+use League\CommonMark\Node\Node;
+use League\Config\Exception\InvalidConfigurationException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DefaultAttributesExtensionTest extends TestCase
 {
+    private const LINK_MARKDOWN = '[league/commonmark](https://commonmark.thephpleague.com)';
+
     /**
      * @dataProvider provideTestCases
      *
@@ -43,6 +48,215 @@ final class DefaultAttributesExtensionTest extends TestCase
         $converter = new MarkdownConverter($environment);
 
         $this->assertSame($expectedHtml, \rtrim($converter->convert($markdown)->getContent()));
+    }
+
+    /**
+     * Every value form, in both callable-handling modes.
+     *
+     * @dataProvider provideValueForms
+     *
+     * @param mixed $value
+     */
+    #[DataProvider('provideValueForms')]
+    public function testValueForm($value, bool $strictCallables, string $expectedClass): void
+    {
+        $html = $this->convertLink($value, $strictCallables);
+
+        $this->assertSame(
+            \sprintf('<p><a class="%s" href="https://commonmark.thephpleague.com">league/commonmark</a></p>', $expectedClass),
+            $html
+        );
+    }
+
+    /**
+     * @return iterable<string, array{mixed, bool, string}>
+     */
+    public static function provideValueForms(): iterable
+    {
+        $staticMethod = AttributeCallbacks::class . '::cssClass';
+
+        // Strings which happen to name a PHP function are values, not callbacks (#1123)
+        foreach (['link', 'header', 'key', 'range', 'current'] as $collision) {
+            yield 'strict: "' . $collision . '"' => [$collision, true, $collision];
+        }
+
+        yield 'strict: multi-word string'   => ['btn btn-link', true, 'btn btn-link'];
+        yield 'strict: string[]'            => [['btn', 'btn-primary'], true, 'btn btn-primary'];
+        yield 'strict: static method string' => [$staticMethod, true, $staticMethod];
+        yield 'strict: array callable'      => [[AttributeCallbacks::class, 'cssClass'], true, AttributeCallbacks::class . ' cssClass'];
+        yield 'strict: closure'             => [static fn (Node $node): string => 'from-closure', true, 'from-closure'];
+        yield 'strict: fromCallable'        => [\Closure::fromCallable([AttributeCallbacks::class, 'cssClass']), true, 'from-static-method'];
+        yield 'strict: invokable object'    => [new AttributeCallbacks(), true, 'from-invokable'];
+
+        yield 'legacy: multi-word string'   => ['btn btn-link', false, 'btn btn-link'];
+        yield 'legacy: string[]'            => [['btn', 'btn-primary'], false, 'btn btn-primary'];
+        yield 'legacy: static method string' => [$staticMethod, false, 'from-static-method'];
+        yield 'legacy: array callable'      => [[AttributeCallbacks::class, 'cssClass'], false, 'from-static-method'];
+        yield 'legacy: closure'             => [static fn (Node $node): string => 'from-closure', false, 'from-closure'];
+        yield 'legacy: fromCallable'        => [\Closure::fromCallable([AttributeCallbacks::class, 'cssClass']), false, 'from-static-method'];
+        yield 'legacy: invokable object'    => [new AttributeCallbacks(), false, 'from-invokable'];
+    }
+
+    /**
+     * Legacy mode still invokes string callables, but a value which collided with an unrelated function
+     * should name the configuration responsible rather than failing inside that function.
+     *
+     * @dataProvider provideCollidingStrings
+     */
+    #[DataProvider('provideCollidingStrings')]
+    public function testCollidingStringInLegacyModeNamesTheConfiguration(string $value): void
+    {
+        // Only the wording this library controls is asserted here; PHP's own message for the collided
+        // function differs between versions, and is covered by the previous-exception test below
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'The "class" attribute configured for %s is the string "%s", which PHP also treats as a callable, '
+            . 'so it was called with the node and failed:',
+            Link::class,
+            $value
+        ));
+
+        $this->convertLink($value, false);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideCollidingStrings(): iterable
+    {
+        yield 'wrong argument count' => ['link'];
+        yield 'wrong argument type'  => ['header'];
+    }
+
+    /**
+     * The underlying error is preserved so the original cause is never lost.
+     */
+    public function testCollidingStringExceptionKeepsTheOriginalError(): void
+    {
+        try {
+            $this->convertLink('link', false);
+            $this->fail('Expected an ' . InvalidConfigurationException::class);
+        } catch (InvalidConfigurationException $e) {
+            $previous = $e->getPrevious();
+
+            $this->assertInstanceOf(\ArgumentCountError::class, $previous);
+            $this->assertStringContainsString($previous->getMessage(), $e->getMessage());
+        }
+    }
+
+    /**
+     * Only values which actually get invoked can fail, so a collision configured for a node type the
+     * document never contains stays inert.
+     */
+    public function testCollidingStringIsInertWhenNoSuchNodeExists(): void
+    {
+        $environment = new Environment(['default_attributes' => [Table::class => ['class' => 'link']]]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new TableExtension());
+        $environment->addExtension(new DefaultAttributesExtension());
+
+        $this->assertSame(
+            '<p>no tables here</p>',
+            \rtrim((new MarkdownConverter($environment))->convert('no tables here')->getContent())
+        );
+    }
+
+    /**
+     * Strict mode makes no exception for arrays which happen to be callable, so enabling it produces
+     * exactly the behavior 3.0 will have.
+     */
+    public function testEveryArrayIsLiteralInStrictMode(): void
+    {
+        $this->assertSame(
+            '<p><a class="' . AttributeCallbacks::class . ' cssClass" href="https://commonmark.thephpleague.com">league/commonmark</a></p>',
+            $this->convertLink([AttributeCallbacks::class, 'cssClass'], true)
+        );
+    }
+
+    /**
+     * @dataProvider provideBothModes
+     */
+    #[DataProvider('provideBothModes')]
+    public function testBooleanValue(bool $strictCallables): void
+    {
+        $environment = new Environment([
+            'default_attributes' => [
+                'attributes' => [Link::class => ['data-tracked' => true]],
+                'strict_callables' => $strictCallables,
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new DefaultAttributesExtension());
+
+        $this->assertSame(
+            '<p><a data-tracked href="https://commonmark.thephpleague.com">league/commonmark</a></p>',
+            \rtrim((new MarkdownConverter($environment))->convert(self::LINK_MARKDOWN)->getContent())
+        );
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function provideBothModes(): iterable
+    {
+        yield 'strict' => [true];
+        yield 'legacy' => [false];
+    }
+
+    /**
+     * The upgrade path for someone already using the flat shape: keep it, add the toggle.
+     */
+    public function testFlatShapeWithToggleAppliesStrictHandling(): void
+    {
+        $environment = new Environment([
+            'default_attributes' => [
+                Link::class => ['class' => 'link'],
+                'strict_callables' => true,
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new DefaultAttributesExtension());
+
+        $this->assertSame(
+            '<p><a class="link" href="https://commonmark.thephpleague.com">league/commonmark</a></p>',
+            \rtrim((new MarkdownConverter($environment))->convert(self::LINK_MARKDOWN)->getContent())
+        );
+    }
+
+    /**
+     * A callback typed against an interface the configured node implements is still a valid callback.
+     */
+    public function testLegacyCallbackTypedAgainstAnImplementedInterfaceIsAccepted(): void
+    {
+        $environment = new Environment([
+            'default_attributes' => [
+                FencedCode::class => ['class' => AttributeCallbacks::class . '::stringContainerClass'],
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new DefaultAttributesExtension());
+
+        $this->assertSame(
+            "<pre><code class=\"from-interface-typed\">hi\n</code></pre>",
+            \rtrim((new MarkdownConverter($environment))->convert("```\nhi\n```")->getContent())
+        );
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function convertLink($value, bool $strictCallables): string
+    {
+        $environment = new Environment([
+            'default_attributes' => [
+                'attributes' => [Link::class => ['class' => $value]],
+                'strict_callables' => $strictCallables,
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new DefaultAttributesExtension());
+
+        return \rtrim((new MarkdownConverter($environment))->convert(self::LINK_MARKDOWN)->getContent());
     }
 
     /**


### PR DESCRIPTION
Closes #1123. Alternative to #1126.

## The problem

PHP treats a string as `callable` whenever it matches the name of a defined function, and `DefaultAttributesExtension` tested every configured value with `is_callable()`. Since PHP ships a global [`link()`](https://www.php.net/manual/en/function.link.php), this:

```php
'default_attributes' => [Link::class => ['class' => 'link']]
```

...called `link()` with the node and died with `ArgumentCountError: link() expects exactly 2 arguments, 1 given`.

It isn't one unlucky word. `header`, `key`, `range`, `current`, `date`, `min`, `sort` and others collide too — `key` and `current` don't even throw, they silently render garbage like `class="data"`. Any single-token value is a landmine; `btn btn-link` only works because a space makes it an invalid function name.

## The fix

A `strict_callables` option. When enabled, only closures and invokable objects are treated as callbacks, so strings and arrays are always literal attribute values.

It ships alongside a new configuration shape, and the two differ only in that option's default:

```php
// since 2.10 — strict_callables defaults to true
'default_attributes' => [
    'attributes' => [Link::class => ['class' => 'link']],   // => class="link"
]

// original shape, still supported — strict_callables defaults to false
'default_attributes' => [
    Link::class => ['class' => 'link'],                     // => still calls link()
    'strict_callables' => true,                             // ...unless you opt in
]
```

Existing configuration therefore behaves exactly as it always has, and `strict_callables` becomes the only behavior in 3.0 (it's marked deprecated on arrival). A `Closure` works identically in both modes, so callbacks can be migrated with `Closure::fromCallable()` ahead of time and 3.0 becomes a no-op.

Both shapes are normalized to one internal structure by a `before()` hook on the schema, so the processor never sniffs shapes at runtime. The normalizer splits reserved keys from node-class keys rather than sniffing all-or-nothing, because `league/config` validates lazily — a flat map merged with `['strict_callables' => true]` arrives as a single array holding both.

**Targeted at `main`** per the PR template, since this is a new feature plus a deprecation rather than a behavior change to an existing branch.

## Also fixed along the way

- **`is_callable()` was probing the autoloader once per node.** With `$syntax_only = false` (the default) it asks whether `btn` is a real class, so `'class' => ['btn', 'btn-primary']` — the most common usage — triggered an uncached autoload attempt for every matching node. Classification is now resolved once per environment instead of per node: 10 links across 2 documents went from 10 probes to 1 (legacy) or 0 (strict).
- **Failures now name the configuration responsible.** When a value is still invoked and fails, the error identifies the attribute and node class and keeps the original as its previous exception, rather than surfacing only whatever the collided function reported.

## Backward compatibility

Configuration written against the old shape is unaffected — that's the point of the flat shape pinning `strict_callables` to `false`.

One thing does change: `$config->get('default_attributes')` now returns the normalized structure (`attributes` + `strict_callables`) instead of the node map, and `get('default_attributes/' . SomeNode::class)` throws `UnknownOptionException` rather than returning the map. This only affects code *reading* the config back. It's noted in the changelog under `### Changed`.

## Testing

- Full suite passes (4371 tests). New coverage runs every value form — colliding strings, string arrays, static-method strings, array callables, closures, `Closure::fromCallable`, invokable objects, bools — across both modes, plus config-shape tests for the normalizer including the multi-merge and mixed-shape cases.
- PHPStan at its existing baseline; Psalm shows nothing beyond pre-existing repo-wide noise.
- Everything parses on PHP 7.4; `markdownlint` clean under the docs config CI uses.

## Open item

- The docs name **2.10** in five places while the changelog entries sit under `[Unreleased]`. If this ships as another version, those need a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

