### PR TITLE
Add slug_normalizer/reserved option for avoiding collisions with page IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
     - `\G` anchors at the cursor, `^` anchors at the start of the line, and lookbehinds and `\b` see the characters actually preceding the cursor; this keeps scanning loops linear and enables left-context assertions that `match()` cannot express
 - Added `RegexHelper::PARTIAL_LINK_TITLE_UNANCHORED` and `RegexHelper::PARTIAL_LINK_DESTINATION_BRACES`, unanchored fragments so each call site can supply its own anchor
 - Added a `default_attributes` configuration format which pairs the node attribute map with a new `strict_callables` option:  `['default_attributes' => ['attributes' => [...], 'strict_callables' => true]]`.  With `strict_callables` enabled, only closures and invokable objects are treated as callbacks, so strings and arrays are always used as literal attribute values.  Callbacks written as string or array callables can be wrapped with `Closure::fromCallable()`.  The original format - passing the node map directly - is still accepted, and defaults `strict_callables` to `false`.
+- Added a new `slug_normalizer/reserved` option which treats the given slugs as already-used, so colliding headings receive an incremental numeric suffix just like duplicate headings do (#1080)
 
 ### Changed
 - Changed the `TableOfContents` extension to render the table of contents once and share it across all placeholders instead of cloning it into each one (#1134)
@@ -27,6 +28,8 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 - Fixed `default_attributes` values which happen to match the name of a PHP function - such as `'class' => 'link'`, `'header'`, `'key'`, `'range'`, or `'current'` - being invoked as callbacks, producing errors like `link() expects exactly 2 arguments, 1 given`.  Enable `strict_callables` to treat strings and arrays as literal attribute values (#1123)
 - Fixed the `DefaultAttributesExtension` re-testing every configured value with `is_callable()` once per matching node, which asked the autoloader whether the first element of each array value named a real class every single time
 - Fixed a `default_attributes` value which PHP treats as callable reporting its failure from inside whichever function it collided with; the error now names the attribute and node class responsible, and keeps the original error as its previous exception
+- Fixed custom `UniqueSlugNormalizerInterface` implementations being wrapped by the built-in `UniqueSlugNormalizer` and never receiving the documented `clearHistory()` calls, which caused slug history to leak across documents when `slug_normalizer/unique` was set to `'document'` (#1080)
+    - Custom implementations are now trusted to enforce uniqueness themselves, per the interface contract; the extra deduplication layer the wrapper used to provide is no longer applied on top of them
 
 ## [2.9.2] - 2026-08-10
 

--- a/docs/2.x/configuration.md
+++ b/docs/2.x/configuration.md
@@ -93,6 +93,7 @@ Here's a list of the core configuration options available:
   - `instance` - An alternative normalizer to use (defaults to the included `SlugNormalizer`)
   - `max_length` - Limits the size of generated slugs (defaults to 255 characters)
   - `unique` - Controls whether slugs should be unique per `'document'` (default) or per `'environment'`; can be disabled with `false`
+  - `reserved` - List of slugs which should be treated as if they were already used, so colliding content receives a numeric suffix instead (defaults to `[]`)
 
 Additional configuration options are available for most of the [available extensions](/2.x/customization/extensions/) - refer to their individual documentation for more details.  For example, the CommonMark core extension offers these additional options:
 

--- a/docs/2.x/customization/slug-normalizer.md
+++ b/docs/2.x/customization/slug-normalizer.md
@@ -118,7 +118,7 @@ Perhaps the page surrounding your rendered Markdown already uses certain HTML ID
 
 There are two different levers for avoiding this kind of collision:
 
-- The [`heading_permalink/id_prefix` option](/2.x/extensions/heading-permalinks/#id_prefix) prepends a prefix to **every** generated ID.  Its default value of `'content'` means generated IDs like `content-comments` can never collide with your page's own IDs - so if you keep that default, you're already protected and don't need this option.
+- The [`heading_permalink/id_prefix` option](/2.x/extensions/heading-permalinks/#id_prefix) prepends a prefix to **every** generated ID.  Its default value of `'content'` acts as a namespace: as long as nothing else on your page uses IDs starting with `content-`, generated IDs like `content-comments` cannot collide - so with the default prefix you typically don't need this option.
 - The `reserved` option protects only the **specific** slugs you list, leaving all other IDs clean and prefix-free.  This is useful when you've set `id_prefix` to an empty string because you want pretty anchors like `#introduction` instead of `#content-introduction`.
 
 The `reserved` option accepts a list of slugs that should be treated as if they were already used.  Any Markdown content that would normally generate one of these slugs will automatically receive an incremental numeric suffix instead, exactly as if a duplicate heading had appeared earlier in the document:
@@ -138,6 +138,6 @@ $config = [
 
 With this configuration, a `## Comments` heading would be given a slug of `comments-1` instead of `comments`, avoiding a collision with the page's own `id="comments"` element.
 
-Note that reserved slugs are compared against the final, normalized slug (before any `heading_permalink/id_prefix` is applied), so they should be listed in that same normalized form: `comments`, not `Comments!`.  This also means that if you do use an `id_prefix`, the prefix should not be included in the reserved entries.
+Note that reserved slugs are compared against the final, normalized slug (before any `heading_permalink/id_prefix` is applied), so they should be listed in that same normalized form: `comments`, not `Comments!`.  This also means that if you do use an `id_prefix`, the prefix should not be included in the reserved entries: if your page contains a prefixed ID like `content-comments` while using the default prefix, reserve the unprefixed slug instead: `'reserved' => ['comments']`.
 
 This option only applies when the `unique` option is enabled and the `instance` doesn't implement `UniqueSlugNormalizerInterface` itself.  (If you bring your own unique normalizer, honoring reserved slugs is up to your implementation.)

--- a/docs/2.x/customization/slug-normalizer.md
+++ b/docs/2.x/customization/slug-normalizer.md
@@ -111,3 +111,33 @@ This option controls whether slugs should be unique.  Possible values include:
 You might have a use case where you're converting several different Markdown documents on the same page and so you'd like to ensure that none of those documents use conflicting slugs.  In that case, you should set the `scope` option to `'environment'` to ensure that a single instance of a `MarkdownConverter` (which uses a single `Environment`) will never produce the same slug twice during its lifetime (which usually lasts the entire duration of a single HTTP request).
 
 If you need complete control over how unique slugs are generated, make your `'instance'` implement `UniqueSlugNormalizerInterface`; otherwise, we'll simply append incremental numbers to slugs to ensure they are unique.
+
+### `reserved`
+
+Perhaps the page surrounding your rendered Markdown already uses certain HTML IDs - maybe your site header has `id="site-logo"` or your comment section uses `id="comments"`.  If a Markdown heading happens to normalize to one of those same slugs you'd end up with duplicate IDs on the page.
+
+There are two different levers for avoiding this kind of collision:
+
+- The [`heading_permalink/id_prefix` option](/2.x/extensions/heading-permalinks/#id_prefix) prepends a prefix to **every** generated ID.  Its default value of `'content'` means generated IDs like `content-comments` can never collide with your page's own IDs - so if you keep that default, you're already protected and don't need this option.
+- The `reserved` option protects only the **specific** slugs you list, leaving all other IDs clean and prefix-free.  This is useful when you've set `id_prefix` to an empty string because you want pretty anchors like `#introduction` instead of `#content-introduction`.
+
+The `reserved` option accepts a list of slugs that should be treated as if they were already used.  Any Markdown content that would normally generate one of these slugs will automatically receive an incremental numeric suffix instead, exactly as if a duplicate heading had appeared earlier in the document:
+
+```php
+$config = [
+    'heading_permalink' => [
+        // No prefixes, so generated IDs and fragments exactly match the heading slugs
+        'id_prefix' => '',
+        'fragment_prefix' => '',
+    ],
+    'slug_normalizer' => [
+        'reserved' => ['site-logo', 'comments'],
+    ],
+];
+```
+
+With this configuration, a `## Comments` heading would be given a slug of `comments-1` instead of `comments`, avoiding a collision with the page's own `id="comments"` element.
+
+Note that reserved slugs are compared against the final, normalized slug (before any `heading_permalink/id_prefix` is applied), so they should be listed in that same normalized form: `comments`, not `Comments!`.  This also means that if you do use an `id_prefix`, the prefix should not be included in the reserved entries.
+
+This option only applies when the `unique` option is enabled and the `instance` doesn't implement `UniqueSlugNormalizerInterface` itself.  (If you bring your own unique normalizer, honoring reserved slugs is up to your implementation.)

--- a/docs/2.x/extensions/heading-permalinks.md
+++ b/docs/2.x/extensions/heading-permalinks.md
@@ -83,6 +83,8 @@ The value of this nested configuration option should be a `string` that you want
 
 This should be a `string` you want prepended to HTML IDs.  This prevents generating HTML ID attributes which might conflict with others in your stylesheet.  A dash separator (`-`) will be added between the prefix and the ID.  You can instead set this to an empty string (`''`) if you don't want a prefix.
 
+Note that removing the prefix means a heading like `## Comments` will generate the ID `comments`, which could collide with an existing `id="comments"` element elsewhere on your page.  If you only need to protect a handful of known IDs like that, the [`slug_normalizer/reserved` option](/2.x/customization/slug-normalizer/#reserved) is a more surgical lever for the same problem: it suffixes just the conflicting slugs while every other ID stays clean and prefix-free.
+
 ### `apply_id_to_heading`
 
 If this value is `true`, the `id` attributes will be written to the `<h>` tag instead of the `<a>`.

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -400,11 +400,13 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
             \assert($normalizer instanceof TextNormalizerInterface);
             $this->injectEnvironmentAndConfigurationIfNeeded($normalizer);
 
-            if ($this->config->get('slug_normalizer/unique') !== UniqueSlugNormalizerInterface::DISABLED && ! $normalizer instanceof UniqueSlugNormalizer) {
-                $normalizer = new UniqueSlugNormalizer($normalizer);
+            if ($this->config->get('slug_normalizer/unique') !== UniqueSlugNormalizerInterface::DISABLED && ! $normalizer instanceof UniqueSlugNormalizerInterface) {
+                /** @var string[] $reserved */
+                $reserved   = $this->config->get('slug_normalizer/reserved');
+                $normalizer = new UniqueSlugNormalizer($normalizer, $reserved);
             }
 
-            if ($normalizer instanceof UniqueSlugNormalizer) {
+            if ($normalizer instanceof UniqueSlugNormalizerInterface) {
                 if ($this->config->get('slug_normalizer/unique') === UniqueSlugNormalizerInterface::PER_DOCUMENT) {
                     $this->addEventListener(DocumentParsedEvent::class, [$normalizer, 'clearHistory'], -1000);
                 }
@@ -445,6 +447,7 @@ final class Environment implements EnvironmentInterface, EnvironmentBuilderInter
                 'instance' => Expect::type(TextNormalizerInterface::class)->default(new SlugNormalizer()),
                 'max_length' => Expect::int()->min(0)->default(255),
                 'unique' => Expect::anyOf(UniqueSlugNormalizerInterface::DISABLED, UniqueSlugNormalizerInterface::PER_ENVIRONMENT, UniqueSlugNormalizerInterface::PER_DOCUMENT)->default(UniqueSlugNormalizerInterface::PER_DOCUMENT),
+                'reserved' => Expect::listOf('string')->default([]),
             ]),
         ]);
     }

--- a/src/Normalizer/UniqueSlugNormalizer.php
+++ b/src/Normalizer/UniqueSlugNormalizer.php
@@ -17,21 +17,40 @@ namespace League\CommonMark\Normalizer;
 final class UniqueSlugNormalizer implements UniqueSlugNormalizerInterface
 {
     private TextNormalizerInterface $innerNormalizer;
+
+    /**
+     * Slugs claimed by the surrounding page (in final, normalized form), seeded as if they'd
+     * already been handed out once, so the first colliding slug gets a "-1" suffix.
+     * Unlike regular history, these survive clearHistory().
+     *
+     * @var array<string, int>
+     */
+    private array $reserved = [];
+
     /**
      * Every slug we've handed out, mapped to the next numeric suffix to try for it
      *
      * @var array<string, int>
      */
-    private array $alreadyUsed = [];
+    private array $alreadyUsed;
 
-    public function __construct(TextNormalizerInterface $innerNormalizer)
+    /**
+     * @param iterable<string> $reservedSlugs
+     */
+    public function __construct(TextNormalizerInterface $innerNormalizer, iterable $reservedSlugs = [])
     {
         $this->innerNormalizer = $innerNormalizer;
+
+        foreach ($reservedSlugs as $slug) {
+            $this->reserved[$slug] = 1;
+        }
+
+        $this->alreadyUsed = $this->reserved;
     }
 
     public function clearHistory(): void
     {
-        $this->alreadyUsed = [];
+        $this->alreadyUsed = $this->reserved;
     }
 
     /**

--- a/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
+++ b/tests/functional/Extension/HeadingPermalink/HeadingPermalinkExtensionTest.php
@@ -51,6 +51,54 @@ final class HeadingPermalinkExtensionTest extends TestCase
         yield ["# Hello World!\n\n# Hello World!", \sprintf("<h1><a id=\"content-hello-world\" href=\"#content-hello-world\" class=\"heading-permalink\" aria-hidden=\"true\" tabindex=\"-1\" title=\"Permalink\">%s</a>Hello World!</h1>\n<h1><a id=\"content-hello-world-1\" href=\"#content-hello-world-1\" class=\"heading-permalink\" aria-hidden=\"true\" tabindex=\"-1\" title=\"Permalink\">%s</a>Hello World!</h1>", HeadingPermalinkRenderer::DEFAULT_SYMBOL, HeadingPermalinkRenderer::DEFAULT_SYMBOL)];
     }
 
+    public function testHeadingPermalinksWithReservedSlugs(): void
+    {
+        $environment = new Environment([
+            'heading_permalink' => [
+                'symbol' => '',
+                'id_prefix' => '',
+                'fragment_prefix' => '',
+            ],
+            'slug_normalizer' => [
+                'reserved' => ['comments', 'site-logo'],
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        $input = "## Comments\n\n## Site Logo\n\n## Comments\n\n## Something Else";
+
+        $expected = <<<'HTML'
+<h2><a id="comments-1" href="#comments-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink"></a>Comments</h2>
+<h2><a id="site-logo-1" href="#site-logo-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink"></a>Site Logo</h2>
+<h2><a id="comments-2" href="#comments-2" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink"></a>Comments</h2>
+<h2><a id="something-else" href="#something-else" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink"></a>Something Else</h2>
+HTML;
+
+        $this->assertEquals($expected, \trim((string) $converter->convert($input)));
+    }
+
+    public function testHeadingPermalinksWithReservedSlugsAndDefaultIdPrefix(): void
+    {
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'reserved' => ['comments'],
+            ],
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        // Reserved slugs are matched before the 'content' id_prefix is applied, so the
+        // suffix appears even though the prefixed ID never collided with 'comments' itself.
+        $expected = \sprintf('<h2><a id="content-comments-1" href="#content-comments-1" class="heading-permalink" aria-hidden="true" tabindex="-1" title="Permalink">%s</a>Comments</h2>', HeadingPermalinkRenderer::DEFAULT_SYMBOL);
+
+        $this->assertEquals($expected, \trim((string) $converter->convert('## Comments')));
+    }
+
     /**
      * @dataProvider dataProviderForTestHeadingPermalinksWithCustomOptions
      */

--- a/tests/unit/Environment/EnvironmentTest.php
+++ b/tests/unit/Environment/EnvironmentTest.php
@@ -27,7 +27,10 @@ use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Normalizer\SlugNormalizer;
 use League\CommonMark\Normalizer\TextNormalizerInterface;
+use League\CommonMark\Normalizer\UniqueSlugNormalizer;
+use League\CommonMark\Normalizer\UniqueSlugNormalizerInterface;
 use League\CommonMark\Parser\Block\BlockStartParserInterface;
 use League\CommonMark\Parser\Block\SkipLinesStartingWithLettersParser;
 use League\CommonMark\Parser\Inline\InlineParserInterface;
@@ -558,6 +561,116 @@ final class EnvironmentTest extends TestCase
         $this->assertSame('foo-3', $normalizer->normalize('Foo'));
         $this->assertSame('foo-4', $normalizer->normalize('Foo'));
         $this->assertSame('foo-5', $normalizer->normalize('Foo'));
+    }
+
+    public function testUniqueSlugNormalizerWithReservedSlugs(): void
+    {
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'reserved' => ['foo'],
+            ],
+        ]);
+
+        $normalizer = $environment->getSlugNormalizer();
+        $this->assertSame('foo-1', $normalizer->normalize('Foo'));
+        $this->assertSame('foo-2', $normalizer->normalize('Foo'));
+        $this->assertSame('bar', $normalizer->normalize('Bar'));
+
+        $environment->dispatch(new DocumentParsedEvent(new Document()));
+
+        $this->assertSame('foo-1', $normalizer->normalize('Foo'));
+        $this->assertSame('bar', $normalizer->normalize('Bar'));
+    }
+
+    public function testReservedSlugsAreIgnoredWhenUniquenessIsDisabled(): void
+    {
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'unique' => false,
+                'reserved' => ['foo'],
+            ],
+        ]);
+
+        $normalizer = $environment->getSlugNormalizer();
+        $this->assertSame('foo', $normalizer->normalize('Foo'));
+        $this->assertSame('foo', $normalizer->normalize('Foo'));
+    }
+
+    public function testReservedSlugsAreIgnoredWhenCustomUniqueNormalizerIsProvided(): void
+    {
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'instance' => new UniqueSlugNormalizer(new SlugNormalizer()),
+                'reserved' => ['foo'],
+            ],
+        ]);
+
+        $normalizer = $environment->getSlugNormalizer();
+        $this->assertSame('foo', $normalizer->normalize('Foo'));
+        $this->assertSame('foo-1', $normalizer->normalize('Foo'));
+    }
+
+    public function testReservedSlugsPerEnvironment(): void
+    {
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'unique' => 'environment',
+                'reserved' => ['foo'],
+            ],
+        ]);
+
+        $normalizer = $environment->getSlugNormalizer();
+        $this->assertSame('foo-1', $normalizer->normalize('Foo'));
+        $this->assertSame('foo-2', $normalizer->normalize('Foo'));
+
+        $environment->dispatch(new DocumentParsedEvent(new Document()));
+
+        $this->assertSame('foo-3', $normalizer->normalize('Foo'));
+    }
+
+    public function testCustomUniqueSlugNormalizerIsNotWrapped(): void
+    {
+        $normalizer = $this->createMock(UniqueSlugNormalizerInterface::class);
+
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'instance' => $normalizer,
+            ],
+        ]);
+
+        $this->assertSame($normalizer, $environment->getSlugNormalizer());
+    }
+
+    public function testCustomUniqueSlugNormalizerHistoryIsClearedPerDocument(): void
+    {
+        $normalizer = $this->createMock(UniqueSlugNormalizerInterface::class);
+        $normalizer->expects($this->once())->method('clearHistory');
+
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'instance' => $normalizer,
+                'unique' => 'document',
+            ],
+        ]);
+
+        $environment->getSlugNormalizer();
+        $environment->dispatch(new DocumentParsedEvent(new Document()));
+    }
+
+    public function testCustomUniqueSlugNormalizerHistoryIsNotClearedPerEnvironment(): void
+    {
+        $normalizer = $this->createMock(UniqueSlugNormalizerInterface::class);
+        $normalizer->expects($this->never())->method('clearHistory');
+
+        $environment = new Environment([
+            'slug_normalizer' => [
+                'instance' => $normalizer,
+                'unique' => 'environment',
+            ],
+        ]);
+
+        $environment->getSlugNormalizer();
+        $environment->dispatch(new DocumentParsedEvent(new Document()));
     }
 
     /**

--- a/tests/unit/Normalizer/UniqueSlugNormalizerTest.php
+++ b/tests/unit/Normalizer/UniqueSlugNormalizerTest.php
@@ -68,6 +68,38 @@ final class UniqueSlugNormalizerTest extends TestCase
         $this->assertSame('-2', $normalizer->normalize(''));
     }
 
+    public function testReservedSlugsAreTreatedAsAlreadyUsed(): void
+    {
+        $normalizer = new UniqueSlugNormalizer(new SlugNormalizer(), ['test', 'example']);
+
+        $this->assertSame('test-1', $normalizer->normalize('test'));
+        $this->assertSame('test-2', $normalizer->normalize('test'));
+        $this->assertSame('example-1', $normalizer->normalize('example'));
+        $this->assertSame('other', $normalizer->normalize('other'));
+    }
+
+    public function testReservedSlugWithSuffixIsSkippedOver(): void
+    {
+        $normalizer = new UniqueSlugNormalizer(new SlugNormalizer(), ['test-1']);
+
+        $this->assertSame('test', $normalizer->normalize('test'));
+        $this->assertSame('test-2', $normalizer->normalize('test'));
+        $this->assertSame('test-1-1', $normalizer->normalize('test 1'));
+    }
+
+    public function testReservedSlugsSurviveClearHistory(): void
+    {
+        $normalizer = new UniqueSlugNormalizer(new SlugNormalizer(), ['test']);
+
+        $this->assertSame('test-1', $normalizer->normalize('test'));
+        $this->assertSame('test-2', $normalizer->normalize('test'));
+
+        $normalizer->clearHistory();
+
+        $this->assertSame('test-1', $normalizer->normalize('test'));
+        $this->assertSame('test-2', $normalizer->normalize('test'));
+    }
+
     public function testClearHistoryForgetsPreviouslyUsedSuffixes(): void
     {
         $normalizer = new UniqueSlugNormalizer(new SlugNormalizer());


### PR DESCRIPTION
Closes #1080.

## What

Adds a new `slug_normalizer/reserved` config option: a list of slugs treated as if they were already used, so any heading (or footnote ref) that would generate one of them receives an incremental numeric suffix instead — exactly the semantics duplicate headings already get:

```php
$config = [
    'heading_permalink' => [
        'id_prefix' => '',
        'fragment_prefix' => '',
    ],
    'slug_normalizer' => [
        'reserved' => ['site-logo', 'comments'],
    ],
];
```

With this, `## Comments` yields `comments-1`, avoiding a collision with the page's own `id="comments"` element while all other IDs stay clean and prefix-free. The docs now explain `heading_permalink/id_prefix` and `slug_normalizer/reserved` as two levers for the same problem: prefix *everything* (the default `content` prefix already prevents collisions) vs. protect only *specific* IDs.

Design notes:

- `UniqueSlugNormalizer` gains an optional `iterable<string> $reservedSlugs` constructor param; seeds survive `clearHistory()`, so reservations hold across documents in `PER_DOCUMENT` mode and in `PER_ENVIRONMENT` mode alike.
- Reserved entries are compared literally against the final normalized slug, before `id_prefix` is applied (documented, with a functional test pinning the behavior).
- The option intentionally lives under `slug_normalizer` rather than `heading_permalink`, so footnote-generated slugs respect reservations too.
- If you supply your own unique normalizer (or disable uniqueness), the option is a documented no-op — honoring reservations is your implementation's responsibility.

## Also fixed

`Environment::getSlugNormalizer()` checked `instanceof UniqueSlugNormalizer` (the final concrete class) instead of the interface, so custom `UniqueSlugNormalizerInterface` implementations were double-wrapped and never received the `clearHistory()` calls the interface documents — leaking slug history across documents in the default `PER_DOCUMENT` mode. Both checks now use the interface, making the escape hatch described in the slug normalizer docs actually work. Note the wrapper's accidental extra dedupe layer is no longer applied on top of custom implementations; they're trusted to enforce uniqueness per the interface contract (see CHANGELOG).

## Testing

- Unit coverage for seeding, suffix skipping, `clearHistory()` retention, config wiring, the no-op paths, `PER_ENVIRONMENT`, and the un-wrapping fix (including listener attach/no-attach per mode)
- Functional tests for the exact wiki scenario from #1080 plus the default-`id_prefix` interaction
- Full suite passes (4,343 tests); an adversarial review pass fuzzed the seeded suffix algorithm (20k trials), probed PHP numeric-string key coercion, nette/schema list merging, and verified the BC delta empirically against HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)