### PR TITLE
fix: accept unordered_list_markers config in InlinesOnlyExtension

### DIFF
--- a/src/Extension/InlinesOnly/InlinesOnlyExtension.php
+++ b/src/Extension/InlinesOnly/InlinesOnlyExtension.php
@@ -30,6 +30,7 @@ final class InlinesOnlyExtension implements ConfigurableExtensionInterface
             'use_underscore' => Expect::bool(true),
             'enable_strong' => Expect::bool(true),
             'enable_em' => Expect::bool(true),
+            'unordered_list_markers' => Expect::listOf('string')->min(1)->default(['*', '+', '-'])->mergeDefaults(false),
         ]));
     }
 

--- a/tests/functional/Extension/InlinesOnly/InlinesOnlyFunctionalTest.php
+++ b/tests/functional/Extension/InlinesOnly/InlinesOnlyFunctionalTest.php
@@ -64,4 +64,20 @@ final class InlinesOnlyFunctionalTest extends TestCase
             [$markdown, $html],
         ];
     }
+
+    /**
+     * InlinesOnlyExtension reuses the shared 'commonmark' config schema, so the
+     * option must be accepted even though it renders no lists.
+     *
+     * @see https://github.com/thephpleague/commonmark/issues/1015
+     */
+    public function testUnorderedListMarkersConfigIsAccepted(): void
+    {
+        $environment = new Environment(['commonmark' => ['unordered_list_markers' => ['*']]]);
+        $environment->addExtension(new InlinesOnlyExtension());
+        $converter = new MarkdownConverter($environment);
+
+        $this->assertSame(['*'], $environment->getConfiguration()->get('commonmark/unordered_list_markers'));
+        $this->assertSame('<em>foo</em>', \trim($converter->convert('*foo*')->getContent()));
+    }
 }


### PR DESCRIPTION

## Problem

- Repo:  thephpleague/commonmark
- Base:  thephpleague/commonmark:2.10  (forked branch; see "Base branch note" below)
- Head:  dualfroz:fix/inlines-only-list-markers-config
- Issue: Closes #1015
- CLA:   Not required. `.github/CONTRIBUTING.md` requests only PSR coding standard,
         tests, and a feature branch. No CLA, DCO, or signed-off-by requirement exists.


## Problem

Setting the `unordered_list_markers` config option while using
`InlinesOnlyExtension` throws a validation exception:

```
League\Config\Exception\ValidationException:
Unexpected item 'commonmark unordered_list_markers'.
```

## Root cause

The `unordered_list_markers` option lives in the shared `commonmark` config
namespace. `CommonMarkCoreExtension::configureSchema()` declares it:

```php
'unordered_list_markers' => Expect::listOf('string')->min(1)->default(['*', '+', '-'])->mergeDefaults(false),
```

`InlinesOnlyExtension::configureSchema()` also registers a schema for the same
`commonmark` namespace, but only declared `use_asterisk`, `use_underscore`,
`enable_strong`, and `enable_em`. Because the Nette schema for that namespace
did not include `unordered_list_markers`, passing the option produced an
"Unexpected item" validation error. This matches @colinodell's diagnosis in the
issue.

## Fix

Declare `unordered_list_markers` in `InlinesOnlyExtension`'s schema using the
exact same definition as `CommonMarkCoreExtension`. `InlinesOnlyExtension` does
not render lists, so the goal is only to make the option accepted by config
validation; rendering behaviour is unchanged.

## Changed files

- `src/Extension/InlinesOnly/InlinesOnlyExtension.php` (+1)
- `tests/functional/Extension/InlinesOnly/InlinesOnlyFunctionalTest.php` (+17)

## Base branch note

`.github/CONTRIBUTING.md` and the PR template state that bug fixes should be
submitted against the lowest maintained branch where they apply, so upper
branches inherit the fix on merge. This branch was cut from the fork's default
(`2.10`). The maintainer may want to retarget the PR base to the lowest branch
where `unordered_list_markers` exists in the schema. Confirm the intended base
before opening.
